### PR TITLE
feat: weekly schedule view with day cards and detail

### DIFF
--- a/docs/superpowers/specs/2026-03-24-schedule-design.md
+++ b/docs/superpowers/specs/2026-03-24-schedule-design.md
@@ -1,0 +1,142 @@
+# Schedule View - Design Spec
+
+## Overview
+
+Add weekly schedule view to the iOS app, replacing the "Coming Soon" placeholder on the Schedule tab. Shows the user's 7-day training plan with workout details, exercise lists, and completion status. Single Convex action call returns all data.
+
+## Goals
+
+- Users see their weekly training plan with session types and workout details
+- Each day shows status (programmed, completed, missed, rest)
+- Tapping a training day shows full exercise list
+- No backend changes - calls existing `schedule:getScheduleData` action
+
+## Architecture
+
+### Single API Call
+
+`schedule:getScheduleData` returns the full week with everything resolved:
+
+- 7 days (Mon-Sun) with session type, derived status, workout title
+- Exercise names and sets/reps for each day
+- No additional queries needed
+
+### Data Flow
+
+```
+ScheduleView
+  .task -> action("schedule:getScheduleData")
+  -> ScheduleData { weekStartDate, days[7] }
+  -> Render day cards
+  -> Tap training day -> push DayDetailView with ScheduleDay
+```
+
+## Components
+
+### Swift Files to Create
+
+| File                             | Purpose                                |
+| -------------------------------- | -------------------------------------- |
+| `Schedule/ScheduleModels.swift`  | Decodable types for schedule data      |
+| `Schedule/ScheduleView.swift`    | Main week view with day cards          |
+| `Schedule/ScheduleDayCard.swift` | Individual day card (training or rest) |
+| `Schedule/DayDetailView.swift`   | Full exercise list for a single day    |
+
+### Swift Files to Modify
+
+| File                    | Change                                             |
+| ----------------------- | -------------------------------------------------- |
+| `App/ContentView.swift` | Replace Schedule tab placeholder with ScheduleView |
+
+## Screen Designs
+
+### ScheduleView
+
+- NavigationStack with "Schedule" title
+- Week date range subtitle: "Mar 24 - Mar 30"
+- ScrollView with VStack of ScheduleDayCards
+- Training days: full card with session info
+- Rest days: minimal compact row
+- Pull-to-refresh reloads data
+- Loading: skeleton cards
+- Error: retry message
+
+### ScheduleDayCard (training day)
+
+- Left color bar using Theme.Colors.sessionTypeColor(sessionType)
+- Day name + date (e.g., "Monday, Mar 24")
+- Session type badge (colored capsule)
+- Status badge: completed (green checkmark), programmed (teal clock), missed (amber warning)
+- Workout title (semibold)
+- Exercise preview: first 3 exercise names, "+N more" if truncated
+- Duration pill: "30 min"
+- Tappable -> navigates to DayDetailView
+
+### ScheduleDayCard (rest day)
+
+- Minimal row: day name + "Rest Day" in muted text
+- No tap action
+- Subtle divider styling
+
+### DayDetailView
+
+- Day name + full date header
+- Session type + status badges (same as card)
+- Workout title (large)
+- Stat cards row: duration, exercise count
+- Full exercise list in VStack:
+  - Each row: exercise name + "3 x 10" sets/reps (or "3 x 30s" for duration)
+  - Numbered list (1, 2, 3...)
+- "Open in Tonal" button if tonalWorkoutId present and status is programmed
+
+## Data Types
+
+```swift
+struct ScheduleData: Decodable {
+    let weekStartDate: String
+    let days: [ScheduleDay]
+}
+
+struct ScheduleDay: Decodable, Identifiable {
+    let dayIndex: Int
+    let dayName: String
+    let date: String
+    let sessionType: String
+    let derivedStatus: String
+    let workoutTitle: String?
+    let exercises: [ScheduleExercise]?
+    let estimatedDuration: Int?
+    let tonalWorkoutId: String?
+    var id: Int { dayIndex }
+    var isRest: Bool { derivedStatus == "rest" }
+    var isTraining: Bool { !isRest }
+}
+
+struct ScheduleExercise: Decodable, Identifiable {
+    let name: String
+    let sets: Int
+    let reps: Int?
+    let duration: Int?
+    var id: String { name }
+}
+```
+
+## Status Visual Design
+
+| Status     | Icon                          | Color                     | Label       |
+| ---------- | ----------------------------- | ------------------------- | ----------- |
+| completed  | checkmark.circle.fill         | Theme.Colors.success      | "Completed" |
+| programmed | clock.fill                    | Theme.Colors.primary      | "Scheduled" |
+| missed     | exclamationmark.triangle.fill | Theme.Colors.warning      | "Missed"    |
+| failed     | xmark.circle.fill             | Theme.Colors.error        | "Failed"    |
+| rest       | moon.fill                     | Theme.Colors.textTertiary | "Rest Day"  |
+
+## Testing
+
+- Schedule tab shows current week's plan
+- Training days show session type, title, exercises
+- Rest days show minimal row
+- Tap training day -> DayDetailView with full exercise list
+- Pull-to-refresh reloads
+- Completed workouts show green checkmark
+- Works without Tonal connected (shows empty/no plan state)

