### PR TITLE
feat: Tonal connection + dashboard with strength, readiness, and history

### DIFF
--- a/docs/superpowers/plans/2026-03-24-tonal-dashboard.md
+++ b/docs/superpowers/plans/2026-03-24-tonal-dashboard.md
@@ -1,0 +1,435 @@
+# Tonal Connection + Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Tonal account connection and real-time dashboard (strength scores, muscle readiness, workout history) to the iOS app by calling existing Convex backend actions.
+
+**Architecture:** iOS calls existing Convex actions (`tonal/connectPublic:connectTonal`, `dashboard:get*`, `users:getMe`) via `ConvexManager.action()`. No backend changes. Dashboard shows 5 data cards in parallel with per-card loading/error states. Tonal tokens are managed entirely server-side.
+
+**Tech Stack:** SwiftUI, ConvexMobile, Swift Charts (for training frequency), iOS 17+
+
+**Spec:** `docs/superpowers/specs/2026-03-24-tonal-dashboard-design.md`
+
+---
+
+## File Map
+
+### Create
+
+| File                                                | Responsibility                                     |
+| --------------------------------------------------- | -------------------------------------------------- |
+| `ios/TonalCoach/Tonal/TonalModels.swift`            | Decodable types matching Convex response shapes    |
+| `ios/TonalCoach/Tonal/AsyncCard.swift`              | Reusable loading/error/content card wrapper        |
+| `ios/TonalCoach/Tonal/ConnectTonalView.swift`       | Tonal credentials form (email + password)          |
+| `ios/TonalCoach/Tonal/TonalDashboardView.swift`     | Main dashboard orchestrating 5 parallel data loads |
+| `ios/TonalCoach/Tonal/StrengthScoreCard.swift`      | 4 circular progress rings + percentile             |
+| `ios/TonalCoach/Tonal/MuscleReadinessCard.swift`    | Color-coded muscle group grid                      |
+| `ios/TonalCoach/Tonal/RecentWorkoutsCard.swift`     | Last 5 workout rows                                |
+| `ios/TonalCoach/Tonal/TrainingFrequencyCard.swift`  | Horizontal bar chart (Swift Charts)                |
+| `ios/TonalCoach/Tonal/ExternalActivitiesCard.swift` | Non-Tonal activity rows                            |
+
+### Modify
+
+| File                                       | Change                                               |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `ios/TonalCoach/App/ContentView.swift`     | Dashboard tab: show TonalDashboard or connect prompt |
+| `ios/TonalCoach/Profile/ProfileView.swift` | Add "Connect Tonal" / "Tonal Connected" row          |
+
+---
+
+## Task 1: TonalModels
+
+**Files:**
+
+- Create: `ios/TonalCoach/Tonal/TonalModels.swift`
+
+- [ ] **Step 1: Create Decodable types**
+
+All types match the exact shapes returned by Convex actions. Key reference: `convex/tonal/types.ts` and `convex/dashboard.ts`.
+
+Important: Convex `v.number()` fields arrive as plain JSON numbers (not `$integer`). Use `@ConvexNumber` for safety (from Models.swift).
+
+```swift
+// UserInfo - from users:getMe query
+struct UserInfo: Decodable {
+    let userId: String
+    let email: String?
+    let hasTonalProfile: Bool
+    let onboardingCompleted: Bool
+    let tonalName: String?
+    let tonalEmail: String?
+    let tonalTokenExpired: Bool
+}
+
+// ConnectResult - from tonal/connectPublic:connectTonal action
+struct ConnectTonalResult: Decodable {
+    let success: Bool
+    let tonalUserId: String
+}
+
+// StrengthData - from dashboard:getStrengthData action
+struct StrengthData: Decodable {
+    let scores: [StrengthScore]
+    let distribution: StrengthDistribution
+}
+
+struct StrengthScore: Decodable, Identifiable {
+    let id: String
+    let userId: String
+    let strengthBodyRegion: String
+    let bodyRegionDisplay: String
+    let score: Double
+    let current: Bool
+}
+
+struct StrengthDistribution: Decodable {
+    let userId: String
+    let overallScore: Double
+    let percentile: Double
+    let distributionPoints: [DistributionPoint]?
+}
+
+struct DistributionPoint: Decodable {
+    let score: Double
+    let yValue: Double
+}
+
+// MuscleReadiness - from dashboard:getMuscleReadiness action
+struct MuscleReadiness: Decodable {
+    let Chest: Double
+    let Shoulders: Double
+    let Back: Double
+    let Triceps: Double
+    let Biceps: Double
+    let Abs: Double
+    let Obliques: Double
+    let Quads: Double
+    let Glutes: Double
+    let Hamstrings: Double
+    let Calves: Double
+
+    var sorted: [(name: String, value: Double)] {
+        [
+            ("Chest", Chest), ("Shoulders", Shoulders), ("Back", Back),
+            ("Triceps", Triceps), ("Biceps", Biceps), ("Abs", Abs),
+            ("Obliques", Obliques), ("Quads", Quads), ("Glutes", Glutes),
+            ("Hamstrings", Hamstrings), ("Calves", Calves),
+        ].sorted { $0.value > $1.value }
+    }
+}
+
+// Activity - from dashboard:getWorkoutHistory action
+struct TonalActivity: Decodable, Identifiable {
+    let activityId: String
+    let activityTime: String
+    let activityType: String
+    let workoutPreview: WorkoutPreview
+    var id: String { activityId }
+}
+
+struct WorkoutPreview: Decodable {
+    let workoutTitle: String
+    let targetArea: String
+    let totalDuration: Double
+    let totalVolume: Double
+    let totalAchievements: Double
+    let programName: String?
+    let coachName: String?
+    let level: String?
+}
+
+// TrainingFrequencyEntry - from dashboard:getTrainingFrequency action
+struct TrainingFrequencyEntry: Decodable, Identifiable {
+    let targetArea: String
+    let count: Int
+    let lastTrainedDate: String
+    var id: String { targetArea }
+}
+
+// ExternalActivity - from dashboard:getExternalActivities action
+struct TonalExternalActivity: Decodable, Identifiable {
+    let id: String
+    let workoutType: String
+    let beginTime: String
+    let activeDuration: Double
+    let activeCalories: Double
+    let averageHeartRate: Double
+    let source: String
+}
+```
+
+- [ ] **Step 2: Build**
+- [ ] **Step 3: Commit**
+
+```bash
+git add ios/TonalCoach/Tonal/TonalModels.swift
+git commit -m "feat(tonal-dash): add Decodable types for Tonal API responses"
+```
+
+---
+
+## Task 2: AsyncCard
+
+**Files:**
+
+- Create: `ios/TonalCoach/Tonal/AsyncCard.swift`
+
+- [ ] **Step 1: Create reusable async loading card**
+
+A generic view that manages loading/error/content states for dashboard sections. Uses `@Observable` view model pattern.
+
+Key design:
+
+- Takes a `title: String`, `load: () async throws -> T` closure, and `@ViewBuilder content: (T) -> Content`
+- Shows skeleton while loading, error+retry on failure, content on success
+- Each card loads independently (one failure doesn't block others)
+- Matches Theme.Colors card styling
+
+- [ ] **Step 2: Build**
+- [ ] **Step 3: Commit**
+
+```bash
+git add ios/TonalCoach/Tonal/AsyncCard.swift
+git commit -m "feat(tonal-dash): add AsyncCard reusable loading wrapper"
+```
+
+---
+
+## Task 3: ConnectTonalView (use design-engineer agent)
+
+**Files:**
+
+- Create: `ios/TonalCoach/Tonal/ConnectTonalView.swift`
+
+**Dispatch to design-engineer** with this brief:
+
+- Read: `ios/TonalCoach/Auth/LoginView.swift` (visual reference - match the form style)
+- Read: `ios/TonalCoach/Shared/Theme.swift` (design tokens)
+- Read: `src/app/onboarding/ConnectStep.tsx` (web reference)
+- Tonal-branded header: dumbbell.fill icon + "Connect Your Tonal" title
+- Subtitle: "Sign in with your Tonal account credentials to see strength scores, muscle readiness, and workout history"
+- Email TextField + Password SecureField (same styling as LoginView)
+- "Connect" primary button (full width, loading spinner)
+- Error banner (same pattern as LoginView)
+- Note: "These are your Tonal credentials, not your tonal.coach account"
+- Presented as `.sheet` - include dismiss button (X in top-right)
+- Calls: `convexManager.action("tonal/connectPublic:connectTonal", with: ["tonalEmail": email, "tonalPassword": password])`
+- Decodes: `ConnectTonalResult`
+- On success: dismiss sheet, haptic success
+- `@Environment(ConvexManager.self)` for action calls
+- `@Environment(\.dismiss)` for sheet dismissal
+
+- [ ] **Step 1: Create ConnectTonalView**
+- [ ] **Step 2: Build**
+- [ ] **Step 3: Commit**
+
+```bash
+git add ios/TonalCoach/Tonal/ConnectTonalView.swift
+git commit -m "feat(tonal-dash): add ConnectTonalView credentials form"
+```
+
+---
+
+## Task 4: Dashboard data cards (dispatch 5 agents in parallel)
+
+**Files:**
+
+- Create: `ios/TonalCoach/Tonal/StrengthScoreCard.swift`
+- Create: `ios/TonalCoach/Tonal/MuscleReadinessCard.swift`
+- Create: `ios/TonalCoach/Tonal/RecentWorkoutsCard.swift`
+- Create: `ios/TonalCoach/Tonal/TrainingFrequencyCard.swift`
+- Create: `ios/TonalCoach/Tonal/ExternalActivitiesCard.swift`
+
+**Dispatch 5 design-engineer agents in parallel**, each creating one card:
+
+**All agents should read:**
+
+- `ios/TonalCoach/Shared/Theme.swift` (design tokens)
+- `ios/TonalCoach/Tonal/TonalModels.swift` (data types)
+- `ios/TonalCoach/Tonal/AsyncCard.swift` (wrapper pattern)
+
+**Agent 4a: StrengthScoreCard**
+
+- Large "Overall" circular progress ring (center) with score inside
+- 3 smaller rings in a row: Upper, Lower, Core
+- Ring colors: Theme.Colors.primary fill, Theme.Colors.border track
+- Percentile badge below: "Top X%" (invert percentile: 100 - distribution.percentile)
+- Data type: `StrengthData`
+
+**Agent 4b: MuscleReadinessCard**
+
+- 2-column LazyVGrid of 11 muscles
+- Each cell: muscle name + readiness % + small colored circle
+- Colors: green (>80%), amber (60-80%), red (<60%) matching Theme.Colors.success/warning/error
+- Data type: `MuscleReadiness` (use `.sorted` computed property)
+
+**Agent 4c: RecentWorkoutsCard**
+
+- VStack of up to 5 `WorkoutRow` views
+- Each row: title (semibold), target area badge, then stats row: volume (lbs), duration (min), PRs
+- Left accent bar using `Theme.Colors.sessionTypeColor` for target area
+- Relative time label (use `RelativeDateTimeFormatter`)
+- Data type: `[TonalActivity]`
+
+**Agent 4d: TrainingFrequencyCard**
+
+- Uses Swift Charts `BarMark` (horizontal bars)
+- `import Charts`
+- Y axis: `.value("Area", entry.targetArea)`
+- X axis: `.value("Count", entry.count)`
+- Bar colors: rotating palette from Theme.Colors.chart1-5
+- Data type: `[TrainingFrequencyEntry]`
+
+**Agent 4e: ExternalActivitiesCard**
+
+- VStack of activity rows (up to 5)
+- Each row: workout type icon (SF Symbol mapping), duration, calories if > 0, HR if > 0, source badge
+- Relative time
+- Data type: `[TonalExternalActivity]`
+
+- [ ] **Step 1: Dispatch all 5 agents**
+- [ ] **Step 2: Build after all complete**
+- [ ] **Step 3: Commit**
+
+```bash
+git add ios/TonalCoach/Tonal/StrengthScoreCard.swift ios/TonalCoach/Tonal/MuscleReadinessCard.swift ios/TonalCoach/Tonal/RecentWorkoutsCard.swift ios/TonalCoach/Tonal/TrainingFrequencyCard.swift ios/TonalCoach/Tonal/ExternalActivitiesCard.swift
+git commit -m "feat(tonal-dash): add 5 dashboard data cards"
+```
+
+---
+
+## Task 5: TonalDashboardView
+
+**Files:**
+
+- Create: `ios/TonalCoach/Tonal/TonalDashboardView.swift`
+
+- [ ] **Step 1: Create main dashboard view**
+
+Orchestrates all 5 data cards. Fires 5 parallel Convex action calls on appear.
+
+Key design:
+
+- `@Environment(ConvexManager.self)` for action calls
+- `@State` properties for each data section (optional, loaded async)
+- `.task` fires all 5 loads concurrently using `TaskGroup` or individual `Task {}`
+- ScrollView with VStack of AsyncCard-wrapped sections
+- Pull-to-refresh reloads all data
+- Each action: `convexManager.action("dashboard:getStrengthData", with: [:])` etc.
+- Note: all dashboard actions take no args (they resolve userId server-side from auth)
+
+- [ ] **Step 2: Build**
+- [ ] **Step 3: Commit**
+
+```bash
+git add ios/TonalCoach/Tonal/TonalDashboardView.swift
+git commit -m "feat(tonal-dash): add TonalDashboardView orchestrating 5 data sections"
+```
+
+---
+
+## Task 6: Wire Dashboard tab
+
+**Files:**
+
+- Modify: `ios/TonalCoach/App/ContentView.swift`
+
+- [ ] **Step 1: Update Dashboard tab logic**
+
+Replace the current `HealthDashboardView()` in the Dashboard tab with:
+
+```swift
+// In the Dashboard tab:
+NavigationStack {
+    DashboardRouter()
+        .navigationTitle("Dashboard")
+        .navigationBarTitleDisplayMode(.large)
+}
+```
+
+Create a `DashboardRouter` view (can be in the same file or ContentView):
+
+- Subscribe to `users:getMe` query to get `hasTonalProfile` and `tonalTokenExpired`
+- If `hasTonalProfile && !tonalTokenExpired`: show `TonalDashboardView()`
+- If `hasTonalProfile && tonalTokenExpired`: show reconnect card + `HealthDashboardView()`
+- If `!hasTonalProfile`: show connect prompt card + `HealthDashboardView()`
+- Connect prompt card: teal border card with "Connect Your Tonal" + "Connect" button
+- Button presents `ConnectTonalView` as `.sheet`
+- After connection: `hasTonalProfile` becomes true (reactive via subscription), dashboard auto-switches
+
+For `users:getMe` subscription, use the Combine sink pattern (matching LibraryHomeView):
+
+```swift
+convex.client.subscribe(to: "users:getMe", yielding: UserInfo.self)
+    .replaceError(with: nil)
+    .receive(on: DispatchQueue.main)
+    .sink { ... }
+```
+
+- [ ] **Step 2: Build**
+- [ ] **Step 3: Commit**
+
+```bash
+git add ios/TonalCoach/App/ContentView.swift
+git commit -m "feat(tonal-dash): wire dashboard tab with Tonal/HealthKit routing"
+```
+
+---
+
+## Task 7: Update ProfileView
+
+**Files:**
+
+- Modify: `ios/TonalCoach/Profile/ProfileView.swift`
+
+- [ ] **Step 1: Add Tonal connection row**
+
+Add a "Tonal" section between Account and Health:
+
+- If connected (`hasTonalProfile`): show "Tonal" row with checkmark + tonalName, "Connected" subtitle
+- If not connected: show "Connect Tonal" button (presents ConnectTonalView sheet)
+- If token expired: show "Reconnect Tonal" button (orange warning color)
+
+Subscribe to `users:getMe` same as Dashboard tab (or pass UserInfo down via environment).
+
+- [ ] **Step 2: Build**
+- [ ] **Step 3: Commit**
+
+```bash
+git add ios/TonalCoach/Profile/ProfileView.swift
+git commit -m "feat(tonal-dash): add Tonal connection status to ProfileView"
+```
+
+---
+
+## Task 8: Integration build and test
+
+- [ ] **Step 1: Regenerate Xcode project and full build**
+
+```bash
+cd ios && xcodegen generate
+xcodebuild -project TonalCoach.xcodeproj -scheme TonalCoach \
+  -destination 'platform=iOS Simulator,id=081A8F9C-DEBB-4AF8-A6DF-6D5BD3C264DC' \
+  -configuration Debug build
+```
+
+- [ ] **Step 2: Manual test checklist**
+
+- [ ] Dashboard shows "Connect Tonal" card when not connected
+- [ ] Tapping Connect opens ConnectTonalView sheet
+- [ ] Entering valid Tonal credentials -> success, sheet dismisses
+- [ ] Dashboard auto-switches to TonalDashboardView with real data
+- [ ] Strength scores show 4 rings with scores
+- [ ] Muscle readiness shows color-coded grid
+- [ ] Recent workouts show up to 5 entries
+- [ ] Training frequency chart renders bars
+- [ ] Pull-to-refresh reloads data
+- [ ] Profile shows "Tonal Connected" with name
+- [ ] Wrong Tonal credentials -> error message in sheet
+
+- [ ] **Step 3: Push and create PR**
+
+```bash
+git push -u origin feat/tonal-dashboard
+gh pr create --title "feat: Tonal connection + dashboard" --body "..."
+```

--- a/ios/TonalCoach/App/ContentView.swift
+++ b/ios/TonalCoach/App/ContentView.swift
@@ -1,3 +1,5 @@
+import Combine
+import ConvexMobile
 import SwiftUI
 
 enum AppTab: String, CaseIterable {
@@ -75,6 +77,7 @@ private struct DashboardRouter: View {
     @State private var userInfo: UserInfo?
     @State private var isLoaded = false
     @State private var showConnectSheet = false
+    @State private var cancellable: AnyCancellable?
 
     var body: some View {
         Group {
@@ -98,7 +101,24 @@ private struct DashboardRouter: View {
         .sheet(isPresented: $showConnectSheet) {
             ConnectTonalView()
         }
-        .task { await loadUser() }
+        .onAppear { subscribeToUser() }
+    }
+
+    /// Subscribe to users:getMe so dashboard auto-updates after Tonal connection.
+    private func subscribeToUser() {
+        guard cancellable == nil else { return }
+        cancellable = convex.client
+            .subscribe(to: "users:getMe", yielding: UserInfo.self)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { _ in
+                    isLoaded = true
+                },
+                receiveValue: { info in
+                    userInfo = info
+                    isLoaded = true
+                }
+            )
     }
 
     private var connectPromptCard: some View {
@@ -134,15 +154,6 @@ private struct DashboardRouter: View {
         )
     }
 
-    private func loadUser() async {
-        do {
-            let info: UserInfo? = try await convex.query("users:getMe")
-            userInfo = info
-        } catch {
-            userInfo = nil
-        }
-        isLoaded = true
-    }
 }
 
 /// Placeholder view for tabs not yet implemented.

--- a/ios/TonalCoach/App/ContentView.swift
+++ b/ios/TonalCoach/App/ContentView.swift
@@ -37,7 +37,7 @@ struct ContentView: View {
                 .tag(AppTab.schedule)
 
             NavigationStack {
-                HealthDashboardView()
+                DashboardRouter()
                     .navigationTitle("Dashboard")
                     .navigationBarTitleDisplayMode(.large)
             }
@@ -64,6 +64,84 @@ struct ContentView: View {
         .onChange(of: selectedTab) { _, _ in
             Theme.Haptics.selection()
         }
+    }
+}
+
+// MARK: - Dashboard Router
+
+/// Routes between the Tonal dashboard and a connect prompt based on user profile state.
+private struct DashboardRouter: View {
+    @Environment(ConvexManager.self) private var convex
+    @State private var userInfo: UserInfo?
+    @State private var isLoaded = false
+    @State private var showConnectSheet = false
+
+    var body: some View {
+        Group {
+            if !isLoaded {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let info = userInfo, info.hasTonalProfile, !info.tonalTokenExpired {
+                TonalDashboardView()
+            } else {
+                ScrollView {
+                    VStack(spacing: Theme.Spacing.lg) {
+                        connectPromptCard
+                        HealthDashboardView()
+                    }
+                    .padding(.horizontal, Theme.Spacing.lg)
+                    .padding(.vertical, Theme.Spacing.md)
+                }
+            }
+        }
+        .background(Theme.Colors.background)
+        .sheet(isPresented: $showConnectSheet) {
+            ConnectTonalView()
+        }
+        .task { await loadUser() }
+    }
+
+    private var connectPromptCard: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "dumbbell.fill")
+                .font(.system(size: 32))
+                .foregroundStyle(Theme.Colors.primary)
+                .accessibilityHidden(true)
+
+            Text("Connect Your Tonal")
+                .font(Theme.Typography.title2)
+                .foregroundStyle(Theme.Colors.textPrimary)
+
+            Text("Link your Tonal account to see strength scores, muscle readiness, and workout history.")
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+
+            Button {
+                showConnectSheet = true
+            } label: {
+                Text("Connect")
+                    .primaryButtonStyle()
+            }
+        }
+        .padding(Theme.Spacing.xl)
+        .frame(maxWidth: .infinity)
+        .background(Theme.Colors.card)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.lg, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.CornerRadius.lg, style: .continuous)
+                .stroke(Theme.Colors.primary.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private func loadUser() async {
+        do {
+            let info: UserInfo? = try await convex.query("users:getMe")
+            userInfo = info
+        } catch {
+            userInfo = nil
+        }
+        isLoaded = true
     }
 }
 

--- a/ios/TonalCoach/Profile/ProfileView.swift
+++ b/ios/TonalCoach/Profile/ProfileView.swift
@@ -1,3 +1,5 @@
+import Combine
+import ConvexMobile
 import SwiftUI
 
 /// Profile/settings tab with notification preferences, health connection, and app info.
@@ -10,6 +12,7 @@ struct ProfileView: View {
 
     @State private var userInfo: UserInfo?
     @State private var showConnectSheet = false
+    @State private var cancellable: AnyCancellable?
 
     var body: some View {
         List {
@@ -183,7 +186,7 @@ struct ProfileView: View {
         .sheet(isPresented: $showConnectSheet) {
             ConnectTonalView()
         }
-        .task { await loadUser() }
+        .onAppear { subscribeToUser() }
     }
 
     // MARK: - Tonal Rows
@@ -246,12 +249,16 @@ struct ProfileView: View {
 
     // MARK: - Data Loading
 
-    private func loadUser() async {
-        do {
-            let info: UserInfo? = try await convex.query("users:getMe")
-            userInfo = info
-        } catch {
-            userInfo = nil
-        }
+    private func subscribeToUser() {
+        guard cancellable == nil else { return }
+        cancellable = convex.client
+            .subscribe(to: "users:getMe", yielding: UserInfo.self)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { info in
+                    userInfo = info
+                }
+            )
     }
 }

--- a/ios/TonalCoach/Profile/ProfileView.swift
+++ b/ios/TonalCoach/Profile/ProfileView.swift
@@ -4,8 +4,12 @@ import SwiftUI
 struct ProfileView: View {
     @Environment(\.healthKitManager) private var healthManager
     @Environment(\.authManager) private var authManager
+    @Environment(ConvexManager.self) private var convex
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = true
     @AppStorage("isGuestMode") private var isGuestMode = false
+
+    @State private var userInfo: UserInfo?
+    @State private var showConnectSheet = false
 
     var body: some View {
         List {
@@ -57,6 +61,22 @@ struct ProfileView: View {
                 }
             } header: {
                 Text("Account")
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            }
+
+            // MARK: - Tonal Section
+            Section {
+                if let info = userInfo, info.hasTonalProfile {
+                    if info.tonalTokenExpired {
+                        tonalExpiredRow(name: info.tonalName)
+                    } else {
+                        tonalConnectedRow(name: info.tonalName)
+                    }
+                } else {
+                    tonalConnectRow
+                }
+            } header: {
+                Text("Tonal")
                     .foregroundStyle(Theme.Colors.textTertiary)
             }
 
@@ -160,5 +180,78 @@ struct ProfileView: View {
         .background(Theme.Colors.background)
         .navigationTitle("Profile")
         .navigationBarTitleDisplayMode(.large)
+        .sheet(isPresented: $showConnectSheet) {
+            ConnectTonalView()
+        }
+        .task { await loadUser() }
+    }
+
+    // MARK: - Tonal Rows
+
+    private func tonalConnectedRow(name: String?) -> some View {
+        HStack {
+            Image(systemName: "dumbbell.fill")
+                .foregroundStyle(Theme.Colors.primary)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name ?? "Tonal")
+                    .font(Theme.Typography.body)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+                Text("Connected")
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(Theme.Colors.success)
+            }
+        }
+        .listRowBackground(Theme.Colors.card)
+    }
+
+    private func tonalExpiredRow(name: String?) -> some View {
+        HStack {
+            Image(systemName: "dumbbell.fill")
+                .foregroundStyle(Theme.Colors.warning)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name ?? "Tonal")
+                    .font(Theme.Typography.body)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+                Text("Session expired")
+                    .font(Theme.Typography.caption)
+                    .foregroundStyle(Theme.Colors.warning)
+            }
+            Spacer()
+            Button("Reconnect") {
+                showConnectSheet = true
+            }
+            .font(Theme.Typography.calloutMedium)
+            .foregroundStyle(Theme.Colors.warning)
+        }
+        .listRowBackground(Theme.Colors.card)
+    }
+
+    private var tonalConnectRow: some View {
+        Button {
+            showConnectSheet = true
+        } label: {
+            HStack {
+                Image(systemName: "dumbbell")
+                    .foregroundStyle(Theme.Colors.primary)
+                    .frame(width: 28)
+                Text("Connect Tonal")
+                    .font(Theme.Typography.body)
+                    .foregroundStyle(Theme.Colors.primary)
+            }
+        }
+        .listRowBackground(Theme.Colors.card)
+    }
+
+    // MARK: - Data Loading
+
+    private func loadUser() async {
+        do {
+            let info: UserInfo? = try await convex.query("users:getMe")
+            userInfo = info
+        } catch {
+            userInfo = nil
+        }
     }
 }

--- a/ios/TonalCoach/Tonal/AsyncCard.swift
+++ b/ios/TonalCoach/Tonal/AsyncCard.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// Reusable card wrapper that manages async loading, error, and content states.
+/// Used by each dashboard section to load data independently.
+struct AsyncCard<T, Content: View>: View {
+    let title: String
+    let load: () async throws -> T
+    @ViewBuilder let content: (T) -> Content
+
+    @State private var data: T?
+    @State private var isLoading = true
+    @State private var error: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            Text(title)
+                .font(Theme.Typography.title2)
+                .foregroundStyle(Theme.Colors.textPrimary)
+
+            if isLoading {
+                loadingView
+            } else if let error {
+                errorView(error)
+            } else if let data {
+                content(data)
+            }
+        }
+        .padding(Theme.Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.Colors.card)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.lg, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.CornerRadius.lg, style: .continuous)
+                .stroke(Theme.Colors.border, lineWidth: 1)
+        )
+        .task { await loadData() }
+    }
+
+    private func loadData() async {
+        isLoading = true
+        error = nil
+        do {
+            data = try await load()
+        } catch {
+            self.error = "Failed to load"
+        }
+        isLoading = false
+    }
+
+    func reload() async {
+        await loadData()
+    }
+
+    private var loadingView: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            ForEach(0..<3, id: \.self) { _ in
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Theme.Colors.border)
+                    .frame(height: 16)
+            }
+        }
+        .frame(minHeight: 80)
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 24))
+                .foregroundStyle(Theme.Colors.textTertiary)
+            Text(message)
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+            Button("Retry") {
+                Task { await loadData() }
+            }
+            .font(Theme.Typography.calloutMedium)
+            .foregroundStyle(Theme.Colors.primary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 80)
+    }
+}

