### PR TITLE
feat: iOS auth with email/password login

### DIFF
--- a/docs/superpowers/plans/2026-03-12-font-landing-design-system.md
+++ b/docs/superpowers/plans/2026-03-12-font-landing-design-system.md
@@ -17,6 +17,7 @@
 ### Task 1: Swap Geist to DM Sans
 
 **Files:**
+
 - Modify: `src/app/layout.tsx`
 - Modify: `src/app/globals.css`
 
@@ -55,6 +56,7 @@ const geistMono = Geist_Mono({
 ```
 
 Also update the body className:
+
 ```tsx
 // REPLACE:
 className={`${geistSans.variable} ${geistMono.variable} antialiased`}
@@ -95,6 +97,7 @@ git commit -m "feat: swap Geist font to DM Sans globally"
 ### Task 2: Update accent color
 
 **Files:**
+
 - Modify: `src/app/globals.css`
 
 - [ ] **Step 1: Update --primary and --primary-foreground in .dark block**
@@ -113,6 +116,7 @@ In `src/app/globals.css`, inside the `.dark { ... }` block:
 - [ ] **Step 2: Visual check**
 
 Run dev server, check:
+
 - Buttons should now be teal/cyan instead of near-white
 - Button text should be white and readable
 - Focus rings should pick up the new teal color
@@ -132,6 +136,7 @@ git commit -m "feat: update brand accent to vibrant teal"
 ### Task 3: Install shadcn primitives
 
 **Files:**
+
 - Create: `src/components/ui/card.tsx`
 - Create: `src/components/ui/label.tsx`
 - Create: `src/components/ui/separator.tsx`
@@ -141,6 +146,7 @@ git commit -m "feat: update brand accent to vibrant teal"
 - [ ] **Step 1: Install components via shadcn CLI**
 
 Run each one:
+
 ```bash
 npx shadcn@latest add card --yes
 npx shadcn@latest add label --yes
@@ -170,6 +176,7 @@ git commit -m "feat: install shadcn Card, Label, Separator, Skeleton, Alert"
 ### Task 4: Create PageLoader component
 
 **Files:**
+
 - Create: `src/components/PageLoader.tsx`
 
 - [ ] **Step 1: Create the component**
@@ -187,9 +194,7 @@ export function PageLoader({ message }: PageLoaderProps) {
     <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="flex flex-col items-center gap-3">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
-        {message && (
-          <p className="text-sm text-muted-foreground">{message}</p>
-        )}
+        {message && <p className="text-sm text-muted-foreground">{message}</p>}
       </div>
     </div>
   );
@@ -213,6 +218,7 @@ git commit -m "feat: add PageLoader shared component"
 ### Task 5: Create ErrorAlert component
 
 **Files:**
+
 - Create: `src/components/ErrorAlert.tsx`
 
 - [ ] **Step 1: Create the component**
@@ -266,6 +272,7 @@ git commit -m "feat: add ErrorAlert shared component"
 ### Task 6: Create EmptyState component
 
 **Files:**
+
 - Create: `src/components/EmptyState.tsx`
 
 - [ ] **Step 1: Create the component**
@@ -287,30 +294,16 @@ interface EmptyStateProps {
   };
 }
 
-export function EmptyState({
-  icon: Icon,
-  title,
-  description,
-  action,
-}: EmptyStateProps) {
+export function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
       <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted">
         <Icon className="size-5 text-muted-foreground" />
       </div>
       <h3 className="text-sm font-medium text-foreground">{title}</h3>
-      {description && (
-        <p className="mt-1 max-w-xs text-sm text-muted-foreground">
-          {description}
-        </p>
-      )}
+      {description && <p className="mt-1 max-w-xs text-sm text-muted-foreground">{description}</p>}
       {action && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="mt-4"
-          onClick={action.onClick}
-        >
+        <Button variant="outline" size="sm" className="mt-4" onClick={action.onClick}>
           {action.label}
         </Button>
       )}
@@ -338,6 +331,7 @@ git commit -m "feat: add EmptyState shared component"
 ### Task 7: Rewrite landing page
 
 **Files:**
+
 - Modify: `src/app/page.tsx` (full rewrite)
 
 **Reference:** Spec section 3 — five sections: nav, hero (100vh), features (5 cards), social proof, bottom CTA, footer.
@@ -352,22 +346,10 @@ The landing page is a `"use client"` component because it reads auth state via `
 
 import Link from "next/link";
 import { useConvexAuth } from "convex/react";
-import {
-  Brain,
-  Send,
-  BellRing,
-  TrendingUp,
-  Utensils,
-  ArrowRight,
-} from "lucide-react";
+import { Brain, Send, BellRing, TrendingUp, Utensils, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 
 interface Feature {
   icon: typeof Brain;
@@ -380,27 +362,23 @@ const FEATURES: Feature[] = [
   {
     icon: Brain,
     title: "AI Coaching",
-    description:
-      "Ask anything about your training. Get answers grounded in your real data.",
+    description: "Ask anything about your training. Get answers grounded in your real data.",
   },
   {
     icon: Send,
     title: "Push to Tonal",
-    description:
-      "Your coach programs workouts and sends them straight to your machine.",
+    description: "Your coach programs workouts and sends them straight to your machine.",
   },
   {
     icon: BellRing,
     title: "Proactive Check-ins",
-    description:
-      "Get nudged when you're overtraining, slacking, or ready to level up.",
+    description: "Get nudged when you're overtraining, slacking, or ready to level up.",
     badge: "Coming Soon",
   },
   {
     icon: TrendingUp,
     title: "Progress Tracking",
-    description:
-      "Strength scores, muscle readiness, and body composition over time.",
+    description: "Strength scores, muscle readiness, and body composition over time.",
     badge: "Body composition coming soon",
   },
   {
@@ -439,20 +417,13 @@ export default function HomePage() {
 
         <div className="relative z-10">
           <h1 className="mx-auto max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-            The personal trainer your{" "}
-            <span className="text-primary">Tonal</span> deserves
+            The personal trainer your <span className="text-primary">Tonal</span> deserves
           </h1>
           <p className="mx-auto mt-6 max-w-lg text-base text-muted-foreground sm:text-lg">
-            AI coaching powered by your real training data. Get personalized
-            advice, push custom workouts, and track your progress — all in one
-            place.
+            AI coaching powered by your real training data. Get personalized advice, push custom
+            workouts, and track your progress — all in one place.
           </p>
-          <Button
-            size="lg"
-            className="mt-8"
-            render={<Link href={ctaHref} />}
-            disabled={isLoading}
-          >
+          <Button size="lg" className="mt-8" render={<Link href={ctaHref} />} disabled={isLoading}>
             {isLoading ? "Loading..." : ctaLabel}
             <ArrowRight className="ml-1 size-4" data-icon="inline-end" />
           </Button>
@@ -471,10 +442,7 @@ export default function HomePage() {
 
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {FEATURES.map(({ icon: Icon, title, description, badge }) => (
-              <Card
-                key={title}
-                className="border-border bg-card/50"
-              >
+              <Card key={title} className="border-border bg-card/50">
                 <CardHeader>
                   <div className="mb-2 flex items-center gap-2">
                     <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10">
@@ -486,9 +454,7 @@ export default function HomePage() {
                       </Badge>
                     )}
                   </div>
-                  <CardTitle className="text-sm font-semibold">
-                    {title}
-                  </CardTitle>
+                  <CardTitle className="text-sm font-semibold">{title}</CardTitle>
                   <CardDescription className="text-sm leading-relaxed">
                     {description}
                   </CardDescription>
@@ -516,12 +482,7 @@ export default function HomePage() {
         <p className="mt-4 text-muted-foreground">
           Connect your Tonal and start coaching in minutes.
         </p>
-        <Button
-          size="lg"
-          className="mt-8"
-          render={<Link href={ctaHref} />}
-          disabled={isLoading}
-        >
+        <Button size="lg" className="mt-8" render={<Link href={ctaHref} />} disabled={isLoading}>
           {isLoading ? "Loading..." : ctaLabel}
           <ArrowRight className="ml-1 size-4" data-icon="inline-end" />
         </Button>
@@ -530,8 +491,7 @@ export default function HomePage() {
       {/* Footer */}
       <footer className="border-t border-border px-4 py-6 text-center">
         <p className="text-xs text-muted-foreground">
-          tonal.coach is an independent project. Not affiliated with or endorsed
-          by Tonal.
+          tonal.coach is an independent project. Not affiliated with or endorsed by Tonal.
         </p>
       </footer>
     </div>
@@ -549,6 +509,7 @@ Expected: No errors. Fix any import issues if shadcn Card export names differ.
 - [ ] **Step 3: Visual check**
 
 Open `http://localhost:3000` in browser:
+
 - Hero should be full viewport with teal glow behind headline
 - "Tonal" word in headline should be teal (text-primary)
 - 5 feature cards in a grid
@@ -570,17 +531,20 @@ git commit -m "feat: redesign landing page with product vision"
 ### Task 8: Refactor login page
 
 **Files:**
+
 - Modify: `src/app/login/page.tsx`
 
 - [ ] **Step 1: Refactor to use shadcn components + PageLoader + ErrorAlert**
 
 Update `src/app/login/page.tsx`:
+
 - Replace the spinner block (lines 26-31) with `<PageLoader />`
 - Replace `<label>` elements with shadcn `<Label>`
 - Replace error `<p>` with `<ErrorAlert>`
 - Wrap the form area in shadcn `<Card>`
 
 Imports to add:
+
 ```tsx
 import { PageLoader } from "@/components/PageLoader";
 import { ErrorAlert } from "@/components/ErrorAlert";
@@ -591,6 +555,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/com
 **Keep `Loader2` in the lucide-react import** — it's still used inside the submit button spinner (`<Loader2 className="size-4 animate-spin" />`). Only the full-page loading block is replaced by `PageLoader`.
 
 Replace auth loading block:
+
 ```tsx
 // REPLACE:
 if (authLoading) {
@@ -607,6 +572,7 @@ if (authLoading) {
 ```
 
 Replace the form wrapper and labels:
+
 ```tsx
 // The <div className="w-full max-w-sm"> becomes:
 <Card className="w-full max-w-sm">
@@ -658,11 +624,13 @@ git commit -m "refactor: login page uses shadcn Card, Label, ErrorAlert, PageLoa
 ### Task 9: Refactor connect-tonal page
 
 **Files:**
+
 - Modify: `src/app/connect-tonal/page.tsx`
 
 - [ ] **Step 1: Refactor to use shadcn components + PageLoader + ErrorAlert**
 
 Imports to add:
+
 ```tsx
 import { PageLoader } from "@/components/PageLoader";
 import { ErrorAlert } from "@/components/ErrorAlert";
@@ -675,6 +643,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/com
 Replace the auth loading spinner (lines 22-28) with `<PageLoader />`.
 
 Replace the form wrapper with a `Card`. The `Link2` icon goes in the `CardHeader`:
+
 ```tsx
 <Card className="w-full max-w-sm">
   <CardHeader className="text-center">
@@ -683,8 +652,7 @@ Replace the form wrapper with a `Card`. The `Link2` icon goes in the `CardHeader
     </div>
     <CardTitle className="text-2xl">Connect Your Tonal</CardTitle>
     <CardDescription>
-      Link your Tonal account to get personalized coaching based on your
-      real training data.
+      Link your Tonal account to get personalized coaching based on your real training data.
     </CardDescription>
   </CardHeader>
   <CardContent>
@@ -704,8 +672,8 @@ Replace the form wrapper with a `Card`. The `Link2` icon goes in the `CardHeader
     </form>
 
     <p className="mt-6 text-center text-xs text-muted-foreground">
-      Your Tonal password is used only to obtain an authentication token. We
-      do not store your password.
+      Your Tonal password is used only to obtain an authentication token. We do not store your
+      password.
     </p>
   </CardContent>
 </Card>
@@ -732,17 +700,20 @@ git commit -m "refactor: connect-tonal page uses shadcn Card, Label, ErrorAlert,
 ### Task 10: Refactor settings page
 
 **Files:**
+
 - Modify: `src/app/settings/page.tsx`
 
 - [ ] **Step 1: Refactor to use shadcn Card, Separator, PageLoader + add error state**
 
 Updates:
+
 - Replace spinner with `<PageLoader />`
 - Replace hand-rolled card divs (`<div className="rounded-lg border border-border bg-card p-4">`) with shadcn `<Card>` + `<CardContent>`
 - Add `<Separator>` between sections instead of relying on margin alone
 - Add error state: if `isAuthenticated` is true but `me` is `null` (not `undefined` — `undefined` means loading, `null` means query returned null), show an `<ErrorAlert>` instead of spinning forever
 
 Imports to add:
+
 ```tsx
 import { PageLoader } from "@/components/PageLoader";
 import { ErrorAlert } from "@/components/ErrorAlert";
@@ -751,6 +722,7 @@ import { Separator } from "@/components/ui/separator";
 ```
 
 Error state logic:
+
 ```tsx
 // After the auth loading check, add:
 if (isAuthenticated && me === null) {
@@ -783,6 +755,7 @@ git commit -m "refactor: settings page uses shadcn Card, Separator, PageLoader +
 ### Task 11: Refactor dashboard page
 
 **Files:**
+
 - Modify: `src/app/dashboard/page.tsx`
 
 - [ ] **Step 1: Replace CardSkeleton and CardError with shadcn equivalents**
@@ -790,6 +763,7 @@ git commit -m "refactor: settings page uses shadcn Card, Separator, PageLoader +
 Remove the local `CardSkeleton` and `CardError` components from the top of the file.
 
 Replace `CardSkeleton` usage with shadcn `Card` + `Skeleton`:
+
 ```tsx
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -812,6 +786,7 @@ function DashboardCardSkeleton({ tall }: { tall?: boolean }) {
 ```
 
 Replace `CardError` usage with `ErrorAlert` inside a `Card`:
+
 ```tsx
 import { ErrorAlert } from "@/components/ErrorAlert";
 
@@ -855,6 +830,7 @@ git commit -m "refactor: dashboard uses shadcn Card, Skeleton, ErrorAlert"
 ### Task 12: Add loading feedback to chat home
 
 **Files:**
+
 - Modify: `src/app/chat/page.tsx`
 
 - [ ] **Step 1: Add a loading spinner overlay when sending a suggestion**
@@ -868,12 +844,14 @@ Replace the `sending` state handling — add a `Loader2` spinner below the sugge
 import { Loader2 } from "lucide-react";
 
 // After the suggestion grid closing </div>, add:
-{sending && (
-  <div className="mt-4 flex items-center justify-center gap-2 text-sm text-muted-foreground">
-    <Loader2 className="size-4 animate-spin" />
-    <span>Starting conversation...</span>
-  </div>
-)}
+{
+  sending && (
+    <div className="mt-4 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+      <Loader2 className="size-4 animate-spin" />
+      <span>Starting conversation...</span>
+    </div>
+  );
+}
 ```
 
 - [ ] **Step 2: Type-check**
@@ -893,6 +871,7 @@ git commit -m "feat: add loading indicator when sending chat suggestion"
 ### Task 13: Add empty state to chat thread
 
 **Files:**
+
 - Modify: `src/components/ChatThread.tsx`
 
 - [ ] **Step 1: Add EmptyState for threads with no messages**
@@ -908,13 +887,15 @@ import { MessageSquare } from "lucide-react";
 // Use status === "Exhausted" to avoid flashing the empty state during initial load.
 // The useUIMessages hook returns "LoadingFirstPage" while loading, then "Exhausted"
 // when there are no more messages to load.
-{status === "Exhausted" && results.length === 0 && (
-  <EmptyState
-    icon={MessageSquare}
-    title="No messages yet"
-    description="Send a message to start the conversation."
-  />
-)}
+{
+  status === "Exhausted" && results.length === 0 && (
+    <EmptyState
+      icon={MessageSquare}
+      title="No messages yet"
+      description="Send a message to start the conversation."
+    />
+  );
+}
 ```
 
 - [ ] **Step 2: Type-check**
@@ -941,6 +922,7 @@ Expected: No errors
 - [ ] **Step 2: Visual walkthrough**
 
 Check every page in the browser:
+
 1. `/` — landing page with hero, features, CTA
 2. `/login` — card-wrapped form, DM Sans font
 3. `/connect-tonal` — card-wrapped form

--- a/docs/superpowers/plans/2026-03-12-ux-refinement.md
+++ b/docs/superpowers/plans/2026-03-12-ux-refinement.md
@@ -15,39 +15,42 @@
 ## File Structure
 
 ### Created
-| File | Responsibility |
-|------|---------------|
-| `src/app/(app)/layout.tsx` | Authenticated route group layout — renders AppShell, auth guards |
-| `src/components/AppShell.tsx` | Responsive nav shell: sidebar (desktop lg+), bottom tabs (mobile) |
-| `src/components/MarkdownContent.tsx` | `react-markdown` wrapper with dark-theme styled components |
-| `src/components/DateDivider.tsx` | "Today", "Yesterday", "March 8" date separator |
-| `convex/threads.ts` | `getActiveThread` (internalQuery), `getCurrentThread` (public query), `listConversationHistory` (public query) |
+
+| File                                 | Responsibility                                                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `src/app/(app)/layout.tsx`           | Authenticated route group layout — renders AppShell, auth guards                                               |
+| `src/components/AppShell.tsx`        | Responsive nav shell: sidebar (desktop lg+), bottom tabs (mobile)                                              |
+| `src/components/MarkdownContent.tsx` | `react-markdown` wrapper with dark-theme styled components                                                     |
+| `src/components/DateDivider.tsx`     | "Today", "Yesterday", "March 8" date separator                                                                 |
+| `convex/threads.ts`                  | `getActiveThread` (internalQuery), `getCurrentThread` (public query), `listConversationHistory` (public query) |
 
 ### Modified
-| File | Changes |
-|------|---------|
-| `convex/chat.ts` | `sendMessage` auto-resolves active thread via `getActiveThread` |
-| `convex/dashboard.ts` | `getTrainingFrequency` adds `lastTrainedDate` per area |
-| `src/components/ChatMessage.tsx` | Full rewrite: full-width, avatars, timestamps, markdown for coach |
-| `src/components/ToolCallIndicator.tsx` | Rewrite: compact chips (animated running, checkmark done) |
-| `src/components/WorkoutCard.tsx` | Status badges for all 4 statuses, teal accent border |
-| `src/components/ChatThread.tsx` | Auto-session model, two data sources, date dividers |
-| `src/components/ChatInput.tsx` | Simplified: no threadId prop, always active |
-| `src/components/StatusBanner.tsx` | No changes to component itself, just moves into AppShell |
-| `src/app/(app)/chat/page.tsx` | Welcome state, auto-send from `?prompt=` param, no thread routing |
-| `src/app/(app)/dashboard/page.tsx` | Greeting header, CTAs on cards |
-| `src/app/(app)/settings/page.tsx` | Remove back arrow + standalone wrapper |
-| `src/components/MuscleReadinessMap.tsx` | Add CTA link when readiness >80% |
-| `src/components/TrainingFrequencyChart.tsx` | Add CTA link when area not trained >7 days |
-| `src/components/StrengthScoreCard.tsx` | Add static "Ask coach" CTA |
+
+| File                                        | Changes                                                           |
+| ------------------------------------------- | ----------------------------------------------------------------- |
+| `convex/chat.ts`                            | `sendMessage` auto-resolves active thread via `getActiveThread`   |
+| `convex/dashboard.ts`                       | `getTrainingFrequency` adds `lastTrainedDate` per area            |
+| `src/components/ChatMessage.tsx`            | Full rewrite: full-width, avatars, timestamps, markdown for coach |
+| `src/components/ToolCallIndicator.tsx`      | Rewrite: compact chips (animated running, checkmark done)         |
+| `src/components/WorkoutCard.tsx`            | Status badges for all 4 statuses, teal accent border              |
+| `src/components/ChatThread.tsx`             | Auto-session model, two data sources, date dividers               |
+| `src/components/ChatInput.tsx`              | Simplified: no threadId prop, always active                       |
+| `src/components/StatusBanner.tsx`           | No changes to component itself, just moves into AppShell          |
+| `src/app/(app)/chat/page.tsx`               | Welcome state, auto-send from `?prompt=` param, no thread routing |
+| `src/app/(app)/dashboard/page.tsx`          | Greeting header, CTAs on cards                                    |
+| `src/app/(app)/settings/page.tsx`           | Remove back arrow + standalone wrapper                            |
+| `src/components/MuscleReadinessMap.tsx`     | Add CTA link when readiness >80%                                  |
+| `src/components/TrainingFrequencyChart.tsx` | Add CTA link when area not trained >7 days                        |
+| `src/components/StrengthScoreCard.tsx`      | Add static "Ask coach" CTA                                        |
 
 ### Deleted
-| File | Reason |
-|------|--------|
-| `src/app/chat/layout.tsx` | Replaced by `(app)/layout.tsx` |
+
+| File                               | Reason                             |
+| ---------------------------------- | ---------------------------------- |
+| `src/app/chat/layout.tsx`          | Replaced by `(app)/layout.tsx`     |
 | `src/app/chat/[threadId]/page.tsx` | Thread managed as state, not route |
-| `src/app/dashboard/layout.tsx` | Replaced by `(app)/layout.tsx` |
-| `src/components/ThreadSidebar.tsx` | One-coach model, no thread list |
+| `src/app/dashboard/layout.tsx`     | Replaced by `(app)/layout.tsx`     |
+| `src/components/ThreadSidebar.tsx` | One-coach model, no thread list    |
 
 ---
 
@@ -56,6 +59,7 @@
 ### Task 1: Install dependencies and scaffold route group
 
 **Files:**
+
 - Modify: `package.json` (add deps)
 - Create: `src/app/(app)/layout.tsx` (placeholder)
 
@@ -94,11 +98,13 @@ git commit -m "chore: install react-markdown, scaffold (app) route group"
 ### Task 2: AppShell component
 
 **Files:**
+
 - Create: `src/components/AppShell.tsx`
 
 **Reference:** The existing `src/app/dashboard/layout.tsx` has a working responsive nav pattern with desktop header + mobile bottom tabs at `sm` breakpoint. The new AppShell uses a **sidebar** (not header) on desktop and changes the breakpoint to `lg` (1024px).
 
 **Context files to read first:**
+
 - `src/app/dashboard/layout.tsx` — existing nav pattern, auth guards, StatusBanner integration
 - `src/components/StatusBanner.tsx` — renders above main content
 - `src/lib/utils.ts` — `cn()` helper
@@ -109,6 +115,7 @@ git commit -m "chore: install react-markdown, scaffold (app) route group"
 Create `src/components/AppShell.tsx` with:
 
 **Layout structure:**
+
 ```
 Desktop (lg+):         Mobile (<lg):
 ┌──────┬─────────┐    ┌─────────────────┐
@@ -126,6 +133,7 @@ Desktop (lg+):         Mobile (<lg):
 **Props:** `{ children: React.ReactNode }`
 
 **Desktop sidebar (256px, hidden below lg):**
+
 - Logo: "tonal.coach" text, `text-sm font-bold`
 - Nav links: Chat (`MessageSquare`), Dashboard (`LayoutDashboard`), Settings (`Settings`)
 - Each link: `Link` from next/link, styled with `cn()`, active state uses `bg-primary/10 text-primary`
@@ -133,14 +141,17 @@ Desktop (lg+):         Mobile (<lg):
 - User name at bottom from `useQuery(api.users.getMe)` — display `tonalName`
 
 **Mobile bottom tabs (visible below lg):**
+
 - Fixed to bottom, `z-40`
 - 3 tabs with icon + label, active tab in `text-primary`
 - Bottom padding: `pb-[env(safe-area-inset-bottom)]` for notch devices
 
 **Mobile header (visible below lg):**
+
 - "tonal.coach" text centered
 
 **Auth guards:** Import and reuse the pattern from `dashboard/layout.tsx`:
+
 - `useConvexAuth()` for `isAuthenticated`, `isLoading`
 - `useQuery(api.users.getMe)` with skip when not authenticated
 - Loading: full-screen `Loader2` spinner
@@ -148,6 +159,7 @@ Desktop (lg+):         Mobile (<lg):
 - No Tonal profile: `router.replace("/connect-tonal")`
 
 **Important implementation details:**
+
 - Use `usePathname()` to determine active nav link
 - Match on `pathname.startsWith(href)` for nested routes (e.g., `/chat` matches `/chat`)
 - Import `StatusBanner` and render it above main content area
@@ -279,6 +291,7 @@ git commit -m "feat: add AppShell component with responsive sidebar/tabs navigat
 ### Task 3: Route restructuring — move pages into (app) group
 
 **Files:**
+
 - Modify: `src/app/(app)/layout.tsx` — wire up AppShell
 - Move: `src/app/chat/page.tsx` → `src/app/(app)/chat/page.tsx`
 - Move: `src/app/dashboard/page.tsx` → `src/app/(app)/dashboard/page.tsx`
@@ -289,6 +302,7 @@ git commit -m "feat: add AppShell component with responsive sidebar/tabs navigat
 - Delete: `src/components/ThreadSidebar.tsx`
 
 **Context files to read first:**
+
 - `src/app/chat/layout.tsx` — has auth guards (moving to AppShell), sidebar toggle, hamburger menu
 - `src/app/chat/page.tsx` — suggestion buttons, thread creation, navigation to `/chat/[threadId]`
 - `src/app/chat/[threadId]/page.tsx` — simple wrapper around ChatThread
@@ -316,6 +330,7 @@ cp src/app/chat/page.tsx src/app/\(app\)/chat/page.tsx
 ```
 
 Then edit `src/app/(app)/chat/page.tsx`:
+
 - Remove any auth guard logic (AppShell handles it)
 - Keep the existing functionality for now (will be rewritten in Task 13)
 
@@ -327,6 +342,7 @@ cp src/app/dashboard/page.tsx src/app/\(app\)/dashboard/page.tsx
 ```
 
 Edit `src/app/(app)/dashboard/page.tsx`:
+
 - Remove any standalone auth guards if present (the dashboard page itself doesn't have them — its layout did)
 - Keep existing card rendering
 
@@ -338,6 +354,7 @@ cp src/app/settings/page.tsx src/app/\(app\)/settings/page.tsx
 ```
 
 Edit `src/app/(app)/settings/page.tsx`:
+
 - Remove auth guard logic (lines checking `isAuthenticated`, `authLoading`, redirects)
 - Remove the back arrow button and `min-h-screen` wrapper
 - Remove `PageLoader` and `useConvexAuth` imports
@@ -355,6 +372,7 @@ rm src/components/ThreadSidebar.tsx
 ```
 
 Also delete the old route directories if they're now empty (after moving pages):
+
 ```bash
 # Remove old chat page (now in (app)/chat/)
 rm src/app/chat/page.tsx
@@ -365,6 +383,7 @@ rm src/app/settings/page.tsx
 ```
 
 Clean up empty directories:
+
 ```bash
 rmdir src/app/chat 2>/dev/null || true
 rmdir src/app/dashboard 2>/dev/null || true
@@ -374,10 +393,12 @@ rmdir src/app/settings 2>/dev/null || true
 - [ ] **Step 6: Fix imports**
 
 Check for any import path changes needed due to file moves. The `@/` alias resolves to `src/`, so component imports should work. But relative imports to `convex/_generated/api` may need updating since the files moved deeper:
+
 - Old: `../../../convex/_generated/api` (from `src/app/chat/page.tsx`)
 - New: `../../../../convex/_generated/api` (from `src/app/(app)/chat/page.tsx`)
 
 The `@/` alias maps to `./src/*` and does NOT cover `convex/`. Update relative imports in all moved files:
+
 - Old (from `src/app/chat/page.tsx`): `from "../../../convex/_generated/api"`
 - New (from `src/app/(app)/chat/page.tsx`): `from "../../../../convex/_generated/api"`
 
@@ -404,9 +425,11 @@ git commit -m "refactor: move authenticated pages into (app) route group with Ap
 ### Task 4: Backend — convex/threads.ts
 
 **Files:**
+
 - Create: `convex/threads.ts`
 
 **Context files to read first:**
+
 - `convex/chat.ts` — current thread/message handling, see how `listUIMessages` and `syncStreams` are used
 - `convex/ai/coach.ts` — agent component setup (`components.agent`)
 - `convex/_generated/api.d.ts` — check available component queries (search for `listThreadsByUserId`, `listMessagesByThreadId` or similar)
@@ -430,30 +453,23 @@ export const getActiveThread = internalQuery({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
     // Use agent component to list threads for this user, most recent first
-    const threads = await ctx.runQuery(
-      components.agent.threads.listThreadsByUserId,
-      {
-        userId: userId as string,
-        paginationOpts: { cursor: null, numItems: 1 },
-        order: "desc",
-      },
-    );
+    const threads = await ctx.runQuery(components.agent.threads.listThreadsByUserId, {
+      userId: userId as string,
+      paginationOpts: { cursor: null, numItems: 1 },
+      order: "desc",
+    });
 
     const thread = threads.page[0];
     if (!thread || thread.status !== "active") return null;
 
     // Get the last message to check staleness
-    const messages = await ctx.runQuery(
-      components.agent.messages.listMessagesByThreadId,
-      {
-        threadId: thread._id,
-        paginationOpts: { cursor: null, numItems: 1 },
-        order: "desc",
-      },
-    );
+    const messages = await ctx.runQuery(components.agent.messages.listMessagesByThreadId, {
+      threadId: thread._id,
+      paginationOpts: { cursor: null, numItems: 1 },
+      order: "desc",
+    });
 
-    const lastMessageTime =
-      messages.page[0]?._creationTime ?? thread._creationTime;
+    const lastMessageTime = messages.page[0]?._creationTime ?? thread._creationTime;
 
     return { threadId: thread._id, lastMessageTime };
   },
@@ -502,14 +518,11 @@ export const listConversationHistory = query({
     if (!userId) return { messages: [], hasMore: false };
 
     // Get threads for this user, newest first (up to 50 — sufficient for most users)
-    const threads = await ctx.runQuery(
-      components.agent.threads.listThreadsByUserId,
-      {
-        userId: userId as string,
-        paginationOpts: { cursor: null, numItems: 50 },
-        order: "desc",
-      },
-    );
+    const threads = await ctx.runQuery(components.agent.threads.listThreadsByUserId, {
+      userId: userId as string,
+      paginationOpts: { cursor: null, numItems: 50 },
+      order: "desc",
+    });
 
     // Find threads older than the current one
     let foundCurrent = !beforeThreadId;
@@ -528,14 +541,11 @@ export const listConversationHistory = query({
 
     // Load messages from the next older thread
     const targetThread = olderThreads[0];
-    const result = await ctx.runQuery(
-      components.agent.messages.listMessagesByThreadId,
-      {
-        threadId: targetThread._id,
-        paginationOpts: { cursor: null, numItems: limit },
-        order: "asc",
-      },
-    );
+    const result = await ctx.runQuery(components.agent.messages.listMessagesByThreadId, {
+      threadId: targetThread._id,
+      paginationOpts: { cursor: null, numItems: limit },
+      order: "asc",
+    });
 
     return {
       messages: result.page,
@@ -566,9 +576,11 @@ git commit -m "feat: add thread queries for auto-session model"
 ### Task 5: Backend — modify convex/chat.ts for auto-resolve
 
 **Files:**
+
 - Modify: `convex/chat.ts`
 
 **Context files to read first:**
+
 - `convex/chat.ts` — current sendMessage implementation
 - `convex/threads.ts` — the getActiveThread query just created
 - `convex/ai/coach.ts` — how agent threads are created and continued
@@ -578,41 +590,41 @@ git commit -m "feat: add thread queries for auto-session model"
 The current code (lines 48-57 of `convex/chat.ts`) has:
 
 ```typescript
-    let targetThreadId: string;
-    if (threadId) {
-      targetThreadId = threadId;
-    } else {
-      const { threadId: newThreadId } = await coachAgent.createThread(ctx, {
-        userId,
-      });
-      targetThreadId = newThreadId;
-    }
+let targetThreadId: string;
+if (threadId) {
+  targetThreadId = threadId;
+} else {
+  const { threadId: newThreadId } = await coachAgent.createThread(ctx, {
+    userId,
+  });
+  targetThreadId = newThreadId;
+}
 ```
 
 Replace that block with the auto-resolve logic:
 
 ```typescript
-    const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-    let targetThreadId: string;
-    if (threadId) {
-      targetThreadId = threadId;
-    } else {
-      // Auto-resolve to active thread if not stale
-      const active = await ctx.runQuery(internal.threads.getActiveThread, {
-        userId,
-      });
+let targetThreadId: string;
+if (threadId) {
+  targetThreadId = threadId;
+} else {
+  // Auto-resolve to active thread if not stale
+  const active = await ctx.runQuery(internal.threads.getActiveThread, {
+    userId,
+  });
 
-      if (active && Date.now() - active.lastMessageTime < STALE_THRESHOLD_MS) {
-        targetThreadId = active.threadId;
-      } else {
-        // Create new thread (stale or none exists)
-        const { threadId: newThreadId } = await coachAgent.createThread(ctx, {
-          userId,
-        });
-        targetThreadId = newThreadId;
-      }
-    }
+  if (active && Date.now() - active.lastMessageTime < STALE_THRESHOLD_MS) {
+    targetThreadId = active.threadId;
+  } else {
+    // Create new thread (stale or none exists)
+    const { threadId: newThreadId } = await coachAgent.createThread(ctx, {
+      userId,
+    });
+    targetThreadId = newThreadId;
+  }
+}
 ```
 
 The file already imports `internal` from `./_generated/api` (line 8), so no new import is needed. The `internal.threads.getActiveThread` reference will resolve after creating `convex/threads.ts` in Task 4.
@@ -637,9 +649,11 @@ git commit -m "feat: auto-resolve active thread in sendMessage with 24h stalenes
 ### Task 6: Backend — modify convex/dashboard.ts for lastTrainedDate
 
 **Files:**
+
 - Modify: `convex/dashboard.ts`
 
 **Context files to read first:**
+
 - `convex/dashboard.ts` — current `getTrainingFrequency` implementation
 
 - [ ] **Step 1: Add lastTrainedDate to getTrainingFrequency response**
@@ -677,6 +691,7 @@ return Object.entries(counts)
 ```
 
 Also update the `TrainingFrequencyEntry` interface:
+
 ```typescript
 interface TrainingFrequencyEntry {
   targetArea: string;
@@ -705,6 +720,7 @@ git commit -m "feat: add lastTrainedDate to training frequency response"
 ### Task 7: MarkdownContent component
 
 **Files:**
+
 - Create: `src/components/MarkdownContent.tsx`
 
 **Context:** This wraps `react-markdown` with dark-theme styled component overrides for the coach's messages.
@@ -718,9 +734,7 @@ import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
 
 const components: Components = {
-  strong: ({ children }) => (
-    <strong className="font-semibold text-foreground">{children}</strong>
-  ),
+  strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
   em: ({ children }) => <em>{children}</em>,
   code: ({ className, children, ...props }) => {
     // Detect code blocks vs inline code
@@ -739,33 +753,23 @@ const components: Components = {
     );
   },
   pre: ({ children }) => (
-    <pre className="my-3 overflow-x-auto rounded-lg bg-muted p-4 font-mono text-sm">
-      {children}
-    </pre>
+    <pre className="my-3 overflow-x-auto rounded-lg bg-muted p-4 font-mono text-sm">{children}</pre>
   ),
-  ul: ({ children }) => (
-    <ul className="my-2 list-disc pl-5 space-y-1">{children}</ul>
-  ),
-  ol: ({ children }) => (
-    <ol className="my-2 list-decimal pl-5 space-y-1">{children}</ol>
-  ),
+  ul: ({ children }) => <ul className="my-2 list-disc pl-5 space-y-1">{children}</ul>,
+  ol: ({ children }) => <ol className="my-2 list-decimal pl-5 space-y-1">{children}</ol>,
   li: ({ children }) => <li>{children}</li>,
   table: ({ children }) => (
     <div className="my-3 overflow-x-auto rounded-lg border border-border">
       <table className="w-full border-collapse text-sm">{children}</table>
     </div>
   ),
-  thead: ({ children }) => (
-    <thead className="bg-muted/50">{children}</thead>
-  ),
+  thead: ({ children }) => <thead className="bg-muted/50">{children}</thead>,
   th: ({ children }) => (
     <th className="border-b border-border px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
       {children}
     </th>
   ),
-  td: ({ children }) => (
-    <td className="border-b border-border px-3 py-2">{children}</td>
-  ),
+  td: ({ children }) => <td className="border-b border-border px-3 py-2">{children}</td>,
   h1: ({ children }) => (
     <h1 className="mb-3 mt-4 text-xl font-semibold text-foreground">{children}</h1>
   ),
@@ -829,14 +833,17 @@ git commit -m "feat: add MarkdownContent component with dark-theme styled react-
 ### Task 8: ChatMessage rewrite
 
 **Files:**
+
 - Modify: `src/components/ChatMessage.tsx` (full rewrite)
 
 **Context files to read first:**
+
 - `src/components/ChatMessage.tsx` — current implementation (bubble-style, FormattedText)
 - `src/components/MarkdownContent.tsx` — just created
 - `src/components/ToolCallIndicator.tsx` — renders inside messages (will be rewritten in Task 9, but keep current interface for now)
 
 **Design:** Full-width messages, no bubbles. Each message has:
+
 - Header: avatar (24px circle) + role name + timestamp
 - Content: indented 32px, full width
 - Separated by subtle border divider
@@ -844,6 +851,7 @@ git commit -m "feat: add MarkdownContent component with dark-theme styled react-
 - [ ] **Step 1: Rewrite ChatMessage**
 
 Replace the entire file content. Key changes:
+
 - Remove `FormattedText` and `TextWithBreaks` helpers
 - Remove bubble styling (user right-aligned, assistant left-aligned)
 - Add avatar: user gets first initial in primary circle, coach gets sparkle icon in muted circle
@@ -906,7 +914,10 @@ export function ChatMessage({ message, userInitial = "U" }: ChatMessageProps) {
 
             if (isUser) {
               return (
-                <p key={i} className="text-sm leading-relaxed text-foreground/90 whitespace-pre-wrap">
+                <p
+                  key={i}
+                  className="text-sm leading-relaxed text-foreground/90 whitespace-pre-wrap"
+                >
                   {text}
                 </p>
               );
@@ -922,9 +933,7 @@ export function ChatMessage({ message, userInitial = "U" }: ChatMessageProps) {
 
         {/* Tool calls: completed ones wrap horizontally as chips per spec */}
         {(() => {
-          const toolParts = message.parts.filter(
-            (part) => part.type === "dynamic-tool",
-          );
+          const toolParts = message.parts.filter((part) => part.type === "dynamic-tool");
           if (toolParts.length === 0) return null;
 
           const hasRunning = toolParts.some(
@@ -972,13 +981,16 @@ git commit -m "feat: rewrite ChatMessage with full-width layout, avatars, and ma
 ### Task 9: ToolCallIndicator rewrite
 
 **Files:**
+
 - Modify: `src/components/ToolCallIndicator.tsx` (full rewrite)
 
 **Context files to read first:**
+
 - `src/components/ToolCallIndicator.tsx` — current implementation
 - `src/components/WorkoutCard.tsx` — special rendering for create_workout
 
 **Design:**
+
 - Running state: animated teal pulse dot + descriptive text (e.g., "Checking muscle readiness...")
 - Completed state: compact chip with teal checkmark + past-tense text
 - Multiple completed chips render as horizontal flex-wrap row
@@ -995,11 +1007,23 @@ import { WorkoutCard } from "./WorkoutCard";
 const TOOL_MESSAGES: Record<string, { running: string; done: string }> = {
   search_exercises: { running: "Searching exercises...", done: "Searched exercises" },
   get_strength_scores: { running: "Checking strength scores...", done: "Checked strength scores" },
-  get_strength_history: { running: "Reviewing strength history...", done: "Reviewed strength history" },
-  get_muscle_readiness: { running: "Checking muscle readiness...", done: "Checked muscle readiness" },
-  get_workout_history: { running: "Reviewing workout history...", done: "Reviewed workout history" },
+  get_strength_history: {
+    running: "Reviewing strength history...",
+    done: "Reviewed strength history",
+  },
+  get_muscle_readiness: {
+    running: "Checking muscle readiness...",
+    done: "Checked muscle readiness",
+  },
+  get_workout_history: {
+    running: "Reviewing workout history...",
+    done: "Reviewed workout history",
+  },
   get_workout_detail: { running: "Loading workout details...", done: "Loaded workout details" },
-  get_training_frequency: { running: "Analyzing training frequency...", done: "Analyzed training frequency" },
+  get_training_frequency: {
+    running: "Analyzing training frequency...",
+    done: "Analyzed training frequency",
+  },
   create_workout: { running: "Creating workout...", done: "Created workout" },
   delete_workout: { running: "Deleting workout...", done: "Deleted workout" },
   estimate_duration: { running: "Estimating duration...", done: "Estimated duration" },
@@ -1022,7 +1046,10 @@ export function ToolCallIndicator({ toolName, state, input }: ToolCallIndicatorP
 
   // Special case: create_workout shows WorkoutCard when done
   if (toolName === "create_workout" && isDone && input) {
-    const data = input as { name?: string; exercises?: Array<{ exerciseName?: string; name?: string; sets?: number; reps?: number }> };
+    const data = input as {
+      name?: string;
+      exercises?: Array<{ exerciseName?: string; name?: string; sets?: number; reps?: number }>;
+    };
     return <WorkoutCard title={data.name} exercises={data.exercises} />;
   }
 
@@ -1069,9 +1096,11 @@ git commit -m "feat: rewrite ToolCallIndicator with compact chip style"
 ### Task 10: WorkoutCard upgrade
 
 **Files:**
+
 - Modify: `src/components/WorkoutCard.tsx`
 
 **Context files to read first:**
+
 - `src/components/WorkoutCard.tsx` — current implementation
 - `convex/schema.ts` — `workoutPlans` table statuses: draft, pushed, completed, deleted
 
@@ -1145,9 +1174,7 @@ export function WorkoutCard({
   return (
     <div className="my-2 rounded-lg border border-primary/30 bg-card p-4">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-foreground">
-          {title ?? "Custom Workout"}
-        </h3>
+        <h3 className="text-sm font-semibold text-foreground">{title ?? "Custom Workout"}</h3>
         <StatusBadge status={status} />
       </div>
 
@@ -1155,9 +1182,7 @@ export function WorkoutCard({
         <ol className="mb-2 space-y-1 pl-5 text-sm">
           {exercises.map((ex, i) => (
             <li key={i} className="text-foreground/80">
-              <span className="font-medium">
-                {ex.exerciseName ?? ex.name ?? "Exercise"}
-              </span>
+              <span className="font-medium">{ex.exerciseName ?? ex.name ?? "Exercise"}</span>
               {ex.sets && ex.reps && (
                 <span className="ml-1.5 text-muted-foreground">
                   — {ex.sets}×{ex.reps}
@@ -1169,9 +1194,7 @@ export function WorkoutCard({
       )}
 
       {estimatedDuration && (
-        <p className="text-xs text-muted-foreground">
-          ~{Math.round(estimatedDuration / 60)} min
-        </p>
+        <p className="text-xs text-muted-foreground">~{Math.round(estimatedDuration / 60)} min</p>
       )}
     </div>
   );
@@ -1196,6 +1219,7 @@ git commit -m "feat: upgrade WorkoutCard with status badges and teal accent"
 ### Task 11: DateDivider component
 
 **Files:**
+
 - Create: `src/components/DateDivider.tsx`
 
 - [ ] **Step 1: Create DateDivider**
@@ -1207,9 +1231,7 @@ function formatDateLabel(date: Date): string {
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const target = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  const diffDays = Math.round(
-    (today.getTime() - target.getTime()) / (1000 * 60 * 60 * 24),
-  );
+  const diffDays = Math.round((today.getTime() - target.getTime()) / (1000 * 60 * 60 * 24));
 
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";
@@ -1230,9 +1252,7 @@ export function DateDivider({ timestamp }: DateDividerProps) {
   return (
     <div className="flex items-center gap-3 px-4 py-2 sm:px-6">
       <div className="h-px flex-1 bg-border" />
-      <span className="text-[11px] font-medium text-muted-foreground/60">
-        {label}
-      </span>
+      <span className="text-[11px] font-medium text-muted-foreground/60">{label}</span>
       <div className="h-px flex-1 bg-border" />
     </div>
   );
@@ -1257,16 +1277,19 @@ git commit -m "feat: add DateDivider component for chat history"
 ### Task 12: ChatThread rewrite
 
 **Files:**
+
 - Modify: `src/components/ChatThread.tsx` (full rewrite)
 - Modify: `src/components/ChatInput.tsx` (simplify props)
 
 **Context files to read first:**
+
 - `src/components/ChatThread.tsx` — current implementation (useUIMessages, pagination, auto-scroll)
 - `src/components/ChatInput.tsx` — current props: `{ threadId, onThreadCreated?, disabled? }`
 - `convex/threads.ts` — getCurrentThread, listConversationHistory
 - `convex/chat.ts` — sendMessage (now auto-resolves thread)
 
 **Design changes:**
+
 - ChatThread no longer receives `threadId` as a prop — it subscribes to `getCurrentThread` query
 - Uses `useUIMessages` for current thread (streaming) and `listConversationHistory` for older threads
 - Date dividers inserted between messages from different days
@@ -1309,9 +1332,11 @@ export function ChatInput({ disabled }: ChatInputProps) {
 Replace `src/components/ChatThread.tsx` entirely.
 
 **Critical API note:** The existing code calls `useUIMessages` with three arguments:
+
 ```tsx
-useUIMessages(api.chat.listMessages, { threadId }, { initialNumItems: 20, stream: true })
+useUIMessages(api.chat.listMessages, { threadId }, { initialNumItems: 20, stream: true });
 ```
+
 It returns `{ results, status, loadMore }` (NOT `{ messages, ... }`). The implementer MUST read the current `ChatThread.tsx` to confirm the exact call signature and return shape, then adapt the code below accordingly.
 
 ```tsx
@@ -1326,10 +1351,7 @@ import { ChatInput } from "./ChatInput";
 import { DateDivider } from "./DateDivider";
 import type { UIMessage } from "@convex-dev/agent/react";
 
-function shouldShowDateDivider(
-  currentTimestamp: number,
-  prevTimestamp: number | null,
-): boolean {
+function shouldShowDateDivider(currentTimestamp: number, prevTimestamp: number | null): boolean {
   if (!prevTimestamp) return true;
   const current = new Date(currentTimestamp);
   const prev = new Date(prevTimestamp);
@@ -1359,11 +1381,14 @@ export function ChatThread({ userInitial }: ChatThreadProps) {
   // Check the @convex-dev/agent/react source to confirm. If "skip" isn't supported,
   // use: `const uiMessages = threadId ? useUIMessages(...) : { results: [], status: "Exhausted", loadMore: () => {} };`
   // or gate the hook call behind a conditional component.
-  const { results: currentMessages, status, loadMore } = useUIMessages(
-    api.chat.listMessages,
-    threadId ? { threadId } : "skip",
-    { initialNumItems: 20, stream: true },
-  );
+  const {
+    results: currentMessages,
+    status,
+    loadMore,
+  } = useUIMessages(api.chat.listMessages, threadId ? { threadId } : "skip", {
+    initialNumItems: 20,
+    stream: true,
+  });
 
   // Historical messages from older threads (static, "Load earlier")
   // NOTE: listConversationHistory returns raw MessageDoc objects from the agent
@@ -1397,9 +1422,7 @@ export function ChatThread({ userInitial }: ChatThreadProps) {
   const allMessages = [...historicalMessages, ...(currentMessages ?? [])];
 
   // Auto-scroll to bottom on new messages
-  const isStreaming = (currentMessages ?? []).some(
-    (m) => m.status === "streaming",
-  );
+  const isStreaming = (currentMessages ?? []).some((m) => m.status === "streaming");
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({
@@ -1440,18 +1463,12 @@ export function ChatThread({ userInitial }: ChatThreadProps) {
 
         {/* Messages with date dividers */}
         {allMessages.map((message, i) => {
-          const prevTimestamp =
-            i > 0 ? allMessages[i - 1]._creationTime : null;
-          const showDivider = shouldShowDateDivider(
-            message._creationTime,
-            prevTimestamp,
-          );
+          const prevTimestamp = i > 0 ? allMessages[i - 1]._creationTime : null;
+          const showDivider = shouldShowDateDivider(message._creationTime, prevTimestamp);
 
           return (
             <div key={message.key}>
-              {showDivider && (
-                <DateDivider timestamp={message._creationTime} />
-              )}
+              {showDivider && <DateDivider timestamp={message._creationTime} />}
               <ChatMessage message={message} userInitial={userInitial} />
             </div>
           );
@@ -1488,13 +1505,16 @@ git commit -m "feat: rewrite ChatThread with auto-session model and date divider
 ### Task 13: Chat page rewrite
 
 **Files:**
+
 - Modify: `src/app/(app)/chat/page.tsx` (full rewrite)
 
 **Context files to read first:**
+
 - `src/app/(app)/chat/page.tsx` — current: suggestion buttons, thread creation, navigation
 - `src/components/ChatThread.tsx` — just rewritten, handles message loading
 
 **Design:**
+
 - Single route `/chat`, no `[threadId]` subroute
 - If no messages: show welcome state (avatar, greeting, 4 suggestion cards)
 - If messages: show ChatThread immediately
@@ -1567,8 +1587,7 @@ function ChatPageInner() {
             What are we working on today?
           </h2>
           <p className="mb-6 max-w-sm text-center text-sm text-muted-foreground">
-            I can check your readiness, program workouts, analyze trends, or
-            just talk training.
+            I can check your readiness, program workouts, analyze trends, or just talk training.
           </p>
           <div className="grid w-full max-w-md grid-cols-2 gap-3">
             {suggestions.map(({ icon: Icon, text }) => (
@@ -1608,6 +1627,7 @@ npx tsc --noEmit
 - [ ] **Step 3: Manual test**
 
 Start the dev server (`npm run dev`) and verify:
+
 1. `/chat` shows welcome state with 4 suggestions when no messages exist
 2. Clicking a suggestion sends a message and transitions to ChatThread
 3. Navigating to `/chat?prompt=test` auto-sends and shows conversation
@@ -1624,12 +1644,14 @@ git commit -m "feat: rewrite chat page with welcome state and auto-send from que
 ### Task 14: Dashboard CTAs + greeting
 
 **Files:**
+
 - Modify: `src/app/(app)/dashboard/page.tsx` — greeting header
 - Modify: `src/components/MuscleReadinessMap.tsx` — CTA
 - Modify: `src/components/TrainingFrequencyChart.tsx` — CTA
 - Modify: `src/components/StrengthScoreCard.tsx` — static CTA
 
 **Context files to read first:**
+
 - `src/app/(app)/dashboard/page.tsx` — current dashboard layout and card rendering
 - `src/components/MuscleReadinessMap.tsx` — readiness values, readinessColor/readinessLabel helpers
 - `src/components/TrainingFrequencyChart.tsx` — frequency data with `targetArea` and `count`
@@ -1652,19 +1674,19 @@ const today = new Date().toLocaleDateString(undefined, {
 
 // In JSX, replace <h1>Training Dashboard</h1> with:
 <div className="mb-6">
-  <h1 className="text-xl font-semibold text-foreground">
-    Hey {firstName}
-  </h1>
+  <h1 className="text-xl font-semibold text-foreground">Hey {firstName}</h1>
   <p className="text-sm text-muted-foreground">{today}</p>
-</div>
+</div>;
 ```
 
 Also add the `useQuery` import if not already present, and import `api`:
+
 ```tsx
 import { useQuery } from "convex/react";
 ```
 
 Also update the local `FrequencyEntry` interface in `dashboard/page.tsx` (around line 116) to include the new field from Task 6:
+
 ```tsx
 interface FrequencyEntry {
   targetArea: string;
@@ -1686,21 +1708,23 @@ import Link from "next/link";
 After the grid of muscle entries, before the closing `</div>`:
 
 ```tsx
-{(() => {
-  const fresh = entries.find((e) => e.value > 80);
-  if (!fresh) return null;
-  const prompt = encodeURIComponent(
-    `My ${fresh.muscle.toLowerCase()} is at ${fresh.value}% readiness. Can you program a ${fresh.muscle.toLowerCase()} workout?`,
-  );
-  return (
-    <Link
-      href={`/chat?prompt=${prompt}`}
-      className="mt-3 block text-xs text-primary hover:underline"
-    >
-      {fresh.muscle} is fresh — ask coach for a workout →
-    </Link>
-  );
-})()}
+{
+  (() => {
+    const fresh = entries.find((e) => e.value > 80);
+    if (!fresh) return null;
+    const prompt = encodeURIComponent(
+      `My ${fresh.muscle.toLowerCase()} is at ${fresh.value}% readiness. Can you program a ${fresh.muscle.toLowerCase()} workout?`,
+    );
+    return (
+      <Link
+        href={`/chat?prompt=${prompt}`}
+        className="mt-3 block text-xs text-primary hover:underline"
+      >
+        {fresh.muscle} is fresh — ask coach for a workout →
+      </Link>
+    );
+  })();
+}
 ```
 
 - [ ] **Step 3: Add CTA to TrainingFrequencyChart**
@@ -1708,6 +1732,7 @@ After the grid of muscle entries, before the closing `</div>`:
 In `src/components/TrainingFrequencyChart.tsx`, accept the new `lastTrainedDate` field and show a CTA when any area hasn't been trained in >7 days:
 
 Update the `FrequencyEntry` interface:
+
 ```tsx
 interface FrequencyEntry {
   targetArea: string;
@@ -1722,27 +1747,29 @@ Add `Link` import and after the frequency bars, before closing `</div>`:
 import Link from "next/link";
 
 // After the bars, add:
-{(() => {
-  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-  const stale = data.find(
-    (d) => d.lastTrainedDate && new Date(d.lastTrainedDate).getTime() < sevenDaysAgo,
-  );
-  if (!stale) return null;
-  const days = Math.round(
-    (Date.now() - new Date(stale.lastTrainedDate!).getTime()) / (1000 * 60 * 60 * 24),
-  );
-  const prompt = encodeURIComponent(
-    `I haven't trained ${stale.targetArea.toLowerCase()} in ${days} days. Can you suggest a workout?`,
-  );
-  return (
-    <Link
-      href={`/chat?prompt=${prompt}`}
-      className="mt-3 block text-xs text-primary hover:underline"
-    >
-      You haven&apos;t hit {stale.targetArea.toLowerCase()} in {days} days — ask coach →
-    </Link>
-  );
-})()}
+{
+  (() => {
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    const stale = data.find(
+      (d) => d.lastTrainedDate && new Date(d.lastTrainedDate).getTime() < sevenDaysAgo,
+    );
+    if (!stale) return null;
+    const days = Math.round(
+      (Date.now() - new Date(stale.lastTrainedDate!).getTime()) / (1000 * 60 * 60 * 24),
+    );
+    const prompt = encodeURIComponent(
+      `I haven't trained ${stale.targetArea.toLowerCase()} in ${days} days. Can you suggest a workout?`,
+    );
+    return (
+      <Link
+        href={`/chat?prompt=${prompt}`}
+        className="mt-3 block text-xs text-primary hover:underline"
+      >
+        You haven&apos;t hit {stale.targetArea.toLowerCase()} in {days} days — ask coach →
+      </Link>
+    );
+  })();
+}
 ```
 
 - [ ] **Step 4: Add static CTA to StrengthScoreCard**
@@ -1758,7 +1785,7 @@ import Link from "next/link";
   className="mt-3 block text-xs text-primary hover:underline"
 >
   Ask coach about your strength trends →
-</Link>
+</Link>;
 ```
 
 - [ ] **Step 5: Add hover elevation to dashboard cards**
@@ -1766,7 +1793,8 @@ import Link from "next/link";
 In `src/app/(app)/dashboard/page.tsx`, the cards are rendered by sub-components. Each sub-component uses a `<div className="rounded-lg border border-border bg-card p-4">` wrapper. Adding hover elevation requires modifying each card component's root div:
 
 ```tsx
-className="rounded-lg border border-border bg-card p-4 transition-shadow hover:shadow-md hover:shadow-black/10"
+className =
+  "rounded-lg border border-border bg-card p-4 transition-shadow hover:shadow-md hover:shadow-black/10";
 ```
 
 Do this for: `MuscleReadinessMap`, `TrainingFrequencyChart`, `StrengthScoreCard`, `RecentWorkoutsList`. Each component has a root `<div className="rounded-lg border border-border bg-card p-4">` — add `transition-shadow hover:shadow-md hover:shadow-black/10` to that className. Note: `RecentWorkoutsList` has two such divs (empty state and content state) — update both.

--- a/docs/superpowers/specs/2026-03-12-font-landing-design-system.md
+++ b/docs/superpowers/specs/2026-03-12-font-landing-design-system.md
@@ -29,11 +29,13 @@ No backend changes. No new dependencies beyond what `next/font/google` and shadc
 **Mono font:** Keep Geist Mono for code contexts (tool call indicators, inline code in chat).
 
 **Weight usage:**
+
 - 700 (bold): page headings, hero headline
 - 500 (medium): subheadings, form labels, button text
 - 400 (regular): body text, descriptions
 
 **Files changed:**
+
 - `src/app/layout.tsx` — swap `Geist` import for `DM_Sans`, set variable to `--font-dm-sans`, update body className
 - `src/app/globals.css` — update `--font-sans: var(--font-dm-sans)` in `@theme inline` block
 
@@ -48,6 +50,7 @@ All pages inherit automatically. No per-page font changes needed.
 **New brand accent:** Vibrant teal/cyan in the `oklch(0.75 0.15 195)` range. Energetic, fitness-appropriate, pops on dark backgrounds.
 
 **Applied to:**
+
 - `--primary` CSS variable (dark theme) — buttons, focus rings, links
 - Hero headline accent word
 - Hero glow gradient
@@ -55,6 +58,7 @@ All pages inherit automatically. No per-page font changes needed.
 - "Coming soon" badge borders (muted version)
 
 **Not changed:**
+
 - Chart colors (`chart-1` through `chart-5`) stay as-is for data visualization
 - Neutrals (background, card, border, muted) stay as-is
 
@@ -63,6 +67,7 @@ All pages inherit automatically. No per-page font changes needed.
 **Light mode:** The app hardcodes `className="dark"` on `<html>`. Light mode is out of scope. No `:root` primary changes needed.
 
 **Files changed:**
+
 - `src/app/globals.css` — update `--primary` and `--primary-foreground` in `.dark` block
 
 ---
@@ -72,35 +77,42 @@ All pages inherit automatically. No per-page font changes needed.
 Full rewrite of `src/app/page.tsx`. Five sections:
 
 ### 3.1 Nav bar
+
 - Logo ("tonal.coach") top-left
 - "Sign In" link top-right (or "Go to Chat" if authenticated)
 - Transparent, minimal
 
 ### 3.2 Hero (full viewport)
+
 - Headline: punchy, sells "the missing piece for your Tonal" angle
 - Subtitle: 1-2 sentences positioning it as a coaching layer
 - Single CTA button (accent-colored, prominent)
 - Radial gradient glow behind headline (accent color at ~10-15% opacity)
 
 ### 3.3 Feature sections
+
 Five features in a staggered or asymmetric grid layout:
+
 - **AI Coaching** — "Ask anything about your training. Get answers grounded in your real data."
 - **Push to Tonal** — "Your coach programs workouts and sends them straight to your machine."
-- **Proactive Check-ins** — "Get nudged when you're overtraining, slacking, or ready to level up." *(coming soon badge)*
-- **Progress Tracking** — "Strength scores, muscle readiness, and body composition over time." *(coming soon badge for body comp)*
-- **Nutrition Intelligence** — "Meal tracking that knows your training load." *(coming soon badge)*
+- **Proactive Check-ins** — "Get nudged when you're overtraining, slacking, or ready to level up." _(coming soon badge)_
+- **Progress Tracking** — "Strength scores, muscle readiness, and body composition over time." _(coming soon badge for body comp)_
+- **Nutrition Intelligence** — "Meal tracking that knows your training load." _(coming soon badge)_
 
 Each feature: Lucide icon + headline + 1-2 line description. Uses shadcn Card.
 
 Icons: Brain (coaching), Send (push), BellRing (proactive), TrendingUp (progress), Utensils (nutrition).
 
 ### 3.4 Social proof placeholder
+
 Quote-style block: "Built by a Tonal owner, for Tonal owners." Keeps it authentic, no fake testimonials.
 
 ### 3.5 Bottom CTA
+
 Repeat headline + CTA button. Standard conversion doubling pattern.
 
 ### 3.6 Footer
+
 - "Not affiliated with or endorsed by Tonal." disclaimer
 - Minimal, no link soup
 
@@ -111,6 +123,7 @@ Repeat headline + CTA button. Standard conversion doubling pattern.
 ## 4. Design System Components
 
 ### 4.1 Install shadcn components
+
 - `Card` (CardHeader, CardTitle, CardDescription, CardContent)
 - `Label`
 - `Separator`
@@ -120,16 +133,19 @@ Repeat headline + CTA button. Standard conversion doubling pattern.
 ### 4.2 New shared components
 
 **`src/components/PageLoader.tsx`**
+
 - Centered full-screen spinner with optional message text
 - Replaces 4 copy-pasted spinner patterns in login, connect-tonal, settings, chat
 - Props: `message?: string`
 
 **`src/components/ErrorAlert.tsx`**
+
 - Uses shadcn Alert with destructive variant
 - Props: `message: string`, `onRetry?: () => void`
 - Replaces inconsistent inline error `<p>` tags
 
 **`src/components/EmptyState.tsx`**
+
 - Centered icon + message + optional CTA button
 - Props: `icon: LucideIcon`, `title: string`, `description?: string`, `action?: { label: string, onClick: () => void }`
 - For empty thread lists, empty chat, etc.
@@ -137,33 +153,40 @@ Repeat headline + CTA button. Standard conversion doubling pattern.
 ### 4.3 Refactor existing pages
 
 **Login (`src/app/login/page.tsx`):**
+
 - Replace spinner with `PageLoader`
 - Replace `<label>` with shadcn `Label`
 - Replace error `<p>` with `ErrorAlert`
 - Wrap form in shadcn `Card`
 
 **Connect Tonal (`src/app/connect-tonal/page.tsx`):**
+
 - Same treatment as Login: `PageLoader`, `Label`, `ErrorAlert`, `Card`
 
 **Settings (`src/app/settings/page.tsx`):**
+
 - Replace spinner with `PageLoader`
 - Replace hand-rolled card divs with shadcn `Card`
 - Add error state if `getMe` query returns `null` unexpectedly (instead of infinite spinner)
 - Use `Separator` between sections
 
 **Dashboard (`src/app/dashboard/page.tsx`):**
+
 - Replace custom `CardSkeleton` with shadcn `Skeleton` inside shadcn `Card`
 - Replace custom `CardError` with `ErrorAlert` inside shadcn `Card`
 - Keep the per-card loading/error pattern (it's good)
 
 **Chat home (`src/app/chat/page.tsx`):**
+
 - Add a subtle loading overlay or spinner when a suggestion is being sent (currently just disables buttons)
 
 **Chat thread (`src/components/ChatThread.tsx`):**
+
 - Add `EmptyState` for threads with no messages yet
 - Existing "Load more" and streaming states are fine
 
 **Chat layout (`src/app/chat/layout.tsx`):**
+
 - No changes needed
 
 ---
@@ -171,12 +194,14 @@ Repeat headline + CTA button. Standard conversion doubling pattern.
 ## 5. Files Summary
 
 ### Created
+
 - `src/components/PageLoader.tsx`
 - `src/components/ErrorAlert.tsx`
 - `src/components/EmptyState.tsx`
 - shadcn component files (Card, Label, Separator, Skeleton, Alert) via `npx shadcn@latest add`
 
 ### Modified
+
 - `src/app/layout.tsx` — font swap
 - `src/app/globals.css` — accent color
 - `src/app/page.tsx` — full rewrite
@@ -188,6 +213,7 @@ Repeat headline + CTA button. Standard conversion doubling pattern.
 - `src/components/ChatThread.tsx` — empty state
 
 ### Not touched
+
 - All Convex backend files
 - Chat message rendering, tool indicators, workout cards
 - Thread sidebar

--- a/docs/superpowers/specs/2026-03-12-ux-refinement.md
+++ b/docs/superpowers/specs/2026-03-12-ux-refinement.md
@@ -43,12 +43,14 @@ New component: `src/components/AppShell.tsx`
 A responsive layout wrapper used by all authenticated pages (chat, dashboard, settings). Replaces both `chat/layout.tsx` (chat only) and `dashboard/layout.tsx` (dashboard only, uses `sm` breakpoint). The new breakpoint is `lg` (1024px) — up from `sm` (640px) — so tablets get the mobile layout instead of a cramped sidebar.
 
 **Desktop (lg and above):**
+
 - Left sidebar (256px width), fixed height, flex column
 - Sidebar contains: logo ("tonal.coach"), nav links (Chat, Dashboard, Settings), divider, user name at bottom (from `tonalName`)
 - Main content fills remaining width
 - No thread list in sidebar (one-coach model)
 
 **Mobile (below lg):**
+
 - No sidebar
 - Bottom tab bar with 3 tabs: Chat, Dashboard, Settings
 - Each tab: Lucide icon + label text
@@ -57,6 +59,7 @@ A responsive layout wrapper used by all authenticated pages (chat, dashboard, se
 - Tab bar has subtle top border, semi-transparent background
 
 **Nav links:**
+
 - Chat: `MessageSquare` icon, routes to `/chat`
 - Dashboard: `LayoutDashboard` icon, routes to `/dashboard`
 - Settings: `Settings` icon, routes to `/settings`
@@ -66,12 +69,14 @@ A responsive layout wrapper used by all authenticated pages (chat, dashboard, se
 ### 1.2 Layout restructuring
 
 **Current structure:**
+
 - `src/app/chat/layout.tsx` — wraps chat pages with sidebar + auth guards
 - `src/app/dashboard/layout.tsx` — wraps dashboard with header nav (desktop) + bottom tabs (mobile) + auth guards, uses `sm` breakpoint
 - `src/app/dashboard/page.tsx` — dashboard page inside dashboard layout
 - `src/app/settings/page.tsx` — standalone page with back arrow, own auth guards
 
 **New structure:**
+
 - `src/app/(app)/layout.tsx` — `AppShell` wrapper with auth guards. Applies to all authenticated routes.
 - `src/app/(app)/chat/page.tsx` — chat (single route, thread managed as state)
 - `src/app/(app)/dashboard/page.tsx` — dashboard
@@ -86,6 +91,7 @@ A responsive layout wrapper used by all authenticated pages (chat, dashboard, se
 ### 1.3 Mobile chat header
 
 On mobile, the chat page gets a minimal header bar (below the status bar, above the message area):
+
 - Left: coach avatar/icon
 - Center: "Coach" or "tonal.coach"
 - Right: (reserved for future — notifications, etc.)
@@ -101,6 +107,7 @@ This replaces the current hamburger menu button since the sidebar no longer exis
 **User experience:** One continuous conversation. Open the app, your coach is there, scroll up to see history. No threads, no "New Chat" button.
 
 **Technical implementation:**
+
 - When user sends a message, check the last message timestamp in the most recent thread.
 - If >24 hours since last message: create a new thread automatically. User doesn't see this.
 - If ≤24 hours: append to existing thread.
@@ -108,11 +115,13 @@ This replaces the current hamburger menu button since the sidebar no longer exis
 - Date dividers ("Today", "Yesterday", "March 8") inserted between messages from different days.
 
 **Backend changes:**
+
 - New `internalQuery`: `getActiveThread` in `convex/threads.ts` — uses the agent component's `listThreadsByUserId` internal query (accepts `userId`, returns threads with `_creationTime`, `status`, `title`) to find the most recent active thread. Returns its ID and the timestamp of the last message in that thread (fetched separately via the agent's message listing, since the thread record itself doesn't store message timestamps). Must be `internalQuery` (not public query) so `sendMessage` action can call it via `ctx.runQuery`.
 - Modify `sendMessage` action in `convex/chat.ts`: staleness check happens inside the action (not client-side). Logic: if no `threadId` provided, call `getActiveThread` via `ctx.runQuery`. If no thread exists or last message is >24h old, create a new thread via the agent component's `createThread`. Then send the message to the resolved thread.
 - Also expose `getActiveThread` as a public query wrapper (or a separate `getCurrentThread` query) so the chat page can subscribe to the current thread ID on load.
 
 **Message loading — two data sources:**
+
 - **Current thread (streaming):** The chat page continues to use `useUIMessages` + `syncStreams` from `@convex-dev/agent/react`, bound to the active thread ID. This preserves real-time streaming for new messages.
 - **Previous threads (static, "Load earlier"):** New public query `listConversationHistory` in `convex/threads.ts` loads historical messages across older threads. Called from the client when user clicks "Load earlier". Paginated with cursor. Returns messages with thread boundary markers for date dividers. These are fully-formed historical messages — no streaming.
 - **Merge strategy:** The chat UI maintains two message arrays: `historicalMessages` (from `listConversationHistory`, prepended at top) and `currentMessages` (from `useUIMessages`, appended at bottom). A date divider component is inserted between messages from different days across both arrays.
@@ -120,6 +129,7 @@ This replaces the current hamburger menu button since the sidebar no longer exis
 **Chat routing:** `/chat` is the only user-facing route. The `[threadId]` route is removed. The chat page calls the public `getCurrentThread` query to subscribe to the active thread ID, then binds `useUIMessages` to it. Thread ID is reactive state from the query, not a URL param.
 
 **Chat home page (`/chat`) changes:**
+
 - No longer a "pick a suggestion to start" gate. The chat input is always active.
 - If no messages exist yet: show the welcome/personality state (section 2.4) above the input.
 - If messages exist: show the conversation immediately, scrolled to bottom.
@@ -130,21 +140,25 @@ This replaces the current hamburger menu button since the sidebar no longer exis
 **Replace `ChatMessage.tsx` entirely.**
 
 New message layout (both roles):
+
 - Header row: avatar (24px circle) + role name ("You" / "Coach") + timestamp
 - Content: indented 32px (aligned with role name), full width
 - Messages separated by subtle `border-border` divider (not inside a bubble)
 
 **User messages:**
+
 - Avatar: user's first initial in a teal (primary) circle
 - Role name: "You"
 - Content: plain text, no markdown processing
 
 **Coach messages:**
+
 - Avatar: sparkle/star icon in a muted circle
 - Role name: "Coach"
 - Content: rendered with `react-markdown` + `remark-gfm`
 
 **Markdown styling (dark theme):**
+
 - **Bold:** `font-semibold text-foreground` (brighter than surrounding text)
 - **Italic:** standard italic
 - **Inline code:** `rounded bg-muted px-1.5 py-0.5 font-mono text-sm`
@@ -156,18 +170,20 @@ New message layout (both roles):
 - **Links:** `text-primary underline underline-offset-2`
 - **Blockquotes:** `border-l-2 border-primary/30 pl-4 italic text-muted-foreground`
 
-**Streaming cursor:** Keep the existing blinking cursor at the end of streaming text. Append the cursor character (`▍`) to the raw markdown string *before* passing it to `react-markdown`, not after the rendered output — this ensures it appears inside the last rendered element (e.g., at the end of a list item) rather than floating outside.
+**Streaming cursor:** Keep the existing blinking cursor at the end of streaming text. Append the cursor character (`▍`) to the raw markdown string _before_ passing it to `react-markdown`, not after the rendered output — this ensures it appears inside the last rendered element (e.g., at the end of a list item) rather than floating outside.
 
 ### 2.3 Tool call indicators
 
 **Replace `ToolCallIndicator.tsx`.**
 
 **Running state (input-streaming / input-available):**
+
 - Inline chip: animated teal pulse dot + descriptive text
 - e.g., `● Checking muscle readiness...`
 - Rendered between user message and coach response
 
 **Completed state (output-available):**
+
 - Compact chip: teal checkmark + past-tense text
 - e.g., `✓ Checked muscle readiness`
 - Multiple completed calls render as a horizontal `flex-wrap` row of chips
@@ -194,6 +210,7 @@ This state disappears once there are messages — it's a welcome screen, not a p
 **When `create_workout` tool completes:**
 
 Render a dedicated `WorkoutCard` component inline in the chat:
+
 - Card with subtle primary border (teal accent)
 - Title: workout name (bold)
 - Exercise list: numbered, with exercise name + sets × reps
@@ -232,6 +249,7 @@ Each dashboard card gets an optional CTA that links to the chat with a pre-fille
 ## 4. Files Summary
 
 ### Created
+
 - `src/components/AppShell.tsx` — responsive navigation shell
 - `src/components/BottomTabs.tsx` — mobile tab bar (or inline in AppShell)
 - `src/components/Sidebar.tsx` — desktop sidebar (or inline in AppShell)
@@ -241,6 +259,7 @@ Each dashboard card gets an optional CTA that links to the chat with a pre-fille
 - `convex/threads.ts` — `getActiveThread` (internalQuery), `getCurrentThread` (public query wrapper), `listConversationHistory` (public query, paginated)
 
 ### Modified
+
 - `src/components/ChatMessage.tsx` — full rewrite (full-width, avatars, markdown)
 - `src/components/ToolCallIndicator.tsx` — rewrite (chip style)
 - `src/components/WorkoutCard.tsx` — add status badges, teal accent
@@ -257,12 +276,14 @@ Each dashboard card gets an optional CTA that links to the chat with a pre-fille
 - `src/components/StrengthScoreCard.tsx` — add static "Ask coach" CTA link
 
 ### Deleted
+
 - `src/app/chat/layout.tsx` — replaced by `(app)/layout.tsx`
 - `src/app/chat/[threadId]/page.tsx` — removed (thread managed as state in `/chat`, not as a route)
 - `src/app/dashboard/layout.tsx` — replaced by `(app)/layout.tsx` (had its own responsive nav at `sm` breakpoint + auth guards)
 - `src/components/ThreadSidebar.tsx` — replaced by Sidebar inside AppShell
 
 ### Not touched
+
 - All other Convex backend files (tonal/, dashboard actions, etc.) except `convex/dashboard.ts` (minor)
 - Landing page, login, connect-tonal (not inside `(app)` group)
 - Dashboard sub-components other than those listed above

--- a/docs/swagger.html
+++ b/docs/swagger.html
@@ -1,41 +1,57 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tonal API - Swagger UI</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
-  <style>
-    html { box-sizing: border-box; overflow-y: scroll; }
-    *, *:before, *:after { box-sizing: inherit; }
-    body { margin: 0; background: #fafafa; }
-    .topbar { display: none; }
-    /* Dark theme overrides */
-    @media (prefers-color-scheme: dark) {
-      body { background: #1a1a2e; color: #e0e0e0; }
-      .swagger-ui { filter: invert(88%) hue-rotate(180deg); }
-      .swagger-ui .model-box { background: rgba(0,0,0,.1); }
-    }
-  </style>
-</head>
-<body>
-  <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
-  <script>
-    SwaggerUIBundle({
-      url: './tonal-api.yaml',
-      dom_id: '#swagger-ui',
-      deepLinking: true,
-      presets: [
-        SwaggerUIBundle.presets.apis,
-        SwaggerUIBundle.SwaggerUIStandalonePreset
-      ],
-      layout: 'BaseLayout',
-      defaultModelsExpandDepth: -1,
-      docExpansion: 'list',
-      filter: true,
-      tagsSorterAlpha: true,
-    });
-  </script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tonal API - Swagger UI</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+    <style>
+      html {
+        box-sizing: border-box;
+        overflow-y: scroll;
+      }
+      *,
+      *:before,
+      *:after {
+        box-sizing: inherit;
+      }
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+      .topbar {
+        display: none;
+      }
+      /* Dark theme overrides */
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #1a1a2e;
+          color: #e0e0e0;
+        }
+        .swagger-ui {
+          filter: invert(88%) hue-rotate(180deg);
+        }
+        .swagger-ui .model-box {
+          background: rgba(0, 0, 0, 0.1);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+      SwaggerUIBundle({
+        url: "./tonal-api.yaml",
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+        layout: "BaseLayout",
+        defaultModelsExpandDepth: -1,
+        docExpansion: "list",
+        filter: true,
+        tagsSorterAlpha: true,
+      });
+    </script>
+  </body>
 </html>

--- a/ios/TonalCoach/App/TonalCoachApp.swift
+++ b/ios/TonalCoach/App/TonalCoachApp.swift
@@ -7,20 +7,35 @@ struct TonalCoachApp: App {
     @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
 
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    @AppStorage("isGuestMode") private var isGuestMode = false
     @State private var convexManager = ConvexManager()
+    @State private var authManager: AuthManager?
     @State private var notificationManager = NotificationManager()
     @State private var healthKitManager = HealthKitManager()
 
     var body: some Scene {
         WindowGroup {
             Group {
-                if hasCompletedOnboarding {
-                    ContentView()
+                if let authManager {
+                    if authManager.isLoading {
+                        splashView
+                    } else if authManager.isAuthenticated || isGuestMode {
+                        if hasCompletedOnboarding {
+                            ContentView()
+                        } else {
+                            OnboardingView()
+                        }
+                    } else {
+                        NavigationStack {
+                            LoginView()
+                        }
+                    }
                 } else {
-                    OnboardingView()
+                    splashView
                 }
             }
             .environment(convexManager)
+            .environment(\.authManager, authManager ?? AuthManager(convexManager: convexManager))
             .environment(\.notificationManager, notificationManager)
             .environment(\.healthKitManager, healthKitManager)
             .preferredColorScheme(.dark)
@@ -28,13 +43,33 @@ struct TonalCoachApp: App {
                 handleDeepLink(url: url)
             }
             .task {
+                let manager = AuthManager(convexManager: convexManager)
+                authManager = manager
+
                 appDelegate.notificationManager = notificationManager
                 notificationManager.convexManager = convexManager
                 await notificationManager.checkAuthorizationStatus()
                 notificationManager.registerNotificationCategories()
+
+                await manager.restoreSession()
             }
         }
     }
+
+    // MARK: - Splash View
+
+    private var splashView: some View {
+        ZStack {
+            Theme.Colors.background
+                .ignoresSafeArea()
+
+            Text("tonal.coach")
+                .font(.system(size: 36, weight: .bold, design: .default))
+                .foregroundStyle(Theme.Colors.primary)
+        }
+    }
+
+    // MARK: - Deep Links
 
     private func handleDeepLink(url: URL) {
         let link = TonalDeepLink(url: url)

--- a/ios/TonalCoach/App/TonalCoachApp.swift
+++ b/ios/TonalCoach/App/TonalCoachApp.swift
@@ -9,33 +9,30 @@ struct TonalCoachApp: App {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("isGuestMode") private var isGuestMode = false
     @State private var convexManager = ConvexManager()
-    @State private var authManager: AuthManager?
     @State private var notificationManager = NotificationManager()
     @State private var healthKitManager = HealthKitManager()
+
+    private var authManager: AuthManager { AuthManager.shared }
 
     var body: some Scene {
         WindowGroup {
             Group {
-                if let authManager {
-                    if authManager.isLoading {
-                        splashView
-                    } else if authManager.isAuthenticated || isGuestMode {
-                        if hasCompletedOnboarding {
-                            ContentView()
-                        } else {
-                            OnboardingView()
-                        }
+                if authManager.isLoading {
+                    splashView
+                } else if authManager.isAuthenticated || isGuestMode {
+                    if hasCompletedOnboarding {
+                        ContentView()
                     } else {
-                        NavigationStack {
-                            LoginView()
-                        }
+                        OnboardingView()
                     }
                 } else {
-                    splashView
+                    NavigationStack {
+                        LoginView()
+                    }
                 }
             }
             .environment(convexManager)
-            .environment(\.authManager, authManager ?? AuthManager(convexManager: convexManager))
+            .environment(\.authManager, authManager)
             .environment(\.notificationManager, notificationManager)
             .environment(\.healthKitManager, healthKitManager)
             .preferredColorScheme(.dark)
@@ -43,15 +40,15 @@ struct TonalCoachApp: App {
                 handleDeepLink(url: url)
             }
             .task {
-                let manager = AuthManager(convexManager: convexManager)
-                authManager = manager
+                // Init auth manager with convex reference and restore session first
+                authManager.setConvexManager(convexManager)
+                await authManager.restoreSession()
 
+                // Notification setup (non-blocking for auth)
                 appDelegate.notificationManager = notificationManager
                 notificationManager.convexManager = convexManager
                 await notificationManager.checkAuthorizationStatus()
                 notificationManager.registerNotificationCategories()
-
-                await manager.restoreSession()
             }
         }
     }

--- a/ios/TonalCoach/Auth/AuthManager.swift
+++ b/ios/TonalCoach/Auth/AuthManager.swift
@@ -1,0 +1,247 @@
+import Combine
+import ConvexMobile
+import Foundation
+import SwiftUI
+
+/// Coordinates all authentication operations for SwiftUI views.
+///
+/// Views interact with this class via `@Environment(\.authManager)`.
+/// It wraps `ConvexManager` auth calls, manages Keychain persistence,
+/// and exposes reactive state for the UI layer.
+@Observable
+final class AuthManager {
+    // MARK: - Public State
+
+    /// Whether the user is currently authenticated.
+    private(set) var isAuthenticated = false
+
+    /// True during auth operations and initial session restore.
+    private(set) var isLoading = true
+
+    /// The signed-in user's email, read from Keychain on restore.
+    private(set) var currentEmail: String?
+
+    /// User-facing error message. Auto-clears on next auth operation.
+    var error: String?
+
+    // MARK: - Dependencies
+
+    private let convexManager: ConvexManager
+
+    // MARK: - Private
+
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(convexManager: ConvexManager = ConvexManager()) {
+        self.convexManager = convexManager
+
+        convexManager.authState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .authenticated:
+                    self.isAuthenticated = true
+                case .unauthenticated:
+                    self.isAuthenticated = false
+                default:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Sign In
+
+    /// Authenticate with email and password.
+    func signIn(email: String, password: String) async {
+        clearError()
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let result: SignInResult = try await convexManager.action(
+                "auth:signIn",
+                with: [
+                    "provider": "password",
+                    "params": [
+                        "email": email,
+                        "password": password,
+                        "flow": "signIn",
+                    ] as [String: ConvexEncodable?],
+                ]
+            )
+            try await handleTokenResult(result, email: email)
+        } catch {
+            self.error = parseError(error)
+        }
+    }
+
+    // MARK: - Sign Up
+
+    /// Create a new account with email and password.
+    func signUp(email: String, password: String) async {
+        clearError()
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let result: SignInResult = try await convexManager.action(
+                "auth:signIn",
+                with: [
+                    "provider": "password",
+                    "params": [
+                        "email": email,
+                        "password": password,
+                        "flow": "signUp",
+                    ] as [String: ConvexEncodable?],
+                ]
+            )
+            try await handleTokenResult(result, email: email)
+        } catch {
+            self.error = parseError(error)
+        }
+    }
+
+    // MARK: - Sign Out
+
+    /// Sign out, clearing all stored credentials.
+    func signOut() async {
+        clearError()
+
+        // Best-effort server-side sign out
+        do {
+            try await convexManager.action("auth:signOut", with: [:])
+        } catch {
+            // Intentionally ignored -- local cleanup proceeds regardless.
+        }
+
+        await convexManager.logout()
+        KeychainHelper.deleteAll()
+        isAuthenticated = false
+        currentEmail = nil
+    }
+
+    // MARK: - Password Reset
+
+    /// Request a password reset code sent to the given email.
+    func requestPasswordReset(email: String) async {
+        clearError()
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let _: SignInResult = try await convexManager.action(
+                "auth:signIn",
+                with: [
+                    "provider": "password",
+                    "params": [
+                        "email": email,
+                        "flow": "reset",
+                    ] as [String: ConvexEncodable?],
+                ]
+            )
+        } catch {
+            self.error = parseError(error)
+        }
+    }
+
+    /// Confirm a password reset using the OTP code and new password.
+    func confirmPasswordReset(email: String, code: String, newPassword: String) async {
+        clearError()
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let result: SignInResult = try await convexManager.action(
+                "auth:signIn",
+                with: [
+                    "provider": "password",
+                    "params": [
+                        "email": email,
+                        "code": code,
+                        "newPassword": newPassword,
+                        "flow": "reset-verification",
+                    ] as [String: ConvexEncodable?],
+                ]
+            )
+            try await handleTokenResult(result, email: email)
+        } catch {
+            self.error = parseError(error)
+        }
+    }
+
+    // MARK: - Session Restore
+
+    /// Attempt to restore a previous session from Keychain credentials.
+    ///
+    /// Call this once on app launch. Sets `isLoading = false` when complete,
+    /// regardless of outcome.
+    func restoreSession() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        guard KeychainHelper.read(key: KeychainHelper.Keys.jwt) != nil else {
+            return
+        }
+
+        currentEmail = KeychainHelper.read(key: KeychainHelper.Keys.email)
+
+        let result = await convexManager.loginFromCache()
+        switch result {
+        case .success:
+            isAuthenticated = true
+        case .failure:
+            KeychainHelper.deleteAll()
+            currentEmail = nil
+            isAuthenticated = false
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func handleTokenResult(_ result: SignInResult, email: String) async throws {
+        guard let tokens = result.tokens else {
+            throw AuthError.noStoredCredentials
+        }
+
+        KeychainHelper.save(key: KeychainHelper.Keys.jwt, value: tokens.token)
+        KeychainHelper.save(key: KeychainHelper.Keys.refreshToken, value: tokens.refreshToken)
+        KeychainHelper.save(key: KeychainHelper.Keys.email, value: email)
+
+        await convexManager.login()
+        isAuthenticated = true
+        currentEmail = email
+    }
+
+    private func clearError() {
+        error = nil
+    }
+
+    private func parseError(_ error: Error) -> String {
+        if let authError = error as? AuthError {
+            return authError.localizedDescription
+        }
+        let message = error.localizedDescription
+        // Strip Convex wrapper prefixes for cleaner user-facing messages.
+        if let range = message.range(of: "Uncaught Error: ") {
+            return String(message[range.upperBound...])
+        }
+        return message
+    }
+}
+
+// MARK: - SwiftUI Environment
+
+private struct AuthManagerKey: EnvironmentKey {
+    static let defaultValue = AuthManager()
+}
+
+extension EnvironmentValues {
+    var authManager: AuthManager {
+        get { self[AuthManagerKey.self] }
+        set { self[AuthManagerKey.self] = newValue }
+    }
+}

--- a/ios/TonalCoach/Auth/AuthManager.swift
+++ b/ios/TonalCoach/Auth/AuthManager.swift
@@ -24,9 +24,13 @@ final class AuthManager {
     /// User-facing error message. Auto-clears on next auth operation.
     var error: String?
 
+    // MARK: - Singleton
+
+    static let shared = AuthManager()
+
     // MARK: - Dependencies
 
-    private let convexManager: ConvexManager
+    private var convexManager: ConvexManager?
 
     // MARK: - Private
 
@@ -34,10 +38,17 @@ final class AuthManager {
 
     // MARK: - Init
 
-    init(convexManager: ConvexManager = ConvexManager()) {
-        self.convexManager = convexManager
+    init() {}
 
-        convexManager.authState
+    init(convexManager: ConvexManager) {
+        setConvexManager(convexManager)
+    }
+
+    func setConvexManager(_ manager: ConvexManager) {
+        self.convexManager = manager
+        cancellables.removeAll()
+
+        manager.authState
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 guard let self else { return }
@@ -53,6 +64,13 @@ final class AuthManager {
             .store(in: &cancellables)
     }
 
+    private func requireConvex() throws -> ConvexManager {
+        guard let convexManager else {
+            throw AuthError.clientNotConfigured
+        }
+        return convexManager
+    }
+
     // MARK: - Sign In
 
     /// Authenticate with email and password.
@@ -62,7 +80,7 @@ final class AuthManager {
         defer { isLoading = false }
 
         do {
-            let result: SignInResult = try await convexManager.action(
+            let result: SignInResult = try await requireConvex().action(
                 "auth:signIn",
                 with: [
                     "provider": "password",
@@ -88,7 +106,7 @@ final class AuthManager {
         defer { isLoading = false }
 
         do {
-            let result: SignInResult = try await convexManager.action(
+            let result: SignInResult = try await requireConvex().action(
                 "auth:signIn",
                 with: [
                     "provider": "password",
@@ -113,12 +131,12 @@ final class AuthManager {
 
         // Best-effort server-side sign out
         do {
-            try await convexManager.action("auth:signOut", with: [:])
+            try await requireConvex().action("auth:signOut", with: [:])
         } catch {
             // Intentionally ignored -- local cleanup proceeds regardless.
         }
 
-        await convexManager.logout()
+        await convexManager?.logout()
         KeychainHelper.deleteAll()
         isAuthenticated = false
         currentEmail = nil
@@ -133,7 +151,7 @@ final class AuthManager {
         defer { isLoading = false }
 
         do {
-            let _: SignInResult = try await convexManager.action(
+            let _: SignInResult = try await requireConvex().action(
                 "auth:signIn",
                 with: [
                     "provider": "password",
@@ -155,7 +173,7 @@ final class AuthManager {
         defer { isLoading = false }
 
         do {
-            let result: SignInResult = try await convexManager.action(
+            let result: SignInResult = try await requireConvex().action(
                 "auth:signIn",
                 with: [
                     "provider": "password",
@@ -189,6 +207,7 @@ final class AuthManager {
 
         currentEmail = KeychainHelper.read(key: KeychainHelper.Keys.email)
 
+        guard let convexManager else { isLoading = false; return }
         let result = await convexManager.loginFromCache()
         switch result {
         case .success:
@@ -211,7 +230,7 @@ final class AuthManager {
         KeychainHelper.save(key: KeychainHelper.Keys.refreshToken, value: tokens.refreshToken)
         KeychainHelper.save(key: KeychainHelper.Keys.email, value: email)
 
-        await convexManager.login()
+        await convexManager?.login()
         isAuthenticated = true
         currentEmail = email
     }
@@ -236,7 +255,7 @@ final class AuthManager {
 // MARK: - SwiftUI Environment
 
 private struct AuthManagerKey: EnvironmentKey {
-    static let defaultValue = AuthManager()
+    static let defaultValue = AuthManager.shared
 }
 
 extension EnvironmentValues {

--- a/ios/TonalCoach/Auth/AuthManager.swift
+++ b/ios/TonalCoach/Auth/AuthManager.swift
@@ -93,6 +93,7 @@ final class AuthManager {
             )
             try await handleTokenResult(result, email: email)
         } catch {
+
             self.error = parseError(error)
         }
     }
@@ -222,6 +223,7 @@ final class AuthManager {
     // MARK: - Private Helpers
 
     private func handleTokenResult(_ result: SignInResult, email: String) async throws {
+
         guard let tokens = result.tokens else {
             throw AuthError.noStoredCredentials
         }

--- a/ios/TonalCoach/Auth/KeychainHelper.swift
+++ b/ios/TonalCoach/Auth/KeychainHelper.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Security
+
+enum KeychainHelper {
+    private static let service = "coach.tonal.app"
+
+    static func save(key: String, value: String) {
+        guard let data = value.data(using: .utf8) else { return }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        SecItemDelete(query as CFDictionary)
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    static func read(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func delete(key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    static func deleteAll() {
+        delete(key: Keys.jwt)
+        delete(key: Keys.refreshToken)
+        delete(key: Keys.email)
+    }
+
+    enum Keys {
+        static let jwt = "convex_jwt"
+        static let refreshToken = "convex_refresh_token"
+        static let email = "convex_user_email"
+    }
+}

--- a/ios/TonalCoach/Auth/LoginView.swift
+++ b/ios/TonalCoach/Auth/LoginView.swift
@@ -1,0 +1,436 @@
+import SwiftUI
+
+// MARK: - Auth Mode
+
+/// Toggleable mode for the login form.
+private enum AuthMode: String, CaseIterable {
+    case signIn = "Sign In"
+    case signUp = "Sign Up"
+}
+
+// MARK: - Login View
+
+/// Email/password login screen with sign-in and sign-up modes.
+///
+/// This is the first screen users see when not authenticated. It provides:
+/// - Segmented control to toggle between sign in and sign up
+/// - Email and password fields with validation
+/// - Error banner with auto-dismiss
+/// - Forgot password navigation (sign-in mode)
+/// - Guest browsing escape hatch
+struct LoginView: View {
+    @Environment(\.authManager) private var authManager
+    @AppStorage("isGuestMode") private var isGuestMode = false
+
+    @State private var mode: AuthMode = .signIn
+    @State private var email = ""
+    @State private var password = ""
+    @State private var errorMessage: String?
+    @State private var errorDismissTask: Task<Void, Never>?
+
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case email
+        case password
+    }
+
+    // MARK: - Derived State
+
+    private var isSignUp: Bool { mode == .signUp }
+
+    private var passwordIsValid: Bool {
+        !isSignUp || password.count >= 8
+    }
+
+    private var canSubmit: Bool {
+        !email.isEmpty && !password.isEmpty && passwordIsValid && !authManager.isLoading
+    }
+
+    private var ctaLabel: String {
+        isSignUp ? "Create Account" : "Sign In"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            Theme.Colors.background
+                .ignoresSafeArea()
+                .onTapGesture { focusedField = nil }
+
+            ScrollView {
+                VStack(spacing: Theme.Spacing.xl) {
+                    Spacer(minLength: Theme.Spacing.xxxl)
+
+                    logo
+                    segmentedControl
+                    formFields
+                    errorBanner
+                    ctaButton
+                    bottomLinks
+                    guestButton
+
+                    Spacer(minLength: Theme.Spacing.xl)
+                }
+                .padding(.horizontal, Theme.Spacing.lg)
+            }
+            .scrollDismissesKeyboard(.interactively)
+        }
+        .onChange(of: authManager.error) { _, newError in
+            if let newError {
+                showError(newError)
+            }
+        }
+        .onChange(of: mode) { _, _ in
+            dismissError()
+        }
+    }
+
+    // MARK: - Logo
+
+    private var logo: some View {
+        Text("tonal.coach")
+            .font(.system(size: 36, weight: .bold, design: .default))
+            .foregroundStyle(Theme.Colors.primary)
+            .padding(.bottom, Theme.Spacing.sm)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: - Segmented Control
+
+    private var segmentedControl: some View {
+        Picker("Auth mode", selection: $mode) {
+            ForEach(AuthMode.allCases, id: \.self) { authMode in
+                Text(authMode.rawValue).tag(authMode)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, Theme.Spacing.xl)
+        .onChange(of: mode) { _, _ in
+            Theme.Haptics.selection()
+        }
+    }
+
+    // MARK: - Form Fields
+
+    private var formFields: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            emailField
+            passwordField
+
+            if isSignUp {
+                passwordHint
+            }
+        }
+    }
+
+    private var emailField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text("Email")
+                .font(Theme.Typography.calloutMedium)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            TextField("you@example.com", text: $email)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .keyboardType(.emailAddress)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textContentType(.emailAddress)
+                .submitLabel(.next)
+                .focused($focusedField, equals: .email)
+                .onSubmit { focusedField = .password }
+                .disabled(authManager.isLoading)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, Theme.Spacing.md)
+                .background(Theme.Colors.card)
+                .clipShape(
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                    .stroke(
+                        focusedField == .email
+                            ? Theme.Colors.ring
+                            : Theme.Colors.input,
+                        lineWidth: 1
+                    )
+                )
+                .accessibilityLabel("Email address")
+        }
+    }
+
+    private var passwordField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text("Password")
+                .font(Theme.Typography.calloutMedium)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            SecureField("Enter your password", text: $password)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .textContentType(isSignUp ? .newPassword : .password)
+                .submitLabel(.go)
+                .focused($focusedField, equals: .password)
+                .onSubmit { submitIfValid() }
+                .disabled(authManager.isLoading)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, Theme.Spacing.md)
+                .background(Theme.Colors.card)
+                .clipShape(
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                    .stroke(
+                        focusedField == .password
+                            ? Theme.Colors.ring
+                            : Theme.Colors.input,
+                        lineWidth: 1
+                    )
+                )
+                .accessibilityLabel("Password")
+        }
+    }
+
+    private var passwordHint: some View {
+        Text("8 characters minimum")
+            .font(Theme.Typography.caption)
+            .foregroundStyle(
+                password.isEmpty
+                    ? Theme.Colors.textTertiary
+                    : passwordIsValid
+                        ? Theme.Colors.success
+                        : Theme.Colors.destructive
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityLabel(
+                password.isEmpty
+                    ? "Password must be at least 8 characters"
+                    : passwordIsValid
+                        ? "Password meets minimum length"
+                        : "Password is too short"
+            )
+    }
+
+    // MARK: - Error Banner
+
+    @ViewBuilder
+    private var errorBanner: some View {
+        if let errorMessage {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 14))
+
+                Text(errorMessage)
+                    .font(Theme.Typography.callout)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Button {
+                    dismissError()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Theme.Colors.destructive.opacity(0.8))
+                        .frame(width: 28, height: 28)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityLabel("Dismiss error")
+            }
+            .foregroundStyle(Theme.Colors.destructive)
+            .padding(Theme.Spacing.md)
+            .background(Theme.Colors.destructive.opacity(0.12))
+            .clipShape(
+                RoundedRectangle(
+                    cornerRadius: Theme.CornerRadius.md,
+                    style: .continuous
+                )
+            )
+            .overlay(
+                RoundedRectangle(
+                    cornerRadius: Theme.CornerRadius.md,
+                    style: .continuous
+                )
+                .stroke(Theme.Colors.destructive.opacity(0.25), lineWidth: 1)
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isStaticText)
+            .accessibilityLabel("Error: \(errorMessage)")
+        }
+    }
+
+    // MARK: - CTA Button
+
+    private var ctaButton: some View {
+        Button {
+            submit()
+        } label: {
+            Group {
+                if authManager.isLoading {
+                    ProgressView()
+                        .tint(Theme.Colors.primaryForeground)
+                } else {
+                    Text(ctaLabel)
+                }
+            }
+            .font(Theme.Typography.calloutMedium)
+            .foregroundStyle(Theme.Colors.primaryForeground)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(
+                canSubmit
+                    ? Theme.Colors.primary
+                    : Theme.Colors.primary.opacity(0.4)
+            )
+            .clipShape(
+                RoundedRectangle(
+                    cornerRadius: Theme.CornerRadius.md,
+                    style: .continuous
+                )
+            )
+        }
+        .disabled(!canSubmit)
+        .accessibilityLabel(
+            authManager.isLoading
+                ? (isSignUp ? "Creating account" : "Signing in")
+                : ctaLabel
+        )
+    }
+
+    // MARK: - Bottom Links
+
+    private var bottomLinks: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            if !isSignUp {
+                NavigationLink {
+                    ResetPasswordView(initialEmail: email)
+                } label: {
+                    Text("Forgot password?")
+                        .font(Theme.Typography.callout)
+                        .foregroundStyle(Theme.Colors.primary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Guest Button
+
+    private var guestButton: some View {
+        Button {
+            isGuestMode = true
+        } label: {
+            Text("Browse as Guest")
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+        }
+        .padding(.top, Theme.Spacing.sm)
+    }
+
+    // MARK: - Actions
+
+    private func submitIfValid() {
+        guard canSubmit else { return }
+        submit()
+    }
+
+    private func submit() {
+        focusedField = nil
+        dismissError()
+
+        Task {
+            if isSignUp {
+                await authManager.signUp(email: email, password: password)
+            } else {
+                await authManager.signIn(email: email, password: password)
+            }
+
+            if authManager.error == nil {
+                Theme.Haptics.success()
+            }
+        }
+    }
+
+    private func showError(_ message: String) {
+        withAnimation(.easeInOut(duration: 0.25)) {
+            errorMessage = message
+        }
+        Theme.Haptics.error()
+
+        errorDismissTask?.cancel()
+        errorDismissTask = Task {
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled else { return }
+            dismissError()
+        }
+    }
+
+    private func dismissError() {
+        errorDismissTask?.cancel()
+        errorDismissTask = nil
+        withAnimation(.easeInOut(duration: 0.2)) {
+            errorMessage = nil
+        }
+        authManager.error = nil
+    }
+}
+
+// MARK: - Reset Password Placeholder
+
+/// Placeholder for the password reset flow. Will be replaced by a full implementation.
+struct ResetPasswordView: View {
+    let initialEmail: String
+
+    var body: some View {
+        ZStack {
+            Theme.Colors.background
+                .ignoresSafeArea()
+
+            VStack(spacing: Theme.Spacing.lg) {
+                Image(systemName: "envelope.badge")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Theme.Colors.primary)
+
+                Text("Reset Password")
+                    .font(Theme.Typography.title)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+
+                Text("Coming soon")
+                    .font(Theme.Typography.callout)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            }
+        }
+        .navigationTitle("Reset Password")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Sign In") {
+    NavigationStack {
+        LoginView()
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Sign Up") {
+    NavigationStack {
+        LoginView()
+    }
+    .preferredColorScheme(.dark)
+}

--- a/ios/TonalCoach/Auth/LoginView.swift
+++ b/ios/TonalCoach/Auth/LoginView.swift
@@ -389,35 +389,7 @@ struct LoginView: View {
     }
 }
 
-// MARK: - Reset Password Placeholder
-
-/// Placeholder for the password reset flow. Will be replaced by a full implementation.
-struct ResetPasswordView: View {
-    let initialEmail: String
-
-    var body: some View {
-        ZStack {
-            Theme.Colors.background
-                .ignoresSafeArea()
-
-            VStack(spacing: Theme.Spacing.lg) {
-                Image(systemName: "envelope.badge")
-                    .font(.system(size: 48))
-                    .foregroundStyle(Theme.Colors.primary)
-
-                Text("Reset Password")
-                    .font(Theme.Typography.title)
-                    .foregroundStyle(Theme.Colors.textPrimary)
-
-                Text("Coming soon")
-                    .font(Theme.Typography.callout)
-                    .foregroundStyle(Theme.Colors.textTertiary)
-            }
-        }
-        .navigationTitle("Reset Password")
-        .navigationBarTitleDisplayMode(.inline)
-    }
-}
+// ResetPasswordView is defined in ResetPasswordView.swift
 
 // MARK: - Preview
 

--- a/ios/TonalCoach/Auth/LoginView.swift
+++ b/ios/TonalCoach/Auth/LoginView.swift
@@ -59,23 +59,22 @@ struct LoginView: View {
                 .ignoresSafeArea()
                 .onTapGesture { focusedField = nil }
 
-            ScrollView {
-                VStack(spacing: Theme.Spacing.xl) {
-                    Spacer(minLength: Theme.Spacing.xxxl)
+            VStack(spacing: Theme.Spacing.xl) {
+                Spacer()
 
-                    logo
-                    segmentedControl
-                    formFields
-                    errorBanner
-                    ctaButton
-                    bottomLinks
-                    guestButton
+                logo
+                segmentedControl
+                formFields
+                errorBanner
+                ctaButton
+                bottomLinks
 
-                    Spacer(minLength: Theme.Spacing.xl)
-                }
-                .padding(.horizontal, Theme.Spacing.lg)
+                Spacer()
+
+                guestButton
+                    .padding(.bottom, Theme.Spacing.lg)
             }
-            .scrollDismissesKeyboard(.interactively)
+            .padding(.horizontal, Theme.Spacing.lg)
         }
         .onChange(of: authManager.error) { _, newError in
             if let newError {

--- a/ios/TonalCoach/Auth/PasswordAuthProvider.swift
+++ b/ios/TonalCoach/Auth/PasswordAuthProvider.swift
@@ -1,0 +1,77 @@
+import ConvexMobile
+import Foundation
+
+struct SignInResult: Decodable {
+    let tokens: TokenPair?
+    let signingIn: Bool?
+}
+
+struct TokenPair: Decodable {
+    let token: String
+    let refreshToken: String
+}
+
+final class PasswordAuthProvider: AuthProvider {
+    typealias T = String
+
+    /// Set after initialization once the ConvexClient is available.
+    var client: ConvexClient?
+
+    func login(onIdToken: @Sendable @escaping (String?) -> Void) async throws -> String {
+        guard let jwt = KeychainHelper.read(key: KeychainHelper.Keys.jwt) else {
+            throw AuthError.noStoredCredentials
+        }
+        onIdToken(jwt)
+        return jwt
+    }
+
+    func loginFromCache(onIdToken: @Sendable @escaping (String?) -> Void) async throws -> String {
+        guard let refreshToken = KeychainHelper.read(key: KeychainHelper.Keys.refreshToken) else {
+            throw AuthError.noStoredCredentials
+        }
+        guard let client else {
+            throw AuthError.clientNotSet
+        }
+
+        let result: SignInResult = try await client.action(
+            "auth:signIn",
+            with: ["refreshToken": refreshToken]
+        )
+
+        guard let tokens = result.tokens else {
+            KeychainHelper.deleteAll()
+            throw AuthError.refreshFailed
+        }
+
+        KeychainHelper.save(key: KeychainHelper.Keys.jwt, value: tokens.token)
+        KeychainHelper.save(key: KeychainHelper.Keys.refreshToken, value: tokens.refreshToken)
+
+        onIdToken(tokens.token)
+        return tokens.token
+    }
+
+    func logout() async throws {
+        KeychainHelper.deleteAll()
+    }
+
+    func extractIdToken(from authResult: String) -> String {
+        authResult
+    }
+}
+
+enum AuthError: LocalizedError {
+    case noStoredCredentials
+    case clientNotSet
+    case refreshFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .noStoredCredentials:
+            "No stored credentials found"
+        case .clientNotSet:
+            "ConvexClient reference not set on auth provider"
+        case .refreshFailed:
+            "Token refresh failed"
+        }
+    }
+}

--- a/ios/TonalCoach/Auth/PasswordAuthProvider.swift
+++ b/ios/TonalCoach/Auth/PasswordAuthProvider.swift
@@ -62,6 +62,7 @@ final class PasswordAuthProvider: AuthProvider {
 enum AuthError: LocalizedError {
     case noStoredCredentials
     case clientNotSet
+    case clientNotConfigured
     case refreshFailed
 
     var errorDescription: String? {
@@ -70,6 +71,8 @@ enum AuthError: LocalizedError {
             "No stored credentials found"
         case .clientNotSet:
             "ConvexClient reference not set on auth provider"
+        case .clientNotConfigured:
+            "AuthManager not configured with ConvexManager"
         case .refreshFailed:
             "Token refresh failed"
         }

--- a/ios/TonalCoach/Auth/ResetPasswordView.swift
+++ b/ios/TonalCoach/Auth/ResetPasswordView.swift
@@ -1,0 +1,492 @@
+import SwiftUI
+
+// MARK: - ResetPasswordView
+
+/// Three-step password reset flow: enter email, enter OTP + new password, success.
+///
+/// Accepts `initialEmail` from the presenting LoginView to reduce friction.
+/// Uses `AuthManager` for network calls and auto-signs the user in on success.
+struct ResetPasswordView: View {
+    let initialEmail: String
+
+    @Environment(\.authManager) private var authManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var step = 1
+    @State private var email = ""
+    @State private var code = ""
+    @State private var newPassword = ""
+    @State private var confirmPassword = ""
+    @State private var localError: String?
+    @State private var codeSent = false
+    @State private var showSuccessCheckmark = false
+
+    var body: some View {
+        ZStack {
+            Theme.Colors.background
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                navigationBar
+
+                Spacer(minLength: 0)
+
+                Group {
+                    switch step {
+                    case 1:
+                        emailStep
+                    case 2:
+                        codeStep
+                    case 3:
+                        successStep
+                    default:
+                        EmptyView()
+                    }
+                }
+                .transition(.asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                ))
+
+                Spacer(minLength: 0)
+
+                stepIndicator
+                    .padding(.bottom, Theme.Spacing.xl)
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: step)
+        .onAppear {
+            email = initialEmail
+        }
+    }
+
+    // MARK: - Navigation Bar
+
+    private var navigationBar: some View {
+        HStack {
+            if step > 1 && step < 3 {
+                Button {
+                    goBack()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityLabel("Go back")
+            } else {
+                // Close button on step 1, hidden on step 3
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityLabel("Close")
+                .opacity(step == 3 ? 0 : 1)
+                .disabled(step == 3)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.top, Theme.Spacing.sm)
+    }
+
+    // MARK: - Step 1: Enter Email
+
+    private var emailStep: some View {
+        VStack(spacing: Theme.Spacing.xl) {
+            VStack(spacing: Theme.Spacing.sm) {
+                Text("Reset Password")
+                    .font(Theme.Typography.title)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+
+                Text("Enter your email and we'll send you a code")
+                    .font(Theme.Typography.callout)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            if codeSent {
+                codeSentConfirmation
+            } else {
+                emailForm
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.xl)
+    }
+
+    private var emailForm: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            TextField("Email", text: $email)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .keyboardType(.emailAddress)
+                .textContentType(.emailAddress)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding(Theme.Spacing.md)
+                .background(Theme.Colors.card)
+                .clipShape(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                        .stroke(Theme.Colors.border, lineWidth: 1)
+                )
+                .accessibilityLabel("Email address")
+
+            errorBanner
+
+            Button {
+                Task { await sendResetCode() }
+            } label: {
+                Group {
+                    if authManager.isLoading {
+                        ProgressView()
+                            .tint(Theme.Colors.primaryForeground)
+                    } else {
+                        Text("Send Reset Code")
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .primaryButtonStyle()
+            }
+            .disabled(email.isEmpty || authManager.isLoading)
+            .opacity(email.isEmpty ? 0.5 : 1.0)
+            .accessibilityLabel("Send reset code")
+        }
+    }
+
+    private var codeSentConfirmation: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.Colors.success)
+                .symbolEffect(.bounce, value: codeSent)
+
+            Text("Check your email")
+                .font(Theme.Typography.headline)
+                .foregroundStyle(Theme.Colors.success)
+        }
+        .transition(.scale.combined(with: .opacity))
+    }
+
+    // MARK: - Step 2: Enter Code + New Password
+
+    private var codeStep: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.xl) {
+                VStack(spacing: Theme.Spacing.sm) {
+                    Text("Enter Code")
+                        .font(Theme.Typography.title)
+                        .foregroundStyle(Theme.Colors.textPrimary)
+
+                    Text("We sent an 8-digit code to \(email)")
+                        .font(Theme.Typography.callout)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+
+                VStack(spacing: Theme.Spacing.lg) {
+                    codeField
+                    newPasswordField
+                    confirmPasswordField
+                }
+
+                errorBanner
+
+                Button {
+                    Task { await resetPassword() }
+                } label: {
+                    Group {
+                        if authManager.isLoading {
+                            ProgressView()
+                                .tint(Theme.Colors.primaryForeground)
+                        } else {
+                            Text("Reset Password")
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .primaryButtonStyle()
+                }
+                .disabled(!isStep2Valid || authManager.isLoading)
+                .opacity(isStep2Valid ? 1.0 : 0.5)
+                .accessibilityLabel("Reset password")
+
+                Button {
+                    Task { await resendCode() }
+                } label: {
+                    Text("Resend code")
+                        .font(Theme.Typography.callout)
+                        .foregroundStyle(Theme.Colors.primary)
+                }
+                .disabled(authManager.isLoading)
+                .accessibilityLabel("Resend verification code")
+            }
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.lg)
+        }
+    }
+
+    private var codeField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text("Verification Code")
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            TextField("12345678", text: $code)
+                .font(Theme.Typography.title)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .multilineTextAlignment(.center)
+                .tracking(6)
+                .keyboardType(.numberPad)
+                .textContentType(.oneTimeCode)
+                .onChange(of: code) { _, newValue in
+                    let filtered = newValue.filter(\.isNumber)
+                    if filtered.count > 8 {
+                        code = String(filtered.prefix(8))
+                    } else if filtered != newValue {
+                        code = filtered
+                    }
+                }
+                .padding(Theme.Spacing.md)
+                .background(Theme.Colors.card)
+                .clipShape(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                        .stroke(Theme.Colors.border, lineWidth: 1)
+                )
+                .accessibilityLabel("8-digit verification code")
+        }
+    }
+
+    private var newPasswordField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text("New Password")
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            SecureField("At least 8 characters", text: $newPassword)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .textContentType(.newPassword)
+                .padding(Theme.Spacing.md)
+                .background(Theme.Colors.card)
+                .clipShape(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                        .stroke(Theme.Colors.border, lineWidth: 1)
+                )
+                .accessibilityLabel("New password, at least 8 characters")
+        }
+    }
+
+    private var confirmPasswordField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text("Confirm Password")
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            SecureField("Repeat new password", text: $confirmPassword)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .textContentType(.newPassword)
+                .padding(Theme.Spacing.md)
+                .background(Theme.Colors.card)
+                .clipShape(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                        .stroke(Theme.Colors.border, lineWidth: 1)
+                )
+                .accessibilityLabel("Confirm new password")
+        }
+    }
+
+    // MARK: - Step 3: Success
+
+    private var successStep: some View {
+        VStack(spacing: Theme.Spacing.xl) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 72))
+                .foregroundStyle(Theme.Colors.success)
+                .scaleEffect(showSuccessCheckmark ? 1.0 : 0.3)
+                .opacity(showSuccessCheckmark ? 1.0 : 0.0)
+                .animation(
+                    .spring(response: 0.5, dampingFraction: 0.6),
+                    value: showSuccessCheckmark
+                )
+
+            VStack(spacing: Theme.Spacing.sm) {
+                Text("Password Reset")
+                    .font(Theme.Typography.title)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+
+                Text("You're all set. Signing you in...")
+                    .font(Theme.Typography.callout)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.xl)
+        .onAppear {
+            showSuccessCheckmark = true
+            Theme.Haptics.success()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                dismiss()
+            }
+        }
+    }
+
+    // MARK: - Shared Components
+
+    private var errorBanner: some View {
+        Group {
+            if let displayError {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 14))
+
+                    Text(displayError)
+                        .font(Theme.Typography.callout)
+                }
+                .foregroundStyle(Theme.Colors.destructive)
+                .padding(Theme.Spacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Theme.Colors.destructive.opacity(0.1))
+                .clipShape(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                        .stroke(
+                            Theme.Colors.destructive.opacity(0.2),
+                            lineWidth: 1
+                        )
+                )
+                .transition(.opacity.combined(with: .move(edge: .top)))
+                .accessibilityLabel("Error: \(displayError)")
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: displayError != nil)
+    }
+
+    private var stepIndicator: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            ForEach(1 ... 3, id: \.self) { dotStep in
+                Circle()
+                    .fill(
+                        dotStep == step
+                            ? Theme.Colors.primary
+                            : Theme.Colors.tertiaryForeground
+                    )
+                    .frame(width: 8, height: 8)
+            }
+        }
+        .padding(.top, Theme.Spacing.lg)
+        .accessibilityLabel("Step \(step) of 3")
+    }
+
+    // MARK: - Computed Properties
+
+    private var isStep2Valid: Bool {
+        code.count == 8
+            && newPassword.count >= 8
+            && newPassword == confirmPassword
+    }
+
+    /// Merges `authManager.error` with local validation errors.
+    private var displayError: String? {
+        localError ?? authManager.error
+    }
+
+    // MARK: - Actions
+
+    private func sendResetCode() async {
+        clearErrors()
+        await authManager.requestPasswordReset(email: email)
+
+        if authManager.error == nil {
+            Theme.Haptics.success()
+            withAnimation {
+                codeSent = true
+            }
+            try? await Task.sleep(for: .seconds(1.5))
+            withAnimation {
+                step = 2
+                codeSent = false
+            }
+        } else {
+            Theme.Haptics.error()
+        }
+    }
+
+    private func resetPassword() async {
+        clearErrors()
+
+        // Client-side validation before network call
+        if newPassword.count < 8 {
+            localError = "Password must be at least 8 characters."
+            Theme.Haptics.error()
+            return
+        }
+        if newPassword != confirmPassword {
+            localError = "Passwords do not match."
+            Theme.Haptics.error()
+            return
+        }
+
+        await authManager.confirmPasswordReset(
+            email: email,
+            code: code,
+            newPassword: newPassword
+        )
+
+        if authManager.error == nil {
+            withAnimation {
+                step = 3
+            }
+        } else {
+            Theme.Haptics.error()
+        }
+    }
+
+    private func resendCode() async {
+        clearErrors()
+        await authManager.requestPasswordReset(email: email)
+        if authManager.error == nil {
+            Theme.Haptics.light()
+        } else {
+            Theme.Haptics.error()
+        }
+    }
+
+    private func goBack() {
+        clearErrors()
+        withAnimation {
+            step -= 1
+        }
+    }
+
+    private func clearErrors() {
+        localError = nil
+        authManager.error = nil
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ResetPasswordView(initialEmail: "user@example.com")
+        .preferredColorScheme(.dark)
+}

--- a/ios/TonalCoach/Library/LibraryHomeView.swift
+++ b/ios/TonalCoach/Library/LibraryHomeView.swift
@@ -542,9 +542,7 @@ final class LibraryViewModel {
             .sink(
                 receiveCompletion: { [weak self] completion in
                     if case .failure(let error) = completion {
-                        print("[LoadInit] ERROR: \(error)")
                     } else {
-                        print("[LoadInit] completed normally")
                     }
                     guard let self else { return }
                     if !self.hasLoadedInitial {
@@ -553,7 +551,6 @@ final class LibraryViewModel {
                     }
                 },
                 receiveValue: { [weak self] response in
-                    print("[LoadInit] GOT \(response.page.count) workouts")
                     guard let self else { return }
                     self.allWorkouts = response.page
                     self.continueCursor = response.continueCursor

--- a/ios/TonalCoach/Profile/ProfileView.swift
+++ b/ios/TonalCoach/Profile/ProfileView.swift
@@ -3,10 +3,63 @@ import SwiftUI
 /// Profile/settings tab with notification preferences, health connection, and app info.
 struct ProfileView: View {
     @Environment(\.healthKitManager) private var healthManager
+    @Environment(\.authManager) private var authManager
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = true
+    @AppStorage("isGuestMode") private var isGuestMode = false
 
     var body: some View {
         List {
+            // MARK: - Account Section
+            Section {
+                if authManager.isAuthenticated {
+                    HStack {
+                        Image(systemName: "person.circle.fill")
+                            .foregroundStyle(Theme.Colors.primary)
+                            .frame(width: 28)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Signed in as")
+                                .font(Theme.Typography.caption)
+                                .foregroundStyle(Theme.Colors.textTertiary)
+                            Text(authManager.currentEmail ?? "Unknown")
+                                .font(Theme.Typography.body)
+                                .foregroundStyle(Theme.Colors.textPrimary)
+                        }
+                    }
+                    .listRowBackground(Theme.Colors.card)
+
+                    Button {
+                        Task { await authManager.signOut() }
+                    } label: {
+                        HStack {
+                            Image(systemName: "arrow.right.square")
+                                .foregroundStyle(Theme.Colors.destructive)
+                                .frame(width: 28)
+                            Text("Sign Out")
+                                .font(Theme.Typography.body)
+                                .foregroundStyle(Theme.Colors.destructive)
+                        }
+                    }
+                    .listRowBackground(Theme.Colors.card)
+                } else {
+                    Button {
+                        isGuestMode = false
+                    } label: {
+                        HStack {
+                            Image(systemName: "person.badge.plus")
+                                .foregroundStyle(Theme.Colors.primary)
+                                .frame(width: 28)
+                            Text("Sign In")
+                                .font(Theme.Typography.body)
+                                .foregroundStyle(Theme.Colors.primary)
+                        }
+                    }
+                    .listRowBackground(Theme.Colors.card)
+                }
+            } header: {
+                Text("Account")
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            }
+
             // MARK: - Health Section
             Section {
                 HStack {

--- a/ios/TonalCoach/Shared/ConvexManager.swift
+++ b/ios/TonalCoach/Shared/ConvexManager.swift
@@ -3,15 +3,25 @@ import ConvexMobile
 import Foundation
 import SwiftUI
 
-/// Global ConvexClient instance, matching the Convex Swift quickstart pattern.
-/// Created once at app launch and never deallocated, keeping the WebSocket alive.
-private let globalConvexClient: ConvexClient = {
+/// Global ConvexClientWithAuth instance, created once at app launch.
+///
+/// Uses `PasswordAuthProvider` so the Convex client can authenticate
+/// via email/password JWTs stored in the Keychain.
+private let sharedAuthProvider = PasswordAuthProvider()
+
+private let globalConvexClient: ConvexClientWithAuth<String> = {
     let url = Bundle.main.infoDictionary?["CONVEX_URL"] as? String
         ?? "https://quaint-bulldog-653.convex.cloud"
-    return ConvexClient(deploymentUrl: url)
+    let client = ConvexClientWithAuth(
+        deploymentUrl: url,
+        authProvider: sharedAuthProvider
+    )
+    // The auth provider needs a reference back to the client for token refresh.
+    sharedAuthProvider.client = client
+    return client
 }()
 
-/// Manager wrapping the global ConvexClient for use throughout the app.
+/// Manager wrapping the global ConvexClientWithAuth for use throughout the app.
 ///
 /// Uses `@Observable` (iOS 17+) so SwiftUI views automatically react to
 /// state changes. Inject via the `.convexManager` environment value.
@@ -26,6 +36,37 @@ final class ConvexManager {
 
     /// Whether the WebSocket connection to Convex is currently active.
     private(set) var isConnected = false
+
+    // MARK: - Auth
+
+    /// Publisher that emits the current authentication state.
+    var authState: AnyPublisher<AuthState<String>, Never> {
+        client.authState
+    }
+
+    /// Trigger a login flow using credentials already stored in the Keychain.
+    ///
+    /// Call this after saving a JWT via `KeychainHelper` (e.g. after a
+    /// successful sign-in API call). Sets `authState` to `.loading`,
+    /// then `.authenticated` or `.unauthenticated`.
+    @discardableResult
+    func login() async -> Result<String, Error> {
+        await client.login()
+    }
+
+    /// Attempt a silent re-authentication using a stored refresh token.
+    ///
+    /// Typically called at app launch. If no valid refresh token exists,
+    /// the result is `.unauthenticated` without user-visible error.
+    @discardableResult
+    func loginFromCache() async -> Result<String, Error> {
+        await client.loginFromCache()
+    }
+
+    /// Log out, clearing Keychain credentials and resetting auth state.
+    func logout() async {
+        await client.logout()
+    }
 
     // MARK: - Private
 


### PR DESCRIPTION
## Summary

- Email/password authentication for the iOS app using the existing `@convex-dev/auth` backend
- Calls the same `auth:signIn` / `auth:signOut` Convex actions as the web app
- JWT + refresh tokens stored in iOS Keychain, fed to `ConvexClientWithAuth`
- 3-step password reset flow with OTP email codes

### New files (5)
- `Auth/KeychainHelper.swift` - Secure token storage via Security framework
- `Auth/PasswordAuthProvider.swift` - Implements convex-swift `AuthProvider` protocol
- `Auth/AuthManager.swift` - `@Observable` auth coordinator (sign in/up/out/reset)
- `Auth/LoginView.swift` - Sign in/up form with segmented control, error handling, guest mode
- `Auth/ResetPasswordView.swift` - 3-step OTP reset (email -> code + password -> success)

### Modified files (3)
- `Shared/ConvexManager.swift` - Switched to `ConvexClientWithAuth`, exposed auth state
- `App/TonalCoachApp.swift` - Auth gate: splash -> login -> app, session restore on launch
- `Profile/ProfileView.swift` - Account section with email display and sign out

### No backend changes
Uses existing `auth:signIn` and `auth:signOut` actions - no new Convex functions needed.

## Test plan
- [ ] App launches -> splash -> LoginView (no stored tokens)
- [ ] Sign up with new email -> authenticated, library loads
- [ ] Sign out -> returns to LoginView
- [ ] Sign in with existing email -> authenticated
- [ ] Wrong password -> error banner
- [ ] "Browse as Guest" -> library works without auth
- [ ] Kill app, relaunch -> auto-restores session from Keychain
- [ ] "Forgot password?" -> 3-step reset flow
- [ ] Profile tab shows email and sign out button

🤖 Generated with [Claude Code](https://claude.com/claude-code)