--- a/ios/TonalCoach/App/ContentView.swift
+++ b/ios/TonalCoach/App/ContentView.swift
@@ -32,7 +32,7 @@ struct ContentView: View {
                 }
                 .tag(AppTab.library)
 
-            ComingSoonView(title: AppTab.schedule.rawValue, icon: AppTab.schedule.icon)
+            ScheduleView()
                 .tabItem {
                     Label(AppTab.schedule.rawValue, systemImage: AppTab.schedule.icon)
                 }

--- a/ios/TonalCoach/Schedule/DayDetailView.swift
+++ b/ios/TonalCoach/Schedule/DayDetailView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+// MARK: - Day Detail View
+
+/// Full detail screen for a training day, showing all exercises with sets/reps.
+///
+/// Pushed via `NavigationLink(value: ScheduleDay.self)` from ScheduleView.
+struct DayDetailView: View {
+    let day: ScheduleDay
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                headerSection
+                statsRow
+                divider
+                exerciseList
+
+                if let tonalId = day.tonalWorkoutId,
+                   day.derivedStatus == "programmed"
+                {
+                    openInTonalButton(tonalId)
+                }
+            }
+            .padding(Theme.Spacing.lg)
+        }
+        .background(Theme.Colors.background)
+        .navigationTitle(day.dayName)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            // Day name + full date
+            Text(fullDateString)
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            // Session type badge + status badge
+            HStack(spacing: Theme.Spacing.sm) {
+                Text(WorkoutLabels.sessionTypeLabel(day.sessionType))
+                    .sessionBadgeStyle(for: day.sessionType)
+                StatusBadgeView(status: day.derivedStatus)
+            }
+
+            // Workout title
+            if let title = day.workoutTitle {
+                Text(title)
+                    .font(Theme.Typography.title)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+            }
+        }
+    }
+
+    // MARK: - Stats Row
+
+    private var statsRow: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            if let duration = day.estimatedDuration, duration > 0 {
+                statPill(
+                    icon: "clock",
+                    text: formatDuration(duration),
+                    accessibilityLabel: "\(duration) minutes"
+                )
+            }
+
+            if let exercises = day.exercises, !exercises.isEmpty {
+                statPill(
+                    icon: "figure.strengthtraining.traditional",
+                    text: "\(exercises.count) exercises",
+                    accessibilityLabel: "\(exercises.count) exercises"
+                )
+            }
+
+            Spacer()
+        }
+    }
+
+    private func statPill(icon: String, text: String, accessibilityLabel: String) -> some View {
+        HStack(spacing: Theme.Spacing.xs) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .accessibilityHidden(true)
+            Text(text)
+                .font(Theme.Typography.calloutMedium)
+        }
+        .foregroundStyle(Theme.Colors.textSecondary)
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(Theme.Colors.muted)
+        .clipShape(Capsule())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Theme.Colors.border)
+            .frame(height: 1)
+    }
+
+    // MARK: - Exercise List
+
+    private var exerciseList: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Exercises")
+                .font(Theme.Typography.headline)
+                .foregroundStyle(Theme.Colors.textPrimary)
+
+            if let exercises = day.exercises, !exercises.isEmpty {
+                ForEach(Array(exercises.enumerated()), id: \.offset) { index, exercise in
+                    exerciseRow(index: index + 1, exercise: exercise)
+                }
+            } else {
+                Text("No exercises listed for this day.")
+                    .font(Theme.Typography.callout)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+                    .padding(.vertical, Theme.Spacing.lg)
+            }
+        }
+    }
+
+    private func exerciseRow(index: Int, exercise: ScheduleExercise) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            // Number circle
+            Text("\(index)")
+                .font(Theme.Typography.caption)
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .frame(width: 24, height: 24)
+                .background(Theme.Colors.muted)
+                .clipShape(Circle())
+
+            // Exercise name
+            Text(exercise.name)
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .lineLimit(2)
+
+            Spacer()
+
+            // Sets x reps
+            Text(exercise.volumeText)
+                .font(Theme.Typography.monoText)
+                .foregroundStyle(Theme.Colors.textSecondary)
+        }
+        .padding(.vertical, Theme.Spacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(index). \(exercise.name), \(exercise.volumeText)")
+    }
+
+    // MARK: - Open in Tonal
+
+    private func openInTonalButton(_ tonalWorkoutId: String) -> some View {
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(Theme.Colors.border)
+                .frame(height: 1)
+                .padding(.bottom, Theme.Spacing.lg)
+
+            Button {
+                let url = "https://link.tonal.com/custom-workout/\(tonalWorkoutId)"
+                TonalDeepLink.openInTonal(url: url)
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Image(systemName: "arrow.up.forward.app")
+                        .accessibilityHidden(true)
+                    Text("Open in Tonal")
+                }
+                .frame(maxWidth: .infinity)
+                .primaryButtonStyle()
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Open this workout in the Tonal app")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Converts "2026-03-24" to "Monday, March 24".
+    private var fullDateString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        guard let date = formatter.date(from: day.date) else {
+            return "\(day.dayName), \(day.date)"
+        }
+        let display = DateFormatter()
+        display.dateFormat = "EEEE, MMMM d"
+        return display.string(from: date)
+    }
+
+    /// Formats minutes into "30 min" or "1h 15m".
+    private func formatDuration(_ minutes: Int) -> String {
+        if minutes < 60 { return "\(minutes) min" }
+        let h = minutes / 60
+        let m = minutes % 60
+        return m > 0 ? "\(h)h \(m)m" : "\(h)h"
+    }
+}