--- a/ios/TonalCoach/Tonal/AsyncCard.swift
+++ b/ios/TonalCoach/Tonal/AsyncCard.swift
@@ -47,10 +47,6 @@ struct AsyncCard<T, Content: View>: View {
         isLoading = false
     }
 
-    func reload() async {
-        await loadData()
-    }
-
     private var loadingView: some View {
         VStack(spacing: Theme.Spacing.md) {
             ForEach(0..<3, id: \.self) { _ in

--- a/ios/TonalCoach/Tonal/ConnectTonalView.swift
+++ b/ios/TonalCoach/Tonal/ConnectTonalView.swift
@@ -1,0 +1,362 @@
+import SwiftUI
+
+// MARK: - Connect Tonal View
+
+/// Sheet-presented form for linking a user's Tonal hardware account.
+///
+/// This view collects Tonal credentials (separate from the tonal.coach account)
+/// and calls the `connectTonal` action to authenticate with the Tonal API.
+/// On success it dismisses automatically with haptic feedback.
+struct ConnectTonalView: View {
+    @Environment(ConvexManager.self) private var convex
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var errorDismissTask: Task<Void, Never>?
+
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case email
+        case password
+    }
+
+    // MARK: - Derived State
+
+    private var canSubmit: Bool {
+        !email.isEmpty && !password.isEmpty && !isLoading
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Theme.Colors.background
+                .ignoresSafeArea()
+                .onTapGesture { focusedField = nil }
+
+            dismissButton
+                .zIndex(1)
+
+            ScrollView {
+                VStack(spacing: Theme.Spacing.xl) {
+                    icon
+                    titleSection
+                    noteText
+                    formFields
+                    errorBanner
+                    connectButton
+                }
+                .padding(.horizontal, Theme.Spacing.lg)
+                .padding(.top, Theme.Spacing.xxxl)
+                .padding(.bottom, Theme.Spacing.xl)
+            }
+        }
+    }
+
+    // MARK: - Dismiss Button
+
+    private var dismissButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Theme.Colors.textSecondary)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .padding(.top, Theme.Spacing.sm)
+        .padding(.trailing, Theme.Spacing.md)
+        .accessibilityLabel("Close")
+    }
+
+    // MARK: - Icon
+
+    private var icon: some View {
+        Image(systemName: "dumbbell.fill")
+            .font(.system(size: 44))
+            .foregroundStyle(Theme.Colors.primary)
+            .accessibilityHidden(true)
+    }
+
+    // MARK: - Title Section
+
+    private var titleSection: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Text("Connect Your Tonal")
+                .font(Theme.Typography.title)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .accessibilityAddTraits(.isHeader)
+
+            Text(
+                "Sign in with your Tonal account credentials to see strength scores, muscle readiness, and workout history"
+            )
+            .font(Theme.Typography.callout)
+            .foregroundStyle(Theme.Colors.textSecondary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, Theme.Spacing.md)
+        }
+    }
+
+    // MARK: - Note Text
+
+    private var noteText: some View {
+        Text("These are your Tonal credentials, not your tonal.coach account")
+            .font(Theme.Typography.caption)
+            .foregroundStyle(Theme.Colors.textTertiary)
+            .multilineTextAlignment(.center)
+    }
+
+    // MARK: - Form Fields
+
+    private var formFields: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            emailField
+            passwordField
+        }
+    }
+
+    private var emailField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text("Email")
+                .font(Theme.Typography.calloutMedium)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            TextField("you@example.com", text: $email)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .keyboardType(.emailAddress)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textContentType(.emailAddress)
+                .submitLabel(.next)
+                .focused($focusedField, equals: .email)
+                .onSubmit { focusedField = .password }
+                .disabled(isLoading)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, Theme.Spacing.md)
+                .background(Theme.Colors.card)
+                .clipShape(
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                    .stroke(
+                        focusedField == .email
+                            ? Theme.Colors.ring
+                            : Theme.Colors.input,
+                        lineWidth: 1
+                    )
+                )
+                .accessibilityLabel("Tonal email address")
+        }
+    }
+
+    private var passwordField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text("Password")
+                .font(Theme.Typography.calloutMedium)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            SecureField("Enter your Tonal password", text: $password)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .textContentType(.password)
+                .submitLabel(.go)
+                .focused($focusedField, equals: .password)
+                .onSubmit { submitIfValid() }
+                .disabled(isLoading)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, Theme.Spacing.md)
+                .background(Theme.Colors.card)
+                .clipShape(
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                    .stroke(
+                        focusedField == .password
+                            ? Theme.Colors.ring
+                            : Theme.Colors.input,
+                        lineWidth: 1
+                    )
+                )
+                .accessibilityLabel("Tonal password")
+        }
+    }
+
+    // MARK: - Error Banner
+
+    @ViewBuilder
+    private var errorBanner: some View {
+        if let errorMessage {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 14))
+
+                Text(errorMessage)
+                    .font(Theme.Typography.callout)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Button {
+                    dismissError()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Theme.Colors.destructive.opacity(0.8))
+                        .frame(width: 28, height: 28)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityLabel("Dismiss error")
+            }
+            .foregroundStyle(Theme.Colors.destructive)
+            .padding(Theme.Spacing.md)
+            .background(Theme.Colors.destructive.opacity(0.12))
+            .clipShape(
+                RoundedRectangle(
+                    cornerRadius: Theme.CornerRadius.md,
+                    style: .continuous
+                )
+            )
+            .overlay(
+                RoundedRectangle(
+                    cornerRadius: Theme.CornerRadius.md,
+                    style: .continuous
+                )
+                .stroke(Theme.Colors.destructive.opacity(0.25), lineWidth: 1)
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isStaticText)
+            .accessibilityLabel("Error: \(errorMessage)")
+        }
+    }
+
+    // MARK: - Connect Button
+
+    private var connectButton: some View {
+        Button {
+            connect()
+        } label: {
+            Group {
+                if isLoading {
+                    ProgressView()
+                        .tint(Theme.Colors.primaryForeground)
+                } else {
+                    Text("Connect")
+                }
+            }
+            .font(Theme.Typography.calloutMedium)
+            .foregroundStyle(Theme.Colors.primaryForeground)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(
+                canSubmit
+                    ? Theme.Colors.primary
+                    : Theme.Colors.primary.opacity(0.4)
+            )
+            .clipShape(
+                RoundedRectangle(
+                    cornerRadius: Theme.CornerRadius.md,
+                    style: .continuous
+                )
+            )
+        }
+        .disabled(!canSubmit)
+        .accessibilityLabel(isLoading ? "Connecting to Tonal" : "Connect")
+    }
+
+    // MARK: - Actions
+
+    private func submitIfValid() {
+        guard canSubmit else { return }
+        connect()
+    }
+
+    private func connect() {
+        focusedField = nil
+        dismissError()
+        isLoading = true
+
+        Task {
+            do {
+                let result: ConnectTonalResult = try await convex.action(
+                    "tonal/connectPublic:connectTonal",
+                    with: ["tonalEmail": email, "tonalPassword": password]
+                )
+                isLoading = false
+                if result.success {
+                    Theme.Haptics.success()
+                    dismiss()
+                }
+            } catch {
+                isLoading = false
+                let message = mapError(error)
+                showError(message)
+            }
+        }
+    }
+
+    private func mapError(_ error: Error) -> String {
+        let description = error.localizedDescription.lowercased()
+        if description.contains("invalid") || description.contains("credentials")
+            || description.contains("unauthorized") || description.contains("401")
+            || description.contains("authentication")
+        {
+            return "Invalid email or password for your Tonal account"
+        }
+        if description.contains("network") || description.contains("timeout")
+            || description.contains("connection") || description.contains("offline")
+        {
+            return "Connection error. Check your internet and try again."
+        }
+        return "Invalid email or password for your Tonal account"
+    }
+
+    private func showError(_ message: String) {
+        withAnimation(.easeInOut(duration: 0.25)) {
+            errorMessage = message
+        }
+        Theme.Haptics.error()
+
+        errorDismissTask?.cancel()
+        errorDismissTask = Task {
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled else { return }
+            dismissError()
+        }
+    }
+
+    private func dismissError() {
+        errorDismissTask?.cancel()
+        errorDismissTask = nil
+        withAnimation(.easeInOut(duration: 0.2)) {
+            errorMessage = nil
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Connect Tonal") {
+    ConnectTonalView()
+        .environment(ConvexManager())
+        .preferredColorScheme(.dark)
+}

--- a/ios/TonalCoach/Tonal/ConnectTonalView.swift
+++ b/ios/TonalCoach/Tonal/ConnectTonalView.swift
@@ -327,7 +327,7 @@ struct ConnectTonalView: View {
         {
             return "Connection error. Check your internet and try again."
         }
-        return "Invalid email or password for your Tonal account"
+        return "Something went wrong. Please try again."
     }
 
     private func showError(_ message: String) {

--- a/ios/TonalCoach/Tonal/ExternalActivitiesCard.swift
+++ b/ios/TonalCoach/Tonal/ExternalActivitiesCard.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+/// Dashboard card listing external (non-Tonal) activities such as runs,
+/// bike rides, and other tracked workouts from connected sources.
+struct ExternalActivitiesCard: View {
+    let activities: [TonalExternalActivity]
+
+    var body: some View {
+        if activities.isEmpty {
+            emptyState
+        } else {
+            VStack(spacing: Theme.Spacing.sm) {
+                ForEach(activities.prefix(5)) { activity in
+                    ExternalActivityRow(activity: activity)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        Text("No external activities")
+            .font(Theme.Typography.callout)
+            .foregroundStyle(Theme.Colors.textTertiary)
+            .frame(maxWidth: .infinity, minHeight: 60)
+    }
+}
+
+// MARK: - Activity Row
+
+private struct ExternalActivityRow: View {
+    let activity: TonalExternalActivity
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: iconName)
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.Colors.primary)
+                .frame(width: 32, height: 32)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                HStack {
+                    Text(activity.workoutType)
+                        .font(Theme.Typography.calloutMedium)
+                        .foregroundStyle(Theme.Colors.textPrimary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Text(activity.beginTime.relativeTime)
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                }
+
+                HStack(spacing: Theme.Spacing.md) {
+                    ExternalStatLabel(text: "\(Int(activity.activeDuration / 60))min")
+
+                    if activity.activeCalories > 0 {
+                        ExternalStatLabel(text: "\(Int(activity.activeCalories))cal")
+                    }
+
+                    if activity.averageHeartRate > 0 {
+                        ExternalStatLabel(text: "\(Int(activity.averageHeartRate)) bpm")
+                    }
+
+                    Text(activity.source)
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(Theme.Colors.primary)
+                        .padding(.horizontal, Theme.Spacing.sm)
+                        .padding(.vertical, 2)
+                        .background(Theme.Colors.primary.opacity(0.15))
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: Theme.CornerRadius.sm, style: .continuous)
+                        )
+                }
+            }
+        }
+        .padding(Theme.Spacing.sm)
+        .background(Theme.Colors.muted)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.sm, style: .continuous))
+    }
+
+    private var iconName: String {
+        switch activity.workoutType.lowercased() {
+        case let t where t.contains("run"):
+            return "figure.run"
+        case let t where t.contains("cycl") || t.contains("bik"):
+            return "bicycle"
+        case let t where t.contains("swim"):
+            return "figure.pool.swim"
+        case let t where t.contains("hik"):
+            return "figure.hiking"
+        case let t where t.contains("yoga"):
+            return "figure.yoga"
+        case let t where t.contains("row"):
+            return "figure.rower"
+        case let t where t.contains("walk"):
+            return "figure.walk"
+        case let t where t.contains("elliptical"):
+            return "figure.elliptical"
+        default:
+            return "figure.strengthtraining.functional"
+        }
+    }
+}
+
+// MARK: - External Stat Label
+
+private struct ExternalStatLabel: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(Theme.Typography.caption)
+            .foregroundStyle(Theme.Colors.textSecondary)
+    }
+}

