### PR TITLE
fix: handle null schedule response for users without a week plan

### DIFF
--- a/ios/TonalCoach/Schedule/ScheduleView.swift
+++ b/ios/TonalCoach/Schedule/ScheduleView.swift
@@ -216,11 +216,11 @@ final class ScheduleViewModel {
         errorMessage = nil
 
         do {
-            let data: ScheduleData = try await manager.action(
+            let data: ScheduleData? = try await manager.action(
                 "schedule:getScheduleData", with: [:]
             )
-            days = data.days
-            weekStartDate = data.weekStartDate
+            days = data?.days ?? []
+            weekStartDate = data?.weekStartDate ?? ""
             hasLoaded = true
             errorMessage = nil
         } catch {


### PR DESCRIPTION
The `schedule:getScheduleData` action returns `null` when no week plan exists (user hasn't completed onboarding or no plan has been generated). The Swift code decoded this as non-optional `ScheduleData`, causing a JSON decode error that showed as "Unable to load schedule."

Now decodes as `ScheduleData?` and falls back to the empty state ("No schedule this week").

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>