--- a/ios/TonalCoach/Schedule/ScheduleDayCard.swift
+++ b/ios/TonalCoach/Schedule/ScheduleDayCard.swift
@@ -1,0 +1,235 @@
+import SwiftUI
+
+// MARK: - Schedule Day Card
+
+/// Renders a single day in the weekly schedule.
+///
+/// Two visual modes:
+/// - **Training day**: full card with left color bar, badges, exercise preview
+/// - **Rest day**: minimal muted row with moon icon
+struct ScheduleDayCard: View {
+    let day: ScheduleDay
+
+    var body: some View {
+        if day.isTraining {
+            trainingCard
+        } else {
+            restRow
+        }
+    }
+
+    // MARK: - Training Card
+
+    private var trainingCard: some View {
+        HStack(spacing: 0) {
+            // Left color bar
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Theme.Colors.sessionTypeColor(day.sessionType))
+                .frame(width: 3)
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                // Day name + date
+                HStack {
+                    Text(day.dayName)
+                        .font(Theme.Typography.headline)
+                        .foregroundStyle(Theme.Colors.textPrimary)
+                    Spacer()
+                    Text(formatDate(day.date))
+                        .font(Theme.Typography.caption)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                }
+
+                // Session type badge + status badge
+                HStack(spacing: Theme.Spacing.sm) {
+                    Text(WorkoutLabels.sessionTypeLabel(day.sessionType))
+                        .sessionBadgeStyle(for: day.sessionType)
+                    StatusBadgeView(status: day.derivedStatus)
+                    Spacer()
+                }
+
+                // Workout title
+                if let title = day.workoutTitle {
+                    Text(title)
+                        .font(Theme.Typography.calloutMedium)
+                        .foregroundStyle(Theme.Colors.textPrimary)
+                        .lineLimit(2)
+                }
+
+                // Exercise preview + duration
+                HStack {
+                    if let exercises = day.exercises, !exercises.isEmpty {
+                        exercisePreview(exercises)
+                    }
+                    Spacer()
+                    if let duration = day.estimatedDuration, duration > 0 {
+                        durationPill(duration)
+                    }
+                }
+            }
+            .padding(Theme.Spacing.md)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .cardStyle()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(trainingAccessibilityLabel)
+    }
+
+    // MARK: - Rest Row
+
+    private var restRow: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "moon.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .accessibilityHidden(true)
+
+            Text(day.dayName)
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textTertiary)
+
+            Text(formatDate(day.date))
+                .font(Theme.Typography.caption)
+                .foregroundStyle(Theme.Colors.textTertiary.opacity(0.6))
+
+            Spacer()
+
+            Text("Rest Day")
+                .font(Theme.Typography.caption)
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .italic()
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.vertical, Theme.Spacing.md)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(day.dayName), \(formatDate(day.date)), Rest day")
+    }
+
+    // MARK: - Exercise Preview
+
+    /// Shows first 3 exercise names with "+N more" if truncated.
+    private func exercisePreview(_ exercises: [ScheduleExercise]) -> some View {
+        let names = exercises.prefix(3).map(\.name)
+        let remaining = exercises.count - names.count
+
+        return HStack(spacing: 0) {
+            Text(names.joined(separator: ", "))
+                .lineLimit(1)
+            if remaining > 0 {
+                Text(" +\(remaining) more")
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            }
+        }
+        .font(Theme.Typography.caption)
+        .foregroundStyle(Theme.Colors.textSecondary)
+    }
+
+    // MARK: - Duration Pill
+
+    private func durationPill(_ minutes: Int) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: "clock")
+                .font(.system(size: 10))
+                .accessibilityHidden(true)
+            Text(formatDuration(minutes))
+        }
+        .font(Theme.Typography.caption)
+        .foregroundStyle(Theme.Colors.textSecondary)
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, 3)
+        .background(Theme.Colors.muted)
+        .clipShape(Capsule())
+        .accessibilityLabel("\(minutes) minutes")
+    }
+
+    // MARK: - Accessibility
+
+    private var trainingAccessibilityLabel: String {
+        var parts = [day.dayName, formatDate(day.date)]
+        parts.append(WorkoutLabels.sessionTypeLabel(day.sessionType))
+        parts.append(StatusBadgeView.statusLabel(day.derivedStatus))
+        if let title = day.workoutTitle {
+            parts.append(title)
+        }
+        if let duration = day.estimatedDuration, duration > 0 {
+            parts.append("\(duration) minutes")
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: - Helpers
+
+    /// Converts "2026-03-24" to "Mar 24".
+    private func formatDate(_ isoDate: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        guard let date = formatter.date(from: isoDate) else { return isoDate }
+        let display = DateFormatter()
+        display.dateFormat = "MMM d"
+        return display.string(from: date)
+    }
+
+    /// Formats minutes into "30 min" or "1h 15m".
+    private func formatDuration(_ minutes: Int) -> String {
+        if minutes < 60 { return "\(minutes) min" }
+        let h = minutes / 60
+        let m = minutes % 60
+        return m > 0 ? "\(h)h \(m)m" : "\(h)h"
+    }
+}
+
+// MARK: - Status Badge View
+
+/// Inline badge showing workout status with icon and colored text.
+///
+/// Uses icon + text + color (never color alone) for accessibility.
+struct StatusBadgeView: View {
+    let status: String
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: iconName)
+                .font(.system(size: 10))
+                .accessibilityHidden(true)
+            Text(StatusBadgeView.statusLabel(status))
+        }
+        .font(Theme.Typography.caption)
+        .foregroundStyle(statusColor)
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, 2)
+        .background(statusColor.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.sm, style: .continuous))
+    }
+
+    /// Human-readable label for a status value.
+    static func statusLabel(_ status: String) -> String {
+        switch status {
+        case "completed":  return "Completed"
+        case "programmed": return "Scheduled"
+        case "missed":     return "Missed"
+        case "failed":     return "Failed"
+        case "rest":       return "Rest Day"
+        default:           return status.capitalized
+        }
+    }
+
+    private var iconName: String {
+        switch status {
+        case "completed":  return "checkmark.circle.fill"
+        case "programmed": return "clock.fill"
+        case "missed":     return "exclamationmark.triangle.fill"
+        case "failed":     return "xmark.circle.fill"
+        default:           return "circle"
+        }
+    }
+
+    private var statusColor: Color {
+        switch status {
+        case "completed":  return Theme.Colors.success
+        case "programmed": return Theme.Colors.primary
+        case "missed":     return Theme.Colors.warning
+        case "failed":     return Theme.Colors.error
+        default:           return Theme.Colors.textTertiary
+        }
+    }
+}