--- a/ios/TonalCoach/Tonal/MuscleReadinessCard.swift
+++ b/ios/TonalCoach/Tonal/MuscleReadinessCard.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// Dashboard card showing muscle readiness percentages in a 2-column grid.
+/// Muscles are sorted by readiness value (highest first) and color-coded
+/// green/yellow/red based on recovery status.
+struct MuscleReadinessCard: View {
+    let data: MuscleReadiness
+
+    private let columns = [
+        GridItem(.flexible(), spacing: Theme.Spacing.md),
+        GridItem(.flexible(), spacing: Theme.Spacing.md),
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: Theme.Spacing.sm) {
+            ForEach(data.sorted, id: \.name) { muscle in
+                MuscleCell(name: muscle.name, value: muscle.value)
+            }
+        }
+    }
+}
+
+// MARK: - Muscle Cell
+
+private struct MuscleCell: View {
+    let name: String
+    let value: Double
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+
+            Text(name)
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text("\(Int(value))%")
+                .font(Theme.Typography.monoText)
+                .foregroundStyle(Theme.Colors.textSecondary)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(name), \(Int(value)) percent readiness")
+    }
+
+    private var statusColor: Color {
+        if value > 80 {
+            return Theme.Colors.success
+        } else if value > 60 {
+            return Theme.Colors.warning
+        } else {
+            return Theme.Colors.error
+        }
+    }
+}

