### PR TITLE
fix: use text-base on mobile chat inputs to prevent iOS Safari zoom

### DIFF
--- a/src/app/(app)/chat/page.tsx
+++ b/src/app/(app)/chat/page.tsx
@@ -176,7 +176,7 @@ function WelcomeInput({
           disabled={sending}
           rows={1}
           aria-label="Message input"
-          className="min-w-0 flex-1 resize-none rounded-xl bg-transparent px-3 py-2.5 text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/60 disabled:opacity-50"
+          className="min-w-0 flex-1 resize-none rounded-xl bg-transparent px-3 py-2.5 text-base leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/60 disabled:opacity-50 sm:text-sm"
         />
         <Button
           size="icon"

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -92,7 +92,7 @@ export function ChatInput({ threadId, disabled, onSend }: ChatInputProps) {
           disabled={isDisabled}
           rows={1}
           aria-label="Message input"
-          className="min-w-0 flex-1 resize-none rounded-xl bg-transparent px-3 py-2.5 text-sm leading-relaxed text-foreground outline-none transition-colors placeholder:text-muted-foreground/60 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-w-0 flex-1 resize-none rounded-xl bg-transparent px-3 py-2.5 text-base leading-relaxed text-foreground outline-none transition-colors placeholder:text-muted-foreground/60 disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm"
           style={{ height: "auto", maxHeight: `${MAX_TEXTAREA_HEIGHT}px` }}
         />
         <Button


### PR DESCRIPTION
iOS Safari auto-zooms on input focus when font-size < 16px. Changed
both chat textareas from text-sm to text-base sm:text-sm so they use
16px on mobile (preventing zoom) and 14px on larger screens.

https://claude.ai/code/session_01S875BPy6Gpekz8Q6HoX6zJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling change affecting chat textareas; no logic, data, or API behavior is modified.
> 
> **Overview**
> Updates both chat message textareas (welcome screen input and `ChatInput`) to use `text-base` by default with `sm:text-sm`, ensuring a 16px font size on mobile to prevent iOS Safari auto-zoom on focus while keeping the smaller font on larger screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 249f34ed6534bd5cbb4d32fa2d78b439fbeafca0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->