--- a/ios/TonalCoach/Schedule/ScheduleModels.swift
+++ b/ios/TonalCoach/Schedule/ScheduleModels.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+// MARK: - Schedule Data
+
+/// Top-level response from `schedule:getScheduleData` action.
+struct ScheduleData: Decodable {
+    let weekStartDate: String
+    let days: [ScheduleDay]
+}
+
+// MARK: - Schedule Day
+
+/// A single day in the weekly schedule (Mon-Sun).
+///
+/// `dayIndex` is 0-6 (Monday-Sunday). `derivedStatus` values:
+/// completed, programmed, missed, failed, rest.
+struct ScheduleDay: Decodable, Identifiable, Hashable {
+    let dayIndex: Int
+    let dayName: String
+    let date: String
+    let sessionType: String
+    let derivedStatus: String
+    let workoutTitle: String?
+    let exercises: [ScheduleExercise]?
+    let estimatedDuration: Int?
+    let tonalWorkoutId: String?
+
+    var id: Int { dayIndex }
+    var isRest: Bool { derivedStatus == "rest" }
+    var isTraining: Bool { !isRest }
+
+    // MARK: Hashable (for NavigationLink value-based navigation)
+
+    static func == (lhs: ScheduleDay, rhs: ScheduleDay) -> Bool {
+        lhs.dayIndex == rhs.dayIndex
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(dayIndex)
+    }
+}
+
+// MARK: - Schedule Exercise
+
+/// An exercise within a scheduled day's workout.
+struct ScheduleExercise: Decodable, Identifiable {
+    let name: String
+    let sets: Int
+    let reps: Int?
+    let duration: Int?
+
+    var id: String { name }
+
+    /// Human-readable volume text: "3 x 10" or "3 x 30s".
+    var volumeText: String {
+        if let reps {
+            return "\(sets) x \(reps)"
+        } else if let duration {
+            return "\(sets) x \(duration)s"
+        }
+        return "\(sets) sets"
+    }
+}