--- a/ios/TonalCoach/Tonal/RecentWorkoutsCard.swift
+++ b/ios/TonalCoach/Tonal/RecentWorkoutsCard.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// Dashboard card listing the most recent Tonal workouts (up to 5).
+/// Each row shows a colored left border keyed to the target area,
+/// the workout title, relative time, and key stats.
+struct RecentWorkoutsCard: View {
+    let workouts: [TonalActivity]
+
+    var body: some View {
+        if workouts.isEmpty {
+            emptyState
+        } else {
+            VStack(spacing: Theme.Spacing.sm) {
+                ForEach(workouts.prefix(5)) { workout in
+                    WorkoutRow(activity: workout)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        Text("No recent workouts")
+            .font(Theme.Typography.callout)
+            .foregroundStyle(Theme.Colors.textTertiary)
+            .frame(maxWidth: .infinity, minHeight: 60)
+    }
+}
+
+// MARK: - Workout Row
+
+private struct WorkoutRow: View {
+    let activity: TonalActivity
+
+    private var preview: WorkoutPreview { activity.workoutPreview }
+    private var borderColor: Color {
+        Theme.Colors.sessionTypeColor(preview.targetArea)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            RoundedRectangle(cornerRadius: 1.5)
+                .fill(borderColor)
+                .frame(width: 3)
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                HStack {
+                    Text(preview.workoutTitle)
+                        .font(Theme.Typography.calloutMedium)
+                        .foregroundStyle(Theme.Colors.textPrimary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Text(activity.activityTime.relativeTime)
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                }
+
+                HStack(spacing: Theme.Spacing.md) {
+                    Text(preview.targetArea.replacingOccurrences(of: "_", with: " ").capitalized)
+                        .sessionBadgeStyle(for: preview.targetArea)
+
+                    StatLabel(text: "\(Int(preview.totalVolume))lbs")
+                    StatLabel(text: "\(Int(preview.totalDuration / 60))min")
+
+                    if preview.totalAchievements > 0 {
+                        StatLabel(
+                            text: "\(Int(preview.totalAchievements)) PR\(preview.totalAchievements == 1 ? "" : "s")"
+                        )
+                    }
+                }
+            }
+            .padding(.leading, Theme.Spacing.md)
+        }
+        .padding(Theme.Spacing.sm)
+        .background(Theme.Colors.muted)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.sm, style: .continuous))
+    }
+}
+
+// MARK: - Stat Label
+
+private struct StatLabel: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(Theme.Typography.caption)
+            .foregroundStyle(Theme.Colors.textSecondary)
+    }
+}