--- a/ios/TonalCoach/Schedule/ScheduleModels.swift
+++ b/ios/TonalCoach/Schedule/ScheduleModels.swift
@@ -32,11 +32,12 @@ struct ScheduleDay: Decodable, Identifiable, Hashable {
     // MARK: Hashable (for NavigationLink value-based navigation)
 
     static func == (lhs: ScheduleDay, rhs: ScheduleDay) -> Bool {
-        lhs.dayIndex == rhs.dayIndex
+        lhs.dayIndex == rhs.dayIndex && lhs.date == rhs.date
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(dayIndex)
+        hasher.combine(date)
     }
 }
 
@@ -47,16 +48,12 @@ struct ScheduleExercise: Decodable, Identifiable {
     let name: String
     let sets: Int
     let reps: Int?
-    let duration: Int?
 
-    var id: String { name }
+    var id: String { "\(name)-\(sets)-\(reps ?? 0)" }
 
-    /// Human-readable volume text: "3 x 10" or "3 x 30s".
     var volumeText: String {
         if let reps {
             return "\(sets) x \(reps)"
-        } else if let duration {
-            return "\(sets) x \(duration)s"
         }
         return "\(sets) sets"
     }

--- a/ios/TonalCoach/Schedule/ScheduleView.swift
+++ b/ios/TonalCoach/Schedule/ScheduleView.swift
@@ -1,0 +1,250 @@
+import SwiftUI
+
+// MARK: - Schedule View
+
+/// Weekly schedule screen showing the user's 7-day training plan.
+///
+/// Loads data via a single `schedule:getScheduleData` action call.
+/// Training days are tappable cards; rest days are minimal rows.
+struct ScheduleView: View {
+    @Environment(ConvexManager.self) private var convex
+    @State private var viewModel = ScheduleViewModel()
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.Colors.background
+                    .ignoresSafeArea()
+
+                Group {
+                    if viewModel.isLoading {
+                        loadingView
+                    } else if let error = viewModel.errorMessage {
+                        errorView(error)
+                    } else if viewModel.hasTrainingDays {
+                        dayListView
+                    } else {
+                        emptyStateView
+                    }
+                }
+            }
+            .navigationTitle("Schedule")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    if let subtitle = viewModel.weekSubtitle {
+                        Text(subtitle)
+                            .font(Theme.Typography.caption)
+                            .foregroundStyle(Theme.Colors.textSecondary)
+                    }
+                }
+            }
+            .refreshable {
+                await viewModel.load(using: convex)
+            }
+            .navigationDestination(for: ScheduleDay.self) { day in
+                DayDetailView(day: day)
+            }
+            .task {
+                await viewModel.loadIfNeeded(using: convex)
+            }
+        }
+    }
+
+    // MARK: - Day List
+
+    private var dayListView: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.md) {
+                if let subtitle = viewModel.weekSubtitle {
+                    Text(subtitle)
+                        .font(Theme.Typography.callout)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, Theme.Spacing.lg)
+                }
+
+                ForEach(viewModel.days) { day in
+                    if day.isTraining {
+                        NavigationLink(value: day) {
+                            ScheduleDayCard(day: day)
+                        }
+                        .buttonStyle(CardButtonStyle())
+                    } else {
+                        ScheduleDayCard(day: day)
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.lg)
+            }
+            .padding(.vertical, Theme.Spacing.md)
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingView: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.md) {
+                ForEach(0..<3, id: \.self) { _ in
+                    ScheduleDayCardSkeleton()
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.vertical, Theme.Spacing.md)
+        }
+    }
+
+    // MARK: - Error
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 32))
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .accessibilityHidden(true)
+
+            Text("Unable to load schedule")
+                .font(Theme.Typography.headline)
+                .foregroundStyle(Theme.Colors.textPrimary)
+
+            Text(message)
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 280)
+
+            Button {
+                Task { await viewModel.load(using: convex) }
+            } label: {
+                Text("Try Again")
+                    .primaryButtonStyle()
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "calendar")
+                .font(.system(size: 32))
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .accessibilityHidden(true)
+
+            Text("No schedule this week")
+                .font(Theme.Typography.headline)
+                .foregroundStyle(Theme.Colors.textPrimary)
+
+            Text("Your weekly training plan will appear here once your coach generates one.")
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 280)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Skeleton Card
+
+/// Placeholder card shown during initial load, matching the shape of ScheduleDayCard.
+private struct ScheduleDayCardSkeleton: View {
+    var body: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Theme.Colors.border)
+                .frame(width: 3, height: 60)
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Theme.Colors.border)
+                    .frame(width: 80, height: 14)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Theme.Colors.border)
+                    .frame(width: 140, height: 12)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Theme.Colors.border)
+                    .frame(width: 200, height: 12)
+            }
+            Spacer()
+        }
+        .padding(Theme.Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .cardStyle()
+        .cardShimmer()
+    }
+}
+
+// MARK: - View Model
+
+/// Manages data loading for the schedule screen.
+///
+/// Uses async/await with `ConvexManager.action()` (matching TonalDashboardView pattern).
+/// The action returns all data in one shot, no pagination needed.
+@Observable
+final class ScheduleViewModel {
+    var days: [ScheduleDay] = []
+    var weekStartDate: String?
+    var isLoading = false
+    var errorMessage: String?
+
+    private var hasLoaded = false
+
+    /// Whether any training days exist in the loaded schedule.
+    var hasTrainingDays: Bool {
+        days.contains { $0.isTraining }
+    }
+
+    /// Formatted week subtitle: "Mar 24 - Mar 30".
+    var weekSubtitle: String? {
+        guard let startStr = weekStartDate else { return nil }
+        return formatWeekRange(from: startStr)
+    }
+
+    // MARK: - Load
+
+    func loadIfNeeded(using manager: ConvexManager) async {
+        guard !hasLoaded, !isLoading else { return }
+        await load(using: manager)
+    }
+
+    @MainActor
+    func load(using manager: ConvexManager) async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let data: ScheduleData = try await manager.action(
+                "schedule:getScheduleData", with: [:]
+            )
+            days = data.days
+            weekStartDate = data.weekStartDate
+            hasLoaded = true
+            errorMessage = nil
+        } catch {
+            errorMessage = "Could not load schedule. Check your connection and try again."
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Date Formatting
+
+    /// Converts "2026-03-24" to "Mar 24 - Mar 30" (7-day range).
+    private func formatWeekRange(from isoDate: String) -> String? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+
+        guard let start = formatter.date(from: isoDate) else { return nil }
+        guard let end = Calendar.current.date(byAdding: .day, value: 6, to: start) else {
+            return nil
+        }
+
+        let display = DateFormatter()
+        display.dateFormat = "MMM d"
+        return "\(display.string(from: start)) - \(display.string(from: end))"
+    }
+}


### PR DESCRIPTION
## Summary

- Weekly schedule view replacing the "Coming Soon" placeholder
- Shows 7-day training plan with session types, workout titles, exercises, and completion status
- Tap training days for full exercise list detail view
- Single `schedule:getScheduleData` Convex action call, no backend changes

### New files (4)
- `Schedule/ScheduleModels.swift` - Decodable types (ScheduleData, ScheduleDay, ScheduleExercise)
- `Schedule/ScheduleView.swift` - Main week view with loading/error/empty states
- `Schedule/ScheduleDayCard.swift` - Training day card + rest day row
- `Schedule/DayDetailView.swift` - Full exercise list with "Open in Tonal" button

### Modified (1)
- `App/ContentView.swift` - Schedule tab now shows ScheduleView

## Test plan
- [ ] Schedule tab shows current week's training plan
- [ ] Training days show session type badge, workout title, exercise preview
- [ ] Rest days show minimal "Rest Day" row
- [ ] Tap training day -> DayDetailView with full exercise list
- [ ] Status badges: completed (green), scheduled (teal), missed (amber)
- [ ] Pull-to-refresh reloads schedule data
- [ ] Empty state when no schedule exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)