--- a/ios/TonalCoach/Tonal/StrengthScoreCard.swift
+++ b/ios/TonalCoach/Tonal/StrengthScoreCard.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// Dashboard card showing overall strength score with a large ring,
+/// three smaller region rings (Upper, Lower, Core), and a percentile badge.
+struct StrengthScoreCard: View {
+    let data: StrengthData
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.xl) {
+            overallRing
+            regionRings
+            percentileBadge
+        }
+    }
+
+    // MARK: - Overall Ring
+
+    private var overallRing: some View {
+        let score = data.distribution.overallScore
+        return ScoreRing(score: score, size: 120, lineWidth: 10)
+    }
+
+    // MARK: - Region Rings
+
+    private var regionRings: some View {
+        HStack(spacing: Theme.Spacing.xl) {
+            ForEach(regionScores, id: \.label) { region in
+                VStack(spacing: Theme.Spacing.sm) {
+                    ScoreRing(score: region.score, size: 60, lineWidth: 6)
+                    Text(region.label)
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                }
+            }
+        }
+    }
+
+    private var regionScores: [(label: String, score: Double)] {
+        let current = data.scores.filter(\.current)
+        let upper = current.first { $0.strengthBodyRegion == "upper_body" }?.score ?? 0
+        let lower = current.first { $0.strengthBodyRegion == "lower_body" }?.score ?? 0
+        let core = current.first { $0.strengthBodyRegion == "core" }?.score ?? 0
+        return [
+            (label: "Upper", score: upper),
+            (label: "Lower", score: lower),
+            (label: "Core", score: core),
+        ]
+    }
+
+    // MARK: - Percentile Badge
+
+    private var percentileBadge: some View {
+        let topPercent = Int(100 - data.distribution.percentile)
+        return Text("Top \(topPercent)%")
+            .font(Theme.Typography.calloutMedium)
+            .foregroundStyle(Theme.Colors.primary)
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.xs)
+            .background(Theme.Colors.primary.opacity(0.15))
+            .clipShape(Capsule())
+    }
+}
+
+// MARK: - Score Ring
+
+/// Circular progress ring with a centered score label.
+private struct ScoreRing: View {
+    let score: Double
+    let size: CGFloat
+    let lineWidth: CGFloat
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Theme.Colors.border, lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: CGFloat(min(score / 100, 1.0)))
+                .stroke(
+                    Theme.Colors.primary,
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+
+            Text("\(Int(score))")
+                .font(size >= 100 ? Theme.Typography.title : Theme.Typography.calloutMedium)
+                .fontWeight(.bold)
+                .foregroundStyle(Theme.Colors.textPrimary)
+        }
+        .frame(width: size, height: size)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Score \(Int(score)) out of 100")
+    }
+}

--- a/ios/TonalCoach/Tonal/TonalDashboardView.swift
+++ b/ios/TonalCoach/Tonal/TonalDashboardView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Uses `AsyncCard` wrappers so sections appear as they load without blocking each other.
 struct TonalDashboardView: View {
     @Environment(ConvexManager.self) private var convex
+    @State private var refreshID = UUID()
 
     var body: some View {
         ScrollView {
@@ -51,6 +52,10 @@ struct TonalDashboardView: View {
             .padding(.horizontal, Theme.Spacing.lg)
             .padding(.vertical, Theme.Spacing.md)
         }
+        .id(refreshID)
         .background(Theme.Colors.background)
+        .refreshable {
+            refreshID = UUID()
+        }
     }
 }

--- a/ios/TonalCoach/Tonal/TonalDashboardView.swift
+++ b/ios/TonalCoach/Tonal/TonalDashboardView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Main Tonal dashboard that displays all 5 data cards, each loading independently.
+/// Uses `AsyncCard` wrappers so sections appear as they load without blocking each other.
+struct TonalDashboardView: View {
+    @Environment(ConvexManager.self) private var convex
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.lg) {
+                AsyncCard(title: "Strength Scores") { [convex] in
+                    try await convex.action(
+                        "dashboard:getStrengthData", with: [:]
+                    ) as StrengthData
+                } content: { data in
+                    StrengthScoreCard(data: data)
+                }
+
+                AsyncCard(title: "Muscle Readiness") { [convex] in
+                    try await convex.action(
+                        "dashboard:getMuscleReadiness", with: [:]
+                    ) as MuscleReadiness
+                } content: { data in
+                    MuscleReadinessCard(data: data)
+                }
+
+                AsyncCard(title: "Recent Workouts") { [convex] in
+                    try await convex.action(
+                        "dashboard:getWorkoutHistory", with: [:]
+                    ) as [TonalActivity]
+                } content: { workouts in
+                    RecentWorkoutsCard(workouts: workouts)
+                }
+
+                AsyncCard(title: "Training Frequency") { [convex] in
+                    try await convex.action(
+                        "dashboard:getTrainingFrequency", with: [:]
+                    ) as [TrainingFrequencyEntry]
+                } content: { entries in
+                    TrainingFrequencyCard(entries: entries)
+                }
+
+                AsyncCard(title: "External Activities") { [convex] in
+                    try await convex.action(
+                        "dashboard:getExternalActivities", with: [:]
+                    ) as [TonalExternalActivity]
+                } content: { activities in
+                    ExternalActivitiesCard(activities: activities)
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.vertical, Theme.Spacing.md)
+        }
+        .background(Theme.Colors.background)
+    }
+}

--- a/ios/TonalCoach/Tonal/TonalModels.swift
+++ b/ios/TonalCoach/Tonal/TonalModels.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+// MARK: - User Info (from users:getMe query)
+
+struct UserInfo: Decodable {
+    let userId: String
+    let email: String?
+    let hasTonalProfile: Bool
+    let onboardingCompleted: Bool
+    let tonalName: String?
+    let tonalEmail: String?
+    let tonalTokenExpired: Bool
+}
+
+// MARK: - Connect Result (from tonal/connectPublic:connectTonal)
+
+struct ConnectTonalResult: Decodable {
+    let success: Bool
+    let tonalUserId: String
+}
+
+// MARK: - Strength (from dashboard:getStrengthData)
+
+struct StrengthData: Decodable {
+    let scores: [StrengthScore]
+    let distribution: StrengthDistribution
+}
+
+struct StrengthScore: Decodable, Identifiable {
+    let id: String
+    let userId: String
+    let strengthBodyRegion: String
+    let bodyRegionDisplay: String
+    let score: Double
+    let current: Bool
+}
+
+struct StrengthDistribution: Decodable {
+    let userId: String
+    let overallScore: Double
+    let percentile: Double
+    let distributionPoints: [DistributionPoint]?
+}
+
+struct DistributionPoint: Decodable {
+    let score: Double
+    let yValue: Double
+}
+
+// MARK: - Muscle Readiness (from dashboard:getMuscleReadiness)
+
+struct MuscleReadiness: Decodable {
+    let Chest: Double
+    let Shoulders: Double
+    let Back: Double
+    let Triceps: Double
+    let Biceps: Double
+    let Abs: Double
+    let Obliques: Double
+    let Quads: Double
+    let Glutes: Double
+    let Hamstrings: Double
+    let Calves: Double
+
+    var sorted: [(name: String, value: Double)] {
+        [
+            ("Chest", Chest), ("Shoulders", Shoulders), ("Back", Back),
+            ("Triceps", Triceps), ("Biceps", Biceps), ("Abs", Abs),
+            ("Obliques", Obliques), ("Quads", Quads), ("Glutes", Glutes),
+            ("Hamstrings", Hamstrings), ("Calves", Calves),
+        ].sorted { $0.value > $1.value }
+    }
+}
+
+// MARK: - Workout Activity (from dashboard:getWorkoutHistory)
+
+struct TonalActivity: Decodable, Identifiable {
+    let activityId: String
+    let activityTime: String
+    let activityType: String
+    let workoutPreview: WorkoutPreview
+    var id: String { activityId }
+}
+
+struct WorkoutPreview: Decodable {
+    let workoutTitle: String
+    let targetArea: String
+    let totalDuration: Double
+    let totalVolume: Double
+    let totalAchievements: Double
+    let programName: String?
+    let coachName: String?
+    let level: String?
+}
+
+// MARK: - Training Frequency (from dashboard:getTrainingFrequency)
+
+struct TrainingFrequencyEntry: Decodable, Identifiable {
+    let targetArea: String
+    let count: Int
+    let lastTrainedDate: String
+    var id: String { targetArea }
+}
+
+// MARK: - External Activity (from dashboard:getExternalActivities)
+
+struct TonalExternalActivity: Decodable, Identifiable {
+    let id: String
+    let workoutType: String
+    let beginTime: String
+    let activeDuration: Double
+    let activeCalories: Double
+    let averageHeartRate: Double
+    let source: String
+}
+
+// MARK: - Relative Time Helper
+
+extension String {
+    /// Parses an ISO 8601 date string and returns a relative time description.
+    var relativeTime: String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: self) ?? ISO8601DateFormatter().date(from: self) else {
+            return self
+        }
+        let relative = RelativeDateTimeFormatter()
+        relative.unitsStyle = .short
+        return relative.localizedString(for: date, relativeTo: .now)
+    }
+}

--- a/ios/TonalCoach/Tonal/TrainingFrequencyCard.swift
+++ b/ios/TonalCoach/Tonal/TrainingFrequencyCard.swift
@@ -1,0 +1,75 @@
+import Charts
+import SwiftUI
+
+/// Dashboard card showing a horizontal bar chart of workouts per target area.
+/// Uses Swift Charts for native rendering with theme-aware colors.
+struct TrainingFrequencyCard: View {
+    let entries: [TrainingFrequencyEntry]
+
+    private let chartPalette: [Color] = [
+        Theme.Colors.chart1,
+        Theme.Colors.chart2,
+        Theme.Colors.chart3,
+        Theme.Colors.chart4,
+        Theme.Colors.chart5,
+    ]
+
+    var body: some View {
+        if entries.isEmpty {
+            emptyState
+        } else {
+            chart
+        }
+    }
+
+    private var chart: some View {
+        Chart(entries) { entry in
+            BarMark(
+                x: .value("Workouts", entry.count),
+                y: .value("Area", entry.targetArea.displayLabel)
+            )
+            .foregroundStyle(barColor(for: entry))
+            .cornerRadius(4)
+        }
+        .chartXAxis {
+            AxisMarks { value in
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                    .foregroundStyle(Theme.Colors.border)
+                AxisValueLabel()
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                    .font(Theme.Typography.caption)
+            }
+        }
+        .chartYAxis {
+            AxisMarks { _ in
+                AxisValueLabel()
+                    .foregroundStyle(Theme.Colors.textSecondary)
+                    .font(Theme.Typography.caption)
+            }
+        }
+        .frame(height: CGFloat(max(120, entries.count * 32)))
+    }
+
+    private func barColor(for entry: TrainingFrequencyEntry) -> Color {
+        guard let index = entries.firstIndex(where: { $0.id == entry.id }) else {
+            return chartPalette[0]
+        }
+        return chartPalette[index % chartPalette.count]
+    }
+
+    private var emptyState: some View {
+        Text("No training data yet")
+            .font(Theme.Typography.callout)
+            .foregroundStyle(Theme.Colors.textTertiary)
+            .frame(maxWidth: .infinity, minHeight: 60)
+    }
+}
+
+// MARK: - Display Label Helper
+
+private extension String {
+    /// Converts a snake_case target area key into a human-readable label.
+    var displayLabel: String {
+        replacingOccurrences(of: "_", with: " ").capitalized
+    }
+}


### PR DESCRIPTION
## Summary

- Connect Tonal account from Dashboard or Profile tab
- Full dashboard with 5 data sections matching the web app
- No backend changes - calls existing Convex actions

### New files (9)
- `Tonal/TonalModels.swift` - Decodable types for all Tonal API responses
- `Tonal/AsyncCard.swift` - Reusable loading/error/content card wrapper
- `Tonal/ConnectTonalView.swift` - Tonal credentials form (sheet)
- `Tonal/TonalDashboardView.swift` - Main dashboard orchestrating 5 parallel loads
- `Tonal/StrengthScoreCard.swift` - 4 circular progress rings + percentile
- `Tonal/MuscleReadinessCard.swift` - Color-coded 11-muscle grid
- `Tonal/RecentWorkoutsCard.swift` - Last 5 workout rows with stats
- `Tonal/TrainingFrequencyCard.swift` - Swift Charts horizontal bar chart
- `Tonal/ExternalActivitiesCard.swift` - Apple Watch / non-Tonal activities

### Modified files (2)
- `App/ContentView.swift` - Dashboard tab routes between Tonal/HealthKit based on connection
- `Profile/ProfileView.swift` - Tonal connection status + connect/reconnect button

## Test plan
- [ ] Dashboard shows "Connect Tonal" card when not connected
- [ ] Tapping Connect opens credential form sheet
- [ ] Valid Tonal credentials -> success, dashboard shows real data
- [ ] Wrong credentials -> error message
- [ ] Strength scores show 4 rings with scores
- [ ] Muscle readiness shows color-coded grid
- [ ] Recent workouts show up to 5 entries
- [ ] Training frequency chart renders bars
- [ ] Profile shows "Tonal Connected" with name
- [ ] HealthKit dashboard still visible when Tonal not connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)