### PR TITLE
feat: AI Coach Chat with streaming, tool approvals, and image uploads

### DIFF
--- a/docs/superpowers/specs/2026-03-24-ios-chat-design.md
+++ b/docs/superpowers/specs/2026-03-24-ios-chat-design.md
@@ -1,0 +1,239 @@
+# AI Coach Chat - iOS Design Spec
+
+## Overview
+
+Add the AI Coach chat interface to the iOS app, replacing the Chat tab placeholder. Users converse with the AI coach, which can analyze their training data, program workouts, manage goals/injuries, and push workouts to Tonal. Messages stream in real-time via Convex subscriptions.
+
+## Goals
+
+- Real-time chat with streaming AI responses
+- Tool call approval UI (workout pushes, week programming)
+- Image upload support (progress photos)
+- Markdown rendering for coach responses
+- Week plan card rendering inline in chat
+- Continuous conversation history across threads
+- Same backend - no new Convex functions needed
+
+## Architecture
+
+### No Backend Changes
+
+The iOS app calls the same mutations/queries/actions as the web:
+
+| Function                      | Type     | Purpose                               |
+| ----------------------------- | -------- | ------------------------------------- |
+| `threads:getCurrentThread`    | query    | Get active thread (subscription)      |
+| `chat:sendMessageMutation`    | mutation | Send user message (text + images)     |
+| `chat:generateImageUploadUrl` | mutation | Get signed upload URL for images      |
+| `chat:listMessages`           | query    | Paginated message list with streaming |
+| `chat:respondToToolApproval`  | mutation | Approve/deny tool execution           |
+| `chat:continueAfterApproval`  | action   | Resume agent after approval           |
+
+### Message Format
+
+Messages use `@convex-dev/agent`'s UIMessage format with parts:
+
+- `text` - plain text content
+- `file` - image with URL and mediaType
+- `dynamic-tool` - tool call with state (input-streaming, approval-requested, output-available, etc.)
+
+### Streaming
+
+Messages stream via Convex subscription to `chat:listMessages`. The `@convex-dev/agent` saves stream deltas (word-level, 100ms throttle) which the subscription picks up in real-time.
+
+## Components
+
+### Swift Files to Create
+
+| File                           | Purpose                                           |
+| ------------------------------ | ------------------------------------------------- |
+| `Chat/ChatModels.swift`        | Decodable types for messages, threads, tool calls |
+| `Chat/ChatView.swift`          | Main chat screen with message list + input        |
+| `Chat/ChatViewModel.swift`     | @Observable managing messages, sending, streaming |
+| `Chat/MessageBubble.swift`     | User/coach message bubbles with markdown          |
+| `Chat/ChatInput.swift`         | Text input with image attachment + send button    |
+| `Chat/ToolApprovalCard.swift`  | Approve/deny card for tool calls                  |
+| `Chat/ToolCallChip.swift`      | Status chip for tool execution                    |
+| `Chat/ThinkingIndicator.swift` | Animated dots while coach is thinking             |
+| `Chat/MarkdownText.swift`      | Markdown renderer for coach responses             |
+
+### Swift Files to Modify
+
+| File                    | Change                                     |
+| ----------------------- | ------------------------------------------ |
+| `App/ContentView.swift` | Replace Chat tab placeholder with ChatView |
+
+## Screen Design
+
+### ChatView (main screen)
+
+- NavigationStack with "Coach" title
+- Message list: ScrollView with LazyVStack
+- Messages grouped by date (dividers between days)
+- Auto-scroll to bottom on new messages
+- Pull up to load earlier messages
+
+**Message types rendered:**
+
+- User bubble (right-aligned, primary color background)
+- Coach bubble (left-aligned, card background, with avatar)
+- Tool approval card (inline, with Approve/Deny buttons)
+- Tool call chips (small status indicators)
+- Thinking indicator (animated dots)
+
+### ChatInput (bottom bar)
+
+- TextField with placeholder "Message your coach..."
+- Image attachment button (paperclip icon)
+- Send button (arrow.up.circle.fill, disabled when empty)
+- Image preview row (thumbnails with remove X)
+- Max 4 images, 10MB each
+- Keyboard-aware padding
+
+### MessageBubble
+
+**User messages (right-aligned):**
+
+- Primary color background, rounded corners
+- Text in primary foreground
+- Images displayed as thumbnails (tappable for full-screen)
+- Timestamp above first message in group
+
+**Coach messages (left-aligned):**
+
+- Card background, rounded corners
+- Sparkle icon avatar
+- Markdown-rendered text (headings, lists, bold, code, tables)
+- Streaming: text appears word-by-word with cursor indicator
+- Week plan blocks rendered as inline cards (if detected)
+
+### ToolApprovalCard
+
+- Card with descriptive label (e.g., "Push workouts to your Tonal")
+- Two buttons: Approve (green checkmark) and Deny (red X)
+- States: pending -> processing -> done
+- On approve: calls `respondToToolApproval` then `continueAfterApproval`
+- On deny: calls `respondToToolApproval` with approved=false
+
+### ThinkingIndicator
+
+- Coach avatar + "Coach" label
+- Three pulsing dots with staggered animation
+- Shown when waiting for first response after sending
+
+## Data Types
+
+```swift
+// Thread
+struct ChatThread: Decodable {
+    let _id: String
+    let userId: String?
+}
+
+// UIMessage from @convex-dev/agent
+struct ChatMessage: Decodable, Identifiable {
+    let key: String
+    let _creationTime: Double
+    let order: Double?
+    let stepOrder: Double?
+    let status: String?  // "pending", "streaming", "final"
+    let role: String     // "user", "assistant"
+    let text: String?
+    let parts: [MessagePart]?
+    var id: String { key }
+    var isUser: Bool { role == "user" }
+    var isAssistant: Bool { role == "assistant" }
+    var isStreaming: Bool { status == "streaming" }
+}
+
+// Message parts (polymorphic)
+struct MessagePart: Decodable {
+    let type: String  // "text", "file", "dynamic-tool"
+    // Text
+    let text: String?
+    // File
+    let url: String?
+    let mediaType: String?
+    let filename: String?
+    // Tool
+    let toolCallId: String?
+    let toolName: String?
+    let input: AnyCodable?
+    let state: String?  // "input-streaming", "approval-requested", "output-available", etc.
+    let approval: ToolApproval?
+}
+
+struct ToolApproval: Decodable {
+    let id: String
+    let approved: Bool?
+}
+
+// Paginated message response
+struct MessageListResponse: Decodable {
+    let page: [ChatMessage]
+    let isDone: Bool
+    let continueCursor: String?
+}
+```
+
+## Key Interactions
+
+### Sending a Message
+
+1. User types text, optionally attaches images
+2. For each image: call `generateImageUploadUrl`, upload to returned URL, collect storage IDs
+3. Call `sendMessageMutation` with text, threadId, imageStorageIds
+4. Show optimistic user bubble immediately
+5. Show thinking indicator
+6. Subscribe to message stream - coach response appears word-by-word
+
+### Tool Approval
+
+1. Coach response includes a `dynamic-tool` part with `state: "approval-requested"`
+2. Render ToolApprovalCard inline
+3. User taps Approve/Deny
+4. Call `respondToToolApproval` mutation
+5. Call `continueAfterApproval` action
+6. Agent continues execution, new message streams in
+
+### Image Upload
+
+1. User taps attachment button
+2. PHPickerViewController for image selection (max 4)
+3. Client-side validation (size, format)
+4. Show thumbnails in preview row
+5. On send: upload all -> collect storage IDs -> include in mutation
+
+## Error Handling
+
+| Scenario           | Handling                                      |
+| ------------------ | --------------------------------------------- |
+| Rate limit (burst) | Show "Slow down" error, disable input briefly |
+| Rate limit (daily) | Show "Daily limit reached" with count         |
+| Network error      | Show retry button on failed message           |
+| Image too large    | Show "Image must be under 10MB"               |
+| Too many images    | Show "Maximum 4 images per message"           |
+| Streaming error    | Show error in coach bubble with retry         |
+
+## Markdown Rendering
+
+Use AttributedString for basic markdown (bold, italic, lists, headings, code, links). For v1, support:
+
+- **Bold** and _italic_
+- Headings (# ## ###)
+- Bullet and numbered lists
+- Inline `code` and code blocks
+- Links (tappable, open in Safari)
+
+Tables and complex markdown can render as plain text in v1.
+
+## Testing
+
+- Send text message -> coach responds with streaming
+- Send image -> appears in bubble, coach acknowledges
+- Tool approval -> approve -> agent continues
+- Tool approval -> deny -> agent acknowledges denial
+- Thinking indicator shows while waiting
+- Auto-scroll to bottom on new messages
+- Switch tabs and back -> messages persist
+- Kill app, relaunch -> conversation history loads

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,13 +1,15 @@
-# Xcode
-*.xcodeproj/
-!*.xcodeproj/project.pbxproj
-!*.xcodeproj/xcshareddata/
-*.xcworkspace/
-!*.xcworkspace/contents.xcworkspacedata
-!*.xcworkspace/xcshareddata/
+# Xcode user data
 xcuserdata/
 *.xccheckout
 *.xcscmblueprint
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
 
 # Build
 build/
@@ -19,9 +21,8 @@ DerivedData/
 # Swift Package Manager
 .build/
 .swiftpm/
-Package.resolved
 
-# CocoaPods (not used, but just in case)
+# CocoaPods
 Pods/
 
 # Fastlane
@@ -36,14 +37,3 @@ iOSInjectionProject/
 # Misc
 *.hmap
 *.moved-aside
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-
-# Generated Xcode project (regenerated via xcodegen)
-TonalCoach.xcodeproj/

--- a/ios/TonalCoach.xcodeproj/project.pbxproj
+++ b/ios/TonalCoach.xcodeproj/project.pbxproj
@@ -1,0 +1,653 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0050DFE0AB4310D4392E8BAD /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA42FD4599C5013850591B /* ChatViewModel.swift */; };
+		014658B7C371AB8BC8FEFA4F /* HealthKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3ECCA7218453986DC46FE3 /* HealthKitManager.swift */; };
+		027E4B892D6B4D73D106535E /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE38C8177CDD4487B4DF6F3 /* KeychainHelper.swift */; };
+		02C6AE86E0A5049514C0BD15 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA6E804A7A741F57B6077E9 /* NotificationDelegate.swift */; };
+		06ACBA3BE13DE7B09F9BD4A6 /* TonalDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998344A11A738B6D7F8AC725 /* TonalDashboardView.swift */; };
+		084B400E6EBE58218C786A4E /* ExternalActivitiesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4572CB37A53DA8BBDDF982 /* ExternalActivitiesCard.swift */; };
+		157388BF966DD54EB48000C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4702C26F8C2C224E144F379C /* ContentView.swift */; };
+		16DA28B597192FE4302CF41A /* TonalDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7B058508882C8DA068C32A /* TonalDeepLink.swift */; };
+		1D17B014F694E6A55C7975E3 /* WorkoutFiltersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D6E147E28AD90E816EF993 /* WorkoutFiltersView.swift */; };
+		1F69D85F0F93AB34FD84C89F /* ResetPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE6475D29CECCEDAC0653EA /* ResetPasswordView.swift */; };
+		20793F8A10949B7240A93963 /* ConnectTonalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263DBEE6AFD50C23CD03E67B /* ConnectTonalView.swift */; };
+		21B90923519D89F563710CBD /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE03FBD05A69014939259C3D /* NotificationSettingsView.swift */; };
+		24BCD3FA70FFE988BF3F36B1 /* ConvexMobile in Frameworks */ = {isa = PBXBuildFile; productRef = B4999B86DD39093EBC062F7D /* ConvexMobile */; };
+		327D4184BD201D767EA906A7 /* StrengthScoreCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7328578675A8F3B615846E43 /* StrengthScoreCard.swift */; };
+		3C43C100345389B3ED170B71 /* PasswordAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB629C1B92F2380B18896233 /* PasswordAuthProvider.swift */; };
+		42BEFE7F07591913ED3B8DA0 /* TrainingFrequencyCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A968A442D233648FA16136BF /* TrainingFrequencyCard.swift */; };
+		45013F1AD272E00E3B29EE9A /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4460B6F5D6ECAB5000D077 /* Theme.swift */; };
+		58593C18825560C6F1760A54 /* ThinkingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F48901D6FC6CA9CFDE14C8 /* ThinkingIndicator.swift */; };
+		5C6880B24F7858B6CFC80B4F /* DMSans-Italic-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8321CA4BD27236034163DE70 /* DMSans-Italic-Variable.ttf */; };
+		5CA7B64CBAE1BF7129C0C9EE /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7486A4B75AF5EE7EB0A043 /* Models.swift */; };
+		6A2D0E0116B05F642E0B2609 /* RecentWorkoutsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6198211493BA5A2186362734 /* RecentWorkoutsCard.swift */; };
+		6C7D859F15594D4DF99D12CD /* DMSans-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 80BD257ADF30EC5730CEA29B /* DMSans-Variable.ttf */; };
+		6EA6E76039A7A1F2F21743C5 /* MuscleReadinessCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F74557E7EABC857AC75A6D /* MuscleReadinessCard.swift */; };
+		736E927A144EBEFB1DFFCB25 /* GeistMono-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E411ECDAAA0F827C3296CC5E /* GeistMono-Variable.ttf */; };
+		7F35CF1AE3D415AAD177D9F1 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4E85E4BCB6785EFB82E7BA /* ChatView.swift */; };
+		7F7792192E65DDD4CD8BD776 /* ChatInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F14CF7C37C679739B9844FE /* ChatInputBar.swift */; };
+		81C3CD4D0DFFDD2CE38D5709 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2311B4105E72BB6B11A97 /* NotificationManager.swift */; };
+		867DF588806D7C0A04D5DDC8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCD2578D91FB3B551BAB790 /* OnboardingView.swift */; };
+		9D801E18724B5959F9780CCB /* TonalCoachApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD4014FB66E4D01C1BF563 /* TonalCoachApp.swift */; };
+		A180D2267F45D4EEE14A52BE /* AsyncCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0F2CA7084518AA231D668C /* AsyncCard.swift */; };
+		A2220BC2C12BB5F24E646C90 /* NotificationPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672CD4A9E189DFA838AA6E62 /* NotificationPermissionView.swift */; };
+		A255A48EA8912657C87AB312 /* WorkoutDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73160B64985BC10A30B0D220 /* WorkoutDetailView.swift */; };
+		A55E36E31571F4267AE2FD00 /* HealthPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D330194F50C144F6BA7C8BB1 /* HealthPermissionView.swift */; };
+		AB04CE09C9B6CF076C62B51C /* ConvexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7355A2969D916D85BC65E9AF /* ConvexManager.swift */; };
+		B16886E2BCB9CA386D6C694E /* DayDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060DC542CFA2F111BF034A25 /* DayDetailView.swift */; };
+		B28FDFEC19F76F878630B018 /* ToolApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B15FA3B7A50423A11C10318 /* ToolApprovalCard.swift */; };
+		B306D9A4350E316F0199F37E /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2D7EB5E260FA3DB9FC5F9 /* LoginView.swift */; };
+		BA93EA39F519BF35C654B5FB /* ScheduleDayCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DB605D1270553152731F1B /* ScheduleDayCard.swift */; };
+		C3A21FFB22CEAF5650584D91 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5104B6101FB951CE50BD1CA /* ProfileView.swift */; };
+		C73C20B5427061040052FD8F /* HealthDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CC410DF7DC8875908F1D45 /* HealthDashboardView.swift */; };
+		D29C91F4BDC6346C0FC65B84 /* ChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0788CC33759688FF4ED6239 /* ChatModels.swift */; };
+		D8A2C98185E1428310C81C34 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 549248671EC5F4CFA5B8ED68 /* HealthKit.framework */; };
+		DB9815B3009CB457E20E0BD2 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4336D243540557F7FD94EFEE /* MessageBubble.swift */; };
+		DE60307AB01F06852935A97F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 757D4EAE09E4618432610A41 /* Assets.xcassets */; };
+		DF7142365C1B6E5170EDDA63 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B95E8720EB1B2578A1B92E /* AuthManager.swift */; };
+		DFA4928A094ADC84B922B68D /* ToolCallChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = E348442ED2A315C10B73F250 /* ToolCallChip.swift */; };
+		E2A755589CA29DC1C4ECBC81 /* ScheduleModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C89295B1569D8B220000BC /* ScheduleModels.swift */; };
+		ED21BA22192AB410A33C1619 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1527475BBBF38809CF28E56E /* ScheduleView.swift */; };
+		F13FD79B53AB9432B6A6E286 /* LibraryHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB955CD4C7D0F3EB4EA7D93 /* LibraryHomeView.swift */; };
+		F5BEBB0864DAA99976946463 /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51510A5E87E4621AB14BFE79 /* MarkdownText.swift */; };
+		FB0B9D8AD5210ABEFD77FC79 /* TonalModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043752E84535B7A45A93EFE6 /* TonalModels.swift */; };
+		FD6D5CD51F2316868B127C64 /* WorkoutCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C7E1B42E65EB4DF0ADA6B4 /* WorkoutCardView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		03CC410DF7DC8875908F1D45 /* HealthDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthDashboardView.swift; sourceTree = "<group>"; };
+		043752E84535B7A45A93EFE6 /* TonalModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TonalModels.swift; sourceTree = "<group>"; };
+		060DC542CFA2F111BF034A25 /* DayDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayDetailView.swift; sourceTree = "<group>"; };
+		12B3B26921CB3B7086A8E0CC /* TonalCoach.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = TonalCoach.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1527475BBBF38809CF28E56E /* ScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
+		1F14CF7C37C679739B9844FE /* ChatInputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInputBar.swift; sourceTree = "<group>"; };
+		1FCD2578D91FB3B551BAB790 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		23FA42FD4599C5013850591B /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		24C89295B1569D8B220000BC /* ScheduleModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleModels.swift; sourceTree = "<group>"; };
+		263DBEE6AFD50C23CD03E67B /* ConnectTonalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectTonalView.swift; sourceTree = "<group>"; };
+		2D4460B6F5D6ECAB5000D077 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		3B15FA3B7A50423A11C10318 /* ToolApprovalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolApprovalCard.swift; sourceTree = "<group>"; };
+		3EE6475D29CECCEDAC0653EA /* ResetPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordView.swift; sourceTree = "<group>"; };
+		3FB955CD4C7D0F3EB4EA7D93 /* LibraryHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryHomeView.swift; sourceTree = "<group>"; };
+		41DB605D1270553152731F1B /* ScheduleDayCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDayCard.swift; sourceTree = "<group>"; };
+		4336D243540557F7FD94EFEE /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
+		4702C26F8C2C224E144F379C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		51510A5E87E4621AB14BFE79 /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
+		51B95E8720EB1B2578A1B92E /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		549248671EC5F4CFA5B8ED68 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = HealthKit.framework; sourceTree = "<group>"; };
+		5CA6E804A7A741F57B6077E9 /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
+		6198211493BA5A2186362734 /* RecentWorkoutsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentWorkoutsCard.swift; sourceTree = "<group>"; };
+		672CD4A9E189DFA838AA6E62 /* NotificationPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionView.swift; sourceTree = "<group>"; };
+		68F48901D6FC6CA9CFDE14C8 /* ThinkingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingIndicator.swift; sourceTree = "<group>"; };
+		73160B64985BC10A30B0D220 /* WorkoutDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutDetailView.swift; sourceTree = "<group>"; };
+		7328578675A8F3B615846E43 /* StrengthScoreCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrengthScoreCard.swift; sourceTree = "<group>"; };
+		7355A2969D916D85BC65E9AF /* ConvexManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvexManager.swift; sourceTree = "<group>"; };
+		757D4EAE09E4618432610A41 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		7A0F2CA7084518AA231D668C /* AsyncCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncCard.swift; sourceTree = "<group>"; };
+		7DE38C8177CDD4487B4DF6F3 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
+		80BD257ADF30EC5730CEA29B /* DMSans-Variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "DMSans-Variable.ttf"; sourceTree = "<group>"; };
+		8321CA4BD27236034163DE70 /* DMSans-Italic-Variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "DMSans-Italic-Variable.ttf"; sourceTree = "<group>"; };
+		83F74557E7EABC857AC75A6D /* MuscleReadinessCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleReadinessCard.swift; sourceTree = "<group>"; };
+		88B2D7EB5E260FA3DB9FC5F9 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		8A4A08A3512144A4D62AA6BB /* TonalCoach.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TonalCoach.entitlements; sourceTree = "<group>"; };
+		8C7486A4B75AF5EE7EB0A043 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		998344A11A738B6D7F8AC725 /* TonalDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TonalDashboardView.swift; sourceTree = "<group>"; };
+		A1B2311B4105E72BB6B11A97 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		A5104B6101FB951CE50BD1CA /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		A968A442D233648FA16136BF /* TrainingFrequencyCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingFrequencyCard.swift; sourceTree = "<group>"; };
+		AA4572CB37A53DA8BBDDF982 /* ExternalActivitiesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalActivitiesCard.swift; sourceTree = "<group>"; };
+		B319CDBC8A0F05CF9054C28D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		CA3ECCA7218453986DC46FE3 /* HealthKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitManager.swift; sourceTree = "<group>"; };
+		CB629C1B92F2380B18896233 /* PasswordAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordAuthProvider.swift; sourceTree = "<group>"; };
+		D330194F50C144F6BA7C8BB1 /* HealthPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthPermissionView.swift; sourceTree = "<group>"; };
+		D5D6E147E28AD90E816EF993 /* WorkoutFiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutFiltersView.swift; sourceTree = "<group>"; };
+		DB4E85E4BCB6785EFB82E7BA /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
+		DC7B058508882C8DA068C32A /* TonalDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TonalDeepLink.swift; sourceTree = "<group>"; };
+		DE03FBD05A69014939259C3D /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
+		E348442ED2A315C10B73F250 /* ToolCallChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallChip.swift; sourceTree = "<group>"; };
+		E411ECDAAA0F827C3296CC5E /* GeistMono-Variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "GeistMono-Variable.ttf"; sourceTree = "<group>"; };
+		EEFD4014FB66E4D01C1BF563 /* TonalCoachApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TonalCoachApp.swift; sourceTree = "<group>"; };
+		F0788CC33759688FF4ED6239 /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
+		F5C7E1B42E65EB4DF0ADA6B4 /* WorkoutCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutCardView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		355ECBED7A498582447C74C8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24BCD3FA70FFE988BF3F36B1 /* ConvexMobile in Frameworks */,
+				D8A2C98185E1428310C81C34 /* HealthKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		07208951617A4E2B15B33FEF /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				8321CA4BD27236034163DE70 /* DMSans-Italic-Variable.ttf */,
+				80BD257ADF30EC5730CEA29B /* DMSans-Variable.ttf */,
+				E411ECDAAA0F827C3296CC5E /* GeistMono-Variable.ttf */,
+			);
+			path = Fonts;
+			sourceTree = "<group>";
+		};
+		1F8E7501B2739A356DF8AE6B /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				A5104B6101FB951CE50BD1CA /* ProfileView.swift */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		24BF8E136B2B0308BE1BC78A = {
+			isa = PBXGroup;
+			children = (
+				755C373BDFA460684694B81A /* TonalCoach */,
+				D2C1157A9BA5E3D02373FB37 /* Frameworks */,
+				B66AEF271E21044285FC38B5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		30725B035DDB4404FBBAEB40 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				07208951617A4E2B15B33FEF /* Fonts */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		40CED15238AB1FEB867073BC /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				1F14CF7C37C679739B9844FE /* ChatInputBar.swift */,
+				F0788CC33759688FF4ED6239 /* ChatModels.swift */,
+				DB4E85E4BCB6785EFB82E7BA /* ChatView.swift */,
+				23FA42FD4599C5013850591B /* ChatViewModel.swift */,
+				51510A5E87E4621AB14BFE79 /* MarkdownText.swift */,
+				4336D243540557F7FD94EFEE /* MessageBubble.swift */,
+				68F48901D6FC6CA9CFDE14C8 /* ThinkingIndicator.swift */,
+				3B15FA3B7A50423A11C10318 /* ToolApprovalCard.swift */,
+				E348442ED2A315C10B73F250 /* ToolCallChip.swift */,
+			);
+			path = Chat;
+			sourceTree = "<group>";
+		};
+		51BEA3798F63ED876E1178AC /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				7355A2969D916D85BC65E9AF /* ConvexManager.swift */,
+				8C7486A4B75AF5EE7EB0A043 /* Models.swift */,
+				2D4460B6F5D6ECAB5000D077 /* Theme.swift */,
+				DC7B058508882C8DA068C32A /* TonalDeepLink.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		755C373BDFA460684694B81A /* TonalCoach */ = {
+			isa = PBXGroup;
+			children = (
+				757D4EAE09E4618432610A41 /* Assets.xcassets */,
+				B319CDBC8A0F05CF9054C28D /* Info.plist */,
+				8A4A08A3512144A4D62AA6BB /* TonalCoach.entitlements */,
+				F17AD975381C9B5F61584858 /* App */,
+				8ED376AAEFA2BC6033B5FBB7 /* Auth */,
+				40CED15238AB1FEB867073BC /* Chat */,
+				ED1687A7A45A32E295C43240 /* Health */,
+				FC8AB388B417908817753115 /* Library */,
+				9B62DDE2042C414A12A4CDBB /* Notifications */,
+				1F8E7501B2739A356DF8AE6B /* Profile */,
+				30725B035DDB4404FBBAEB40 /* Resources */,
+				F1C0ABA49EB98D378BBC1E34 /* Schedule */,
+				51BEA3798F63ED876E1178AC /* Shared */,
+				B8DAF86ABB90B98ECFAA5143 /* Tonal */,
+			);
+			path = TonalCoach;
+			sourceTree = "<group>";
+		};
+		8ED376AAEFA2BC6033B5FBB7 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				51B95E8720EB1B2578A1B92E /* AuthManager.swift */,
+				7DE38C8177CDD4487B4DF6F3 /* KeychainHelper.swift */,
+				88B2D7EB5E260FA3DB9FC5F9 /* LoginView.swift */,
+				CB629C1B92F2380B18896233 /* PasswordAuthProvider.swift */,
+				3EE6475D29CECCEDAC0653EA /* ResetPasswordView.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		9B62DDE2042C414A12A4CDBB /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				5CA6E804A7A741F57B6077E9 /* NotificationDelegate.swift */,
+				A1B2311B4105E72BB6B11A97 /* NotificationManager.swift */,
+				672CD4A9E189DFA838AA6E62 /* NotificationPermissionView.swift */,
+				DE03FBD05A69014939259C3D /* NotificationSettingsView.swift */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
+		B66AEF271E21044285FC38B5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				12B3B26921CB3B7086A8E0CC /* TonalCoach.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B8DAF86ABB90B98ECFAA5143 /* Tonal */ = {
+			isa = PBXGroup;
+			children = (
+				7A0F2CA7084518AA231D668C /* AsyncCard.swift */,
+				263DBEE6AFD50C23CD03E67B /* ConnectTonalView.swift */,
+				AA4572CB37A53DA8BBDDF982 /* ExternalActivitiesCard.swift */,
+				83F74557E7EABC857AC75A6D /* MuscleReadinessCard.swift */,
+				6198211493BA5A2186362734 /* RecentWorkoutsCard.swift */,
+				7328578675A8F3B615846E43 /* StrengthScoreCard.swift */,
+				998344A11A738B6D7F8AC725 /* TonalDashboardView.swift */,
+				043752E84535B7A45A93EFE6 /* TonalModels.swift */,
+				A968A442D233648FA16136BF /* TrainingFrequencyCard.swift */,
+			);
+			path = Tonal;
+			sourceTree = "<group>";
+		};
+		D2C1157A9BA5E3D02373FB37 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				549248671EC5F4CFA5B8ED68 /* HealthKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		ED1687A7A45A32E295C43240 /* Health */ = {
+			isa = PBXGroup;
+			children = (
+				03CC410DF7DC8875908F1D45 /* HealthDashboardView.swift */,
+				CA3ECCA7218453986DC46FE3 /* HealthKitManager.swift */,
+				D330194F50C144F6BA7C8BB1 /* HealthPermissionView.swift */,
+			);
+			path = Health;
+			sourceTree = "<group>";
+		};
+		F17AD975381C9B5F61584858 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				4702C26F8C2C224E144F379C /* ContentView.swift */,
+				1FCD2578D91FB3B551BAB790 /* OnboardingView.swift */,
+				EEFD4014FB66E4D01C1BF563 /* TonalCoachApp.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		F1C0ABA49EB98D378BBC1E34 /* Schedule */ = {
+			isa = PBXGroup;
+			children = (
+				060DC542CFA2F111BF034A25 /* DayDetailView.swift */,
+				41DB605D1270553152731F1B /* ScheduleDayCard.swift */,
+				24C89295B1569D8B220000BC /* ScheduleModels.swift */,
+				1527475BBBF38809CF28E56E /* ScheduleView.swift */,
+			);
+			path = Schedule;
+			sourceTree = "<group>";
+		};
+		FC8AB388B417908817753115 /* Library */ = {
+			isa = PBXGroup;
+			children = (
+				3FB955CD4C7D0F3EB4EA7D93 /* LibraryHomeView.swift */,
+				F5C7E1B42E65EB4DF0ADA6B4 /* WorkoutCardView.swift */,
+				73160B64985BC10A30B0D220 /* WorkoutDetailView.swift */,
+				D5D6E147E28AD90E816EF993 /* WorkoutFiltersView.swift */,
+			);
+			path = Library;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1D82C9D600BC4556741688F6 /* TonalCoach */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 55D4E77B04BE4C0003511B69 /* Build configuration list for PBXNativeTarget "TonalCoach" */;
+			buildPhases = (
+				78E0CF410871C6E37359D3C5 /* Sources */,
+				66CADCC72FA6D3BD55E34B62 /* Resources */,
+				355ECBED7A498582447C74C8 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TonalCoach;
+			packageProductDependencies = (
+				B4999B86DD39093EBC062F7D /* ConvexMobile */,
+			);
+			productName = TonalCoach;
+			productReference = 12B3B26921CB3B7086A8E0CC /* TonalCoach.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B408C389D23B195868258B83 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 9627E7AA46A01D1107E05391 /* Build configuration list for PBXProject "TonalCoach" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 24BF8E136B2B0308BE1BC78A;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				0D2E0A338957B18BFB8477CB /* XCRemoteSwiftPackageReference "convex-swift" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = B66AEF271E21044285FC38B5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1D82C9D600BC4556741688F6 /* TonalCoach */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		66CADCC72FA6D3BD55E34B62 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE60307AB01F06852935A97F /* Assets.xcassets in Resources */,
+				5C6880B24F7858B6CFC80B4F /* DMSans-Italic-Variable.ttf in Resources */,
+				6C7D859F15594D4DF99D12CD /* DMSans-Variable.ttf in Resources */,
+				736E927A144EBEFB1DFFCB25 /* GeistMono-Variable.ttf in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		78E0CF410871C6E37359D3C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A180D2267F45D4EEE14A52BE /* AsyncCard.swift in Sources */,
+				DF7142365C1B6E5170EDDA63 /* AuthManager.swift in Sources */,
+				7F7792192E65DDD4CD8BD776 /* ChatInputBar.swift in Sources */,
+				D29C91F4BDC6346C0FC65B84 /* ChatModels.swift in Sources */,
+				7F35CF1AE3D415AAD177D9F1 /* ChatView.swift in Sources */,
+				0050DFE0AB4310D4392E8BAD /* ChatViewModel.swift in Sources */,
+				20793F8A10949B7240A93963 /* ConnectTonalView.swift in Sources */,
+				157388BF966DD54EB48000C0 /* ContentView.swift in Sources */,
+				AB04CE09C9B6CF076C62B51C /* ConvexManager.swift in Sources */,
+				B16886E2BCB9CA386D6C694E /* DayDetailView.swift in Sources */,
+				084B400E6EBE58218C786A4E /* ExternalActivitiesCard.swift in Sources */,
+				C73C20B5427061040052FD8F /* HealthDashboardView.swift in Sources */,
+				014658B7C371AB8BC8FEFA4F /* HealthKitManager.swift in Sources */,
+				A55E36E31571F4267AE2FD00 /* HealthPermissionView.swift in Sources */,
+				027E4B892D6B4D73D106535E /* KeychainHelper.swift in Sources */,
+				F13FD79B53AB9432B6A6E286 /* LibraryHomeView.swift in Sources */,
+				B306D9A4350E316F0199F37E /* LoginView.swift in Sources */,
+				F5BEBB0864DAA99976946463 /* MarkdownText.swift in Sources */,
+				DB9815B3009CB457E20E0BD2 /* MessageBubble.swift in Sources */,
+				5CA7B64CBAE1BF7129C0C9EE /* Models.swift in Sources */,
+				6EA6E76039A7A1F2F21743C5 /* MuscleReadinessCard.swift in Sources */,
+				02C6AE86E0A5049514C0BD15 /* NotificationDelegate.swift in Sources */,
+				81C3CD4D0DFFDD2CE38D5709 /* NotificationManager.swift in Sources */,
+				A2220BC2C12BB5F24E646C90 /* NotificationPermissionView.swift in Sources */,
+				21B90923519D89F563710CBD /* NotificationSettingsView.swift in Sources */,
+				867DF588806D7C0A04D5DDC8 /* OnboardingView.swift in Sources */,
+				3C43C100345389B3ED170B71 /* PasswordAuthProvider.swift in Sources */,
+				C3A21FFB22CEAF5650584D91 /* ProfileView.swift in Sources */,
+				6A2D0E0116B05F642E0B2609 /* RecentWorkoutsCard.swift in Sources */,
+				1F69D85F0F93AB34FD84C89F /* ResetPasswordView.swift in Sources */,
+				BA93EA39F519BF35C654B5FB /* ScheduleDayCard.swift in Sources */,
+				E2A755589CA29DC1C4ECBC81 /* ScheduleModels.swift in Sources */,
+				ED21BA22192AB410A33C1619 /* ScheduleView.swift in Sources */,
+				327D4184BD201D767EA906A7 /* StrengthScoreCard.swift in Sources */,
+				45013F1AD272E00E3B29EE9A /* Theme.swift in Sources */,
+				58593C18825560C6F1760A54 /* ThinkingIndicator.swift in Sources */,
+				9D801E18724B5959F9780CCB /* TonalCoachApp.swift in Sources */,
+				06ACBA3BE13DE7B09F9BD4A6 /* TonalDashboardView.swift in Sources */,
+				16DA28B597192FE4302CF41A /* TonalDeepLink.swift in Sources */,
+				FB0B9D8AD5210ABEFD77FC79 /* TonalModels.swift in Sources */,
+				B28FDFEC19F76F878630B018 /* ToolApprovalCard.swift in Sources */,
+				DFA4928A094ADC84B922B68D /* ToolCallChip.swift in Sources */,
+				42BEFE7F07591913ED3B8DA0 /* TrainingFrequencyCard.swift in Sources */,
+				FD6D5CD51F2316868B127C64 /* WorkoutCardView.swift in Sources */,
+				A255A48EA8912657C87AB312 /* WorkoutDetailView.swift in Sources */,
+				1D17B014F694E6A55C7975E3 /* WorkoutFiltersView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		07D1C4102C59EA5DA9D1BCCE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.9;
+			};
+			name = Debug;
+		};
+		16DE484215E2BC0F25D34881 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.9;
+			};
+			name = Release;
+		};
+		7D32C937036A5029EA547F7F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TonalCoach/TonalCoach.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CONVEX_URL = "https://quaint-bulldog-653.convex.cloud";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\".\"",
+				);
+				INFOPLIST_FILE = TonalCoach/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = coach.tonal.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		DAE150A507675C2B011AC159 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TonalCoach/TonalCoach.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CONVEX_URL = "https://quaint-bulldog-653.convex.cloud";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\".\"",
+				);
+				INFOPLIST_FILE = TonalCoach/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = coach.tonal.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		55D4E77B04BE4C0003511B69 /* Build configuration list for PBXNativeTarget "TonalCoach" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAE150A507675C2B011AC159 /* Debug */,
+				7D32C937036A5029EA547F7F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		9627E7AA46A01D1107E05391 /* Build configuration list for PBXProject "TonalCoach" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				07D1C4102C59EA5DA9D1BCCE /* Debug */,
+				16DE484215E2BC0F25D34881 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		0D2E0A338957B18BFB8477CB /* XCRemoteSwiftPackageReference "convex-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/get-convex/convex-swift.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B4999B86DD39093EBC062F7D /* ConvexMobile */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0D2E0A338957B18BFB8477CB /* XCRemoteSwiftPackageReference "convex-swift" */;
+			productName = ConvexMobile;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = B408C389D23B195868258B83 /* Project object */;
+}

--- a/ios/TonalCoach.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/TonalCoach.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/TonalCoach.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TonalCoach.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "8b33edde3ec8e1197003fa0ec54eef4332606b2f1f9a413d8c22ba8040e84cb1",
+  "pins" : [
+    {
+      "identity" : "convex-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/get-convex/convex-swift.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "125b71b2f8725931a5b0e8252f0799ef2adad120"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/TonalCoach.xcodeproj/xcshareddata/xcschemes/TonalCoach.xcscheme
+++ b/ios/TonalCoach.xcodeproj/xcshareddata/xcschemes/TonalCoach.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1D82C9D600BC4556741688F6"
+               BuildableName = "TonalCoach.app"
+               BlueprintName = "TonalCoach"
+               ReferencedContainer = "container:TonalCoach.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D82C9D600BC4556741688F6"
+            BuildableName = "TonalCoach.app"
+            BlueprintName = "TonalCoach"
+            ReferencedContainer = "container:TonalCoach.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D82C9D600BC4556741688F6"
+            BuildableName = "TonalCoach.app"
+            BlueprintName = "TonalCoach"
+            ReferencedContainer = "container:TonalCoach.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D82C9D600BC4556741688F6"
+            BuildableName = "TonalCoach.app"
+            BlueprintName = "TonalCoach"
+            ReferencedContainer = "container:TonalCoach.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/TonalCoach/App/ContentView.swift
+++ b/ios/TonalCoach/App/ContentView.swift
@@ -48,7 +48,7 @@ struct ContentView: View {
             }
             .tag(AppTab.dashboard)
 
-            ComingSoonView(title: AppTab.chat.rawValue, icon: AppTab.chat.icon)
+            ChatView()
                 .tabItem {
                     Label(AppTab.chat.rawValue, systemImage: AppTab.chat.icon)
                 }

--- a/ios/TonalCoach/App/ContentView.swift
+++ b/ios/TonalCoach/App/ContentView.swift
@@ -22,15 +22,15 @@ enum AppTab: String, CaseIterable {
 
 /// Root view with tab-based navigation.
 struct ContentView: View {
-    @State private var selectedTab: AppTab = .library
+    @State private var selectedTab: AppTab = .chat
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            LibraryHomeView()
+            ChatView()
                 .tabItem {
-                    Label(AppTab.library.rawValue, systemImage: AppTab.library.icon)
+                    Label(AppTab.chat.rawValue, systemImage: AppTab.chat.icon)
                 }
-                .tag(AppTab.library)
+                .tag(AppTab.chat)
 
             ScheduleView()
                 .tabItem {
@@ -48,11 +48,11 @@ struct ContentView: View {
             }
             .tag(AppTab.dashboard)
 
-            ChatView()
+            LibraryHomeView()
                 .tabItem {
-                    Label(AppTab.chat.rawValue, systemImage: AppTab.chat.icon)
+                    Label(AppTab.library.rawValue, systemImage: AppTab.library.icon)
                 }
-                .tag(AppTab.chat)
+                .tag(AppTab.library)
 
             NavigationStack {
                 ProfileView()

--- a/ios/TonalCoach/Chat/ChatInputBar.swift
+++ b/ios/TonalCoach/Chat/ChatInputBar.swift
@@ -39,7 +39,7 @@ struct ChatInputBar: View {
                 }
 
                 // Input row
-                HStack(alignment: .bottom, spacing: Theme.Spacing.sm) {
+                HStack(alignment: .bottom, spacing: 4) {
                     // Attachment button
                     PhotosPicker(
                         selection: $selectedPhotos,
@@ -54,7 +54,7 @@ struct ChatInputBar: View {
                                     ? Theme.Colors.textTertiary
                                     : Theme.Colors.textSecondary
                             )
-                            .frame(width: 44, height: 44)
+                            .frame(width: 36, height: 36)
                             .contentShape(Rectangle())
                     }
                     .disabled(viewModel.isSending || viewModel.pendingImages.count >= 4)
@@ -65,7 +65,7 @@ struct ChatInputBar: View {
                             : "Opens photo picker"
                     )
 
-                    // Text field
+                    // Text field with background
                     TextField("Message your coach...", text: $text, axis: .vertical)
                         .font(Theme.Typography.body)
                         .foregroundStyle(Theme.Colors.textPrimary)
@@ -74,6 +74,14 @@ struct ChatInputBar: View {
                         .disabled(viewModel.isSending)
                         .submitLabel(.send)
                         .onSubmit { send() }
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .padding(.vertical, Theme.Spacing.sm)
+                        .background(Theme.Colors.background)
+                        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                .stroke(Theme.Colors.border, lineWidth: 1)
+                        )
                         .accessibilityLabel("Message input")
 
                     // Send button
@@ -85,7 +93,7 @@ struct ChatInputBar: View {
                                     .tint(Theme.Colors.primary)
                             } else {
                                 Image(systemName: "arrow.up.circle.fill")
-                                    .font(.system(size: 28))
+                                    .font(.system(size: 30))
                                     .foregroundStyle(
                                         canSend
                                             ? Theme.Colors.primary
@@ -93,7 +101,7 @@ struct ChatInputBar: View {
                                     )
                             }
                         }
-                        .frame(width: 44, height: 44)
+                        .frame(width: 36, height: 36)
                         .contentShape(Rectangle())
                     }
                     .disabled(!canSend)
@@ -104,10 +112,11 @@ struct ChatInputBar: View {
                     )
                 }
             }
-            .padding(.horizontal, Theme.Spacing.md)
-            .padding(.vertical, Theme.Spacing.sm)
-            .background(Theme.Colors.card)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.top, Theme.Spacing.sm)
+            .padding(.bottom, Theme.Spacing.xs)
         }
+        .background(Theme.Colors.card)
         .onChange(of: selectedPhotos) { _, newItems in
             handlePhotoSelection(newItems)
         }

--- a/ios/TonalCoach/Chat/ChatInputBar.swift
+++ b/ios/TonalCoach/Chat/ChatInputBar.swift
@@ -1,0 +1,205 @@
+import PhotosUI
+import SwiftUI
+
+// MARK: - Chat Input Bar
+
+/// Bottom input bar for composing and sending messages to the coach.
+///
+/// Features:
+/// - Multiline text field (up to 5 lines)
+/// - Image attachment via PhotosPicker (max 4 images)
+/// - Image preview row with remove buttons
+/// - Send button with loading state
+/// - Keyboard-aware via SwiftUI safe area
+struct ChatInputBar: View {
+    let viewModel: ChatViewModel
+    @Environment(\.convexManager) private var convex
+
+    @State private var text = ""
+    @State private var selectedPhotos: [PhotosPickerItem] = []
+    @FocusState private var isTextFieldFocused: Bool
+
+    private var canSend: Bool {
+        let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasImages = !viewModel.pendingImages.isEmpty
+        return (hasText || hasImages) && !viewModel.isSending
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Top border
+            Rectangle()
+                .fill(Theme.Colors.border)
+                .frame(height: 0.5)
+
+            VStack(spacing: Theme.Spacing.sm) {
+                // Image preview row
+                if !viewModel.pendingImages.isEmpty {
+                    imagePreviewRow
+                }
+
+                // Input row
+                HStack(alignment: .bottom, spacing: Theme.Spacing.sm) {
+                    // Attachment button
+                    PhotosPicker(
+                        selection: $selectedPhotos,
+                        maxSelectionCount: 4 - viewModel.pendingImages.count,
+                        matching: .images,
+                        photoLibrary: .shared()
+                    ) {
+                        Image(systemName: "paperclip")
+                            .font(.system(size: 18))
+                            .foregroundStyle(
+                                viewModel.pendingImages.count >= 4
+                                    ? Theme.Colors.textTertiary
+                                    : Theme.Colors.textSecondary
+                            )
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .disabled(viewModel.isSending || viewModel.pendingImages.count >= 4)
+                    .accessibilityLabel("Attach images")
+                    .accessibilityHint(
+                        viewModel.pendingImages.count >= 4
+                            ? "Maximum 4 images reached"
+                            : "Opens photo picker"
+                    )
+
+                    // Text field
+                    TextField("Message your coach...", text: $text, axis: .vertical)
+                        .font(Theme.Typography.body)
+                        .foregroundStyle(Theme.Colors.textPrimary)
+                        .lineLimit(1...5)
+                        .focused($isTextFieldFocused)
+                        .disabled(viewModel.isSending)
+                        .submitLabel(.send)
+                        .onSubmit { send() }
+                        .accessibilityLabel("Message input")
+
+                    // Send button
+                    Button(action: send) {
+                        Group {
+                            if viewModel.isSending || viewModel.isUploadingImages {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .tint(Theme.Colors.primary)
+                            } else {
+                                Image(systemName: "arrow.up.circle.fill")
+                                    .font(.system(size: 28))
+                                    .foregroundStyle(
+                                        canSend
+                                            ? Theme.Colors.primary
+                                            : Theme.Colors.textTertiary
+                                    )
+                            }
+                        }
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                    }
+                    .disabled(!canSend)
+                    .accessibilityLabel(
+                        viewModel.isSending
+                            ? "Sending message"
+                            : "Send message"
+                    )
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .background(Theme.Colors.card)
+        }
+        .onChange(of: selectedPhotos) { _, newItems in
+            handlePhotoSelection(newItems)
+        }
+    }
+
+    // MARK: - Image Preview Row
+
+    private var imagePreviewRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.Spacing.sm) {
+                ForEach(
+                    Array(viewModel.pendingImages.enumerated()),
+                    id: \.element.id
+                ) { index, pending in
+                    ZStack(alignment: .topTrailing) {
+                        Image(uiImage: pending.preview)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 64, height: 64)
+                            .clipShape(
+                                RoundedRectangle(
+                                    cornerRadius: Theme.CornerRadius.md,
+                                    style: .continuous
+                                )
+                            )
+
+                        // Remove button
+                        Button {
+                            withAnimation(.easeOut(duration: 0.15)) {
+                                viewModel.removeImage(at: index)
+                            }
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 18))
+                                .foregroundStyle(Theme.Colors.textPrimary)
+                                .background(
+                                    Circle()
+                                        .fill(Theme.Colors.background)
+                                        .frame(width: 16, height: 16)
+                                )
+                        }
+                        .offset(x: 4, y: -4)
+                        .accessibilityLabel("Remove image \(index + 1)")
+                    }
+                }
+
+                // Upload indicator
+                if viewModel.isUploadingImages {
+                    RoundedRectangle(
+                        cornerRadius: Theme.CornerRadius.md,
+                        style: .continuous
+                    )
+                    .fill(Theme.Colors.muted)
+                    .frame(width: 64, height: 64)
+                    .overlay(
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(Theme.Colors.textTertiary)
+                    )
+                    .accessibilityLabel("Uploading images")
+                }
+            }
+            .padding(.top, Theme.Spacing.xs)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func send() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard canSend else { return }
+
+        Theme.Haptics.light()
+        text = ""
+        isTextFieldFocused = false
+
+        Task {
+            await viewModel.send(text: trimmed, using: convex)
+        }
+    }
+
+    private func handlePhotoSelection(_ items: [PhotosPickerItem]) {
+        guard !items.isEmpty else { return }
+
+        Task {
+            for item in items {
+                if let data = try? await item.loadTransferable(type: Data.self) {
+                    viewModel.addImage(data)
+                }
+            }
+            // Reset selection so the same photos can be re-selected
+            selectedPhotos = []
+        }
+    }
+}

--- a/ios/TonalCoach/Chat/ChatModels.swift
+++ b/ios/TonalCoach/Chat/ChatModels.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+// MARK: - Thread
+
+/// Active thread response from `threads:getCurrentThread`.
+/// Returns nil when no active thread exists for the user.
+struct ChatThread: Decodable {
+    let threadId: String
+    let lastMessageTime: Double
+}
+
+// MARK: - Message
+
+/// UIMessage format from @convex-dev/agent.
+/// Messages have a `parts` array that can contain text, files, and tool calls.
+struct ChatMessage: Decodable, Identifiable {
+    let key: String
+    let _creationTime: Double
+    let order: Double?
+    let stepOrder: Double?
+    let status: String? // "pending", "streaming", "final"
+    let role: String // "user", "assistant"
+    let text: String?
+    let parts: [MessagePart]?
+
+    var id: String { key }
+    var isUser: Bool { role == "user" }
+    var isAssistant: Bool { role == "assistant" }
+    var isStreaming: Bool { status == "streaming" }
+
+    /// Extract all text from parts, falling back to top-level text.
+    var displayText: String {
+        if let parts, !parts.isEmpty {
+            let textParts = parts.compactMap { $0.type == "text" ? $0.text : nil }
+            if !textParts.isEmpty {
+                return textParts.joined()
+            }
+        }
+        return text ?? ""
+    }
+
+    /// Extract image URLs from file parts.
+    var imageUrls: [String] {
+        parts?.compactMap { $0.type == "file" ? $0.url : nil } ?? []
+    }
+
+    /// Extract tool call parts.
+    var toolCalls: [MessagePart] {
+        parts?.filter { $0.type == "dynamic-tool" } ?? []
+    }
+
+    /// Whether this message has any visible content (text or images).
+    var hasContent: Bool {
+        !displayText.isEmpty || !imageUrls.isEmpty || !toolCalls.isEmpty
+    }
+
+    /// Creation date for grouping.
+    var creationDate: Date {
+        Date(timeIntervalSince1970: _creationTime / 1000)
+    }
+
+    /// Sort key: prefer order (assigned by agent), fall back to creation time.
+    var sortKey: Double {
+        order ?? _creationTime
+    }
+}
+
+// MARK: - Message Part
+
+/// Polymorphic message part -- can be text, file, or tool call.
+/// Uses optional properties since the shape varies by type.
+struct MessagePart: Decodable, Identifiable {
+    let type: String // "text", "file", "dynamic-tool"
+
+    // Text part
+    let text: String?
+
+    // File part
+    let url: String?
+    let mediaType: String?
+    let filename: String?
+
+    // Tool part
+    let toolCallId: String?
+    let toolName: String?
+    let state: String?
+    // "input-streaming", "input-available", "output-available",
+    // "approval-requested", "approval-responded", "output-denied"
+    let approval: ToolApproval?
+
+    var id: String {
+        toolCallId ?? url ?? text ?? UUID().uuidString
+    }
+
+    var isApprovalRequested: Bool {
+        type == "dynamic-tool" && state == "approval-requested"
+    }
+
+    var isApprovalResponded: Bool {
+        type == "dynamic-tool" && state == "approval-responded"
+    }
+
+    var isToolRunning: Bool {
+        type == "dynamic-tool" && (state == "input-streaming" || state == "input-available")
+    }
+
+    var isToolDone: Bool {
+        type == "dynamic-tool" && state == "output-available"
+    }
+
+    /// Human-readable label for a tool call.
+    var toolLabel: String {
+        switch toolName {
+        case "create_workout": return "Creating workout"
+        case "program_week": return "Programming your week"
+        case "approve_week_plan": return "Push workouts to Tonal"
+        case "delete_workout": return "Delete workout"
+        case "delete_week_plan": return "Delete week plan"
+        case "search_exercises": return "Searching exercises"
+        case "get_strength_scores": return "Checking strength scores"
+        case "get_muscle_readiness": return "Checking muscle readiness"
+        case "get_workout_history": return "Reviewing workout history"
+        case "get_workout_detail": return "Analyzing workout"
+        case "get_training_frequency": return "Checking training frequency"
+        case "get_strength_history": return "Loading strength history"
+        case "estimate_duration": return "Estimating duration"
+        case "record_feedback": return "Recording feedback"
+        case "set_goal": return "Setting goal"
+        case "report_injury": return "Recording injury"
+        case "resolve_injury": return "Resolving injury"
+        case "get_goals": return "Checking goals"
+        case "get_injuries": return "Checking injuries"
+        case "swap_exercise": return "Swapping exercise"
+        case "add_exercise": return "Adding exercise"
+        case "move_session": return "Moving session"
+        default: return toolName ?? "Processing"
+        }
+    }
+}
+
+// MARK: - Tool Approval
+
+struct ToolApproval: Decodable {
+    let id: String
+    let approved: Bool?
+}
+
+// MARK: - Send Message Result
+
+/// Response from `chat:sendMessage` action (handles thread creation)
+/// and `chat:sendMessageMutation` mutation.
+struct SendMessageResult: Decodable {
+    let threadId: String
+}
+
+// MARK: - Create Thread Result
+
+/// Response from `chat:createThread` mutation.
+struct CreateThreadResult: Decodable {
+    let threadId: String
+}
+
+// MARK: - Upload URL Result
+
+/// Response from `chat:generateImageUploadUrl` mutation.
+struct UploadUrlResult: Decodable {
+    let uploadUrl: String
+}
+
+// MARK: - Upload Response
+
+/// Response body from POSTing image data to a Convex upload URL.
+struct UploadResponse: Decodable {
+    let storageId: String
+}
+
+// MARK: - Tool Approval Response
+
+/// Response from `chat:respondToToolApproval` mutation.
+struct ToolApprovalResult: Decodable {
+    let messageId: String
+}
+
+// MARK: - Message List Response
+
+/// Paginated message list from `chat:listMessages`.
+/// Includes streaming state alongside the standard pagination shape.
+struct MessageListResponse: Decodable {
+    let page: [ChatMessage]
+    let isDone: Bool
+    let continueCursor: String
+}

--- a/ios/TonalCoach/Chat/ChatView.swift
+++ b/ios/TonalCoach/Chat/ChatView.swift
@@ -133,8 +133,17 @@ struct ChatView: View {
                             dateDivider(group.label)
 
                             ForEach(group.messages) { message in
-                                messageBubble(for: message)
-                                    .id(message.id)
+                                MessageBubble(message: message) { approvalId, approved in
+                                    Task {
+                                        await viewModel.respondToApproval(
+                                            approvalId: approvalId,
+                                            approved: approved,
+                                            using: convex
+                                        )
+                                    }
+                                }
+                                .padding(.vertical, Theme.Spacing.xs)
+                                .id(message.id)
                             }
                         }
 
@@ -177,53 +186,6 @@ struct ChatView: View {
         }
     }
 
-    // MARK: - Message Bubble
-
-    @ViewBuilder
-    private func messageBubble(for message: ChatMessage) -> some View {
-        VStack(
-            alignment: message.isUser ? .trailing : .leading,
-            spacing: Theme.Spacing.xs
-        ) {
-            // Text content
-            if !message.displayText.isEmpty {
-                if message.isUser {
-                    UserBubble(text: message.displayText)
-                } else {
-                    CoachBubble(
-                        text: message.displayText,
-                        isStreaming: message.isStreaming
-                    )
-                }
-            }
-
-            // Image attachments
-            if !message.imageUrls.isEmpty {
-                ImageAttachmentRow(urls: message.imageUrls)
-            }
-
-            // Tool calls
-            ForEach(message.toolCalls) { part in
-                if part.isApprovalRequested {
-                    ToolApprovalCard(part: part) { approved in
-                        guard let approvalId = part.approval?.id else { return }
-                        Task {
-                            await viewModel.respondToApproval(
-                                approvalId: approvalId,
-                                approved: approved,
-                                using: convex
-                            )
-                        }
-                    }
-                } else {
-                    ToolCallChip(part: part)
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: message.isUser ? .trailing : .leading)
-        .padding(.vertical, Theme.Spacing.xs)
-    }
-
     // MARK: - Date Divider
 
     private func dateDivider(_ label: String) -> some View {
@@ -260,6 +222,26 @@ struct ChatView: View {
         .background(Theme.Colors.destructive.opacity(0.1))
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Error: \(message)")
+    }
+
+    // MARK: - Coach Avatar
+
+    private func coachAvatar(size: CGFloat, iconSize: CGFloat) -> some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.Colors.primary, Color(hex: "9754ed")],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: size, height: size)
+            Image(systemName: "sparkles")
+                .font(.system(size: iconSize, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+        .accessibilityHidden(true)
     }
 
     // MARK: - Thinking Indicator State
@@ -315,26 +297,6 @@ struct ChatView: View {
         }
     }
 
-    // MARK: - Coach Avatar
-
-    private func coachAvatar(size: CGFloat, iconSize: CGFloat) -> some View {
-        ZStack {
-            Circle()
-                .fill(
-                    LinearGradient(
-                        colors: [Theme.Colors.primary, Color(hex: "9754ed")],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-                .frame(width: size, height: size)
-            Image(systemName: "sparkles")
-                .font(.system(size: iconSize, weight: .semibold))
-                .foregroundStyle(.white)
-        }
-        .accessibilityHidden(true)
-    }
-
     // MARK: - Actions
 
     private func sendSuggestion(_ text: String) {
@@ -343,147 +305,3 @@ struct ChatView: View {
         }
     }
 }
-
-// MARK: - User Bubble
-
-/// Right-aligned bubble for user messages with a chat-tail shape.
-private struct UserBubble: View {
-    let text: String
-
-    var body: some View {
-        Text(text)
-            .font(Theme.Typography.body)
-            .foregroundStyle(Theme.Colors.primaryForeground)
-            .padding(.horizontal, Theme.Spacing.md)
-            .padding(.vertical, Theme.Spacing.sm)
-            .background(Theme.Colors.primary)
-            .clipShape(
-                UnevenRoundedRectangle(
-                    topLeadingRadius: 16,
-                    bottomLeadingRadius: 16,
-                    bottomTrailingRadius: 8,
-                    topTrailingRadius: 16,
-                    style: .continuous
-                )
-            )
-            .accessibilityLabel("You said: \(text)")
-    }
-}
-
-// MARK: - Coach Bubble
-
-/// Left-aligned bubble for assistant messages with markdown rendering and avatar.
-private struct CoachBubble: View {
-    let text: String
-    var isStreaming: Bool = false
-
-    var body: some View {
-        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
-            // Coach avatar matching ThinkingIndicator style
-            ZStack {
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: [Theme.Colors.primary, Color(hex: "9754ed")],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                    .frame(width: 28, height: 28)
-                Image(systemName: "sparkles")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.white)
-            }
-            .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 0) {
-                MarkdownText(content: text)
-                    .textSelection(.enabled)
-
-                if isStreaming {
-                    streamingDots
-                }
-            }
-            .padding(.horizontal, Theme.Spacing.md)
-            .padding(.vertical, Theme.Spacing.sm)
-            .background(Theme.Colors.card)
-            .clipShape(bubbleShape)
-            .overlay(bubbleShape.stroke(Theme.Colors.border, lineWidth: 1))
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Coach said: \(text)")
-    }
-
-    private var streamingDots: some View {
-        HStack(spacing: 2) {
-            ForEach(0..<3, id: \.self) { _ in
-                Circle()
-                    .fill(Theme.Colors.textTertiary)
-                    .frame(width: 3, height: 3)
-                    .opacity(0.6)
-            }
-        }
-        .padding(.top, Theme.Spacing.xs)
-        .accessibilityLabel("Still typing")
-    }
-
-    private var bubbleShape: UnevenRoundedRectangle {
-        UnevenRoundedRectangle(
-            topLeadingRadius: 16,
-            bottomLeadingRadius: 8,
-            bottomTrailingRadius: 16,
-            topTrailingRadius: 16,
-            style: .continuous
-        )
-    }
-}
-
-// MARK: - Image Attachment Row
-
-/// Displays image attachments from a message as async-loaded thumbnails.
-private struct ImageAttachmentRow: View {
-    let urls: [String]
-
-    var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
-            ForEach(urls, id: \.self) { urlString in
-                if let url = URL(string: urlString) {
-                    AsyncImage(url: url) { phase in
-                        switch phase {
-                        case .success(let image):
-                            image
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 120, height: 120)
-                                .clipShape(
-                                    RoundedRectangle(
-                                        cornerRadius: Theme.CornerRadius.md,
-                                        style: .continuous
-                                    )
-                                )
-                        case .failure:
-                            imagePlaceholder(icon: "photo.badge.exclamationmark")
-                        case .empty:
-                            imagePlaceholder(icon: "photo")
-                                .overlay(ProgressView().tint(Theme.Colors.textTertiary))
-                        @unknown default:
-                            imagePlaceholder(icon: "photo")
-                        }
-                    }
-                    .accessibilityLabel("Attached image")
-                }
-            }
-        }
-    }
-
-    private func imagePlaceholder(icon: String) -> some View {
-        RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
-            .fill(Theme.Colors.muted)
-            .frame(width: 120, height: 120)
-            .overlay(
-                Image(systemName: icon)
-                    .foregroundStyle(Theme.Colors.textTertiary)
-            )
-    }
-}
-

--- a/ios/TonalCoach/Chat/ChatView.swift
+++ b/ios/TonalCoach/Chat/ChatView.swift
@@ -52,11 +52,8 @@ struct ChatView: View {
             Spacer()
 
             VStack(spacing: Theme.Spacing.lg) {
-                // Coach avatar
-                Image(systemName: "brain.head.profile.fill")
-                    .font(.system(size: 48))
-                    .foregroundStyle(Theme.Colors.primary)
-                    .accessibilityHidden(true)
+                // Coach avatar matching ThinkingIndicator's gradient style
+                coachAvatar(size: 56, iconSize: 24)
 
                 VStack(spacing: Theme.Spacing.sm) {
                     Text("tonal.coach")
@@ -184,15 +181,46 @@ struct ChatView: View {
 
     @ViewBuilder
     private func messageBubble(for message: ChatMessage) -> some View {
-        MessageBubble(message: message) { approvalId, approved in
-            Task {
-                await viewModel.respondToApproval(
-                    approvalId: approvalId,
-                    approved: approved,
-                    using: convex
-                )
+        VStack(
+            alignment: message.isUser ? .trailing : .leading,
+            spacing: Theme.Spacing.xs
+        ) {
+            // Text content
+            if !message.displayText.isEmpty {
+                if message.isUser {
+                    UserBubble(text: message.displayText)
+                } else {
+                    CoachBubble(
+                        text: message.displayText,
+                        isStreaming: message.isStreaming
+                    )
+                }
+            }
+
+            // Image attachments
+            if !message.imageUrls.isEmpty {
+                ImageAttachmentRow(urls: message.imageUrls)
+            }
+
+            // Tool calls
+            ForEach(message.toolCalls) { part in
+                if part.isApprovalRequested {
+                    ToolApprovalCard(part: part) { approved in
+                        guard let approvalId = part.approval?.id else { return }
+                        Task {
+                            await viewModel.respondToApproval(
+                                approvalId: approvalId,
+                                approved: approved,
+                                using: convex
+                            )
+                        }
+                    }
+                } else {
+                    ToolCallChip(part: part)
+                }
             }
         }
+        .frame(maxWidth: .infinity, alignment: message.isUser ? .trailing : .leading)
         .padding(.vertical, Theme.Spacing.xs)
     }
 
@@ -287,12 +315,175 @@ struct ChatView: View {
         }
     }
 
+    // MARK: - Coach Avatar
+
+    private func coachAvatar(size: CGFloat, iconSize: CGFloat) -> some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.Colors.primary, Color(hex: "9754ed")],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: size, height: size)
+            Image(systemName: "sparkles")
+                .font(.system(size: iconSize, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+        .accessibilityHidden(true)
+    }
+
     // MARK: - Actions
 
     private func sendSuggestion(_ text: String) {
         Task {
             await viewModel.send(text: text, using: convex)
         }
+    }
+}
+
+// MARK: - User Bubble
+
+/// Right-aligned bubble for user messages with a chat-tail shape.
+private struct UserBubble: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(Theme.Typography.body)
+            .foregroundStyle(Theme.Colors.primaryForeground)
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .background(Theme.Colors.primary)
+            .clipShape(
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 16,
+                    bottomLeadingRadius: 16,
+                    bottomTrailingRadius: 8,
+                    topTrailingRadius: 16,
+                    style: .continuous
+                )
+            )
+            .accessibilityLabel("You said: \(text)")
+    }
+}
+
+// MARK: - Coach Bubble
+
+/// Left-aligned bubble for assistant messages with markdown rendering and avatar.
+private struct CoachBubble: View {
+    let text: String
+    var isStreaming: Bool = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+            // Coach avatar matching ThinkingIndicator style
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [Theme.Colors.primary, Color(hex: "9754ed")],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 28, height: 28)
+                Image(systemName: "sparkles")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 0) {
+                MarkdownText(content: text)
+                    .textSelection(.enabled)
+
+                if isStreaming {
+                    streamingDots
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .background(Theme.Colors.card)
+            .clipShape(bubbleShape)
+            .overlay(bubbleShape.stroke(Theme.Colors.border, lineWidth: 1))
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Coach said: \(text)")
+    }
+
+    private var streamingDots: some View {
+        HStack(spacing: 2) {
+            ForEach(0..<3, id: \.self) { _ in
+                Circle()
+                    .fill(Theme.Colors.textTertiary)
+                    .frame(width: 3, height: 3)
+                    .opacity(0.6)
+            }
+        }
+        .padding(.top, Theme.Spacing.xs)
+        .accessibilityLabel("Still typing")
+    }
+
+    private var bubbleShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            topLeadingRadius: 16,
+            bottomLeadingRadius: 8,
+            bottomTrailingRadius: 16,
+            topTrailingRadius: 16,
+            style: .continuous
+        )
+    }
+}
+
+// MARK: - Image Attachment Row
+
+/// Displays image attachments from a message as async-loaded thumbnails.
+private struct ImageAttachmentRow: View {
+    let urls: [String]
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            ForEach(urls, id: \.self) { urlString in
+                if let url = URL(string: urlString) {
+                    AsyncImage(url: url) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 120, height: 120)
+                                .clipShape(
+                                    RoundedRectangle(
+                                        cornerRadius: Theme.CornerRadius.md,
+                                        style: .continuous
+                                    )
+                                )
+                        case .failure:
+                            imagePlaceholder(icon: "photo.badge.exclamationmark")
+                        case .empty:
+                            imagePlaceholder(icon: "photo")
+                                .overlay(ProgressView().tint(Theme.Colors.textTertiary))
+                        @unknown default:
+                            imagePlaceholder(icon: "photo")
+                        }
+                    }
+                    .accessibilityLabel("Attached image")
+                }
+            }
+        }
+    }
+
+    private func imagePlaceholder(icon: String) -> some View {
+        RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
+            .fill(Theme.Colors.muted)
+            .frame(width: 120, height: 120)
+            .overlay(
+                Image(systemName: icon)
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            )
     }
 }
 

--- a/ios/TonalCoach/Chat/ChatView.swift
+++ b/ios/TonalCoach/Chat/ChatView.swift
@@ -1,0 +1,298 @@
+import SwiftUI
+
+// MARK: - Chat View
+
+/// Main chat screen for the AI training coach.
+///
+/// Replaces the "Coming Soon" placeholder on the Chat tab.
+/// Manages three states: loading, empty (welcome + suggestions), and active (message list).
+struct ChatView: View {
+    @Environment(\.convexManager) private var convex
+    @State private var viewModel = ChatViewModel()
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.Colors.background
+                    .ignoresSafeArea()
+
+                Group {
+                    if viewModel.isLoadingMessages && viewModel.messages.isEmpty {
+                        loadingView
+                    } else if viewModel.messages.isEmpty && viewModel.currentThreadId == nil {
+                        emptyStateView
+                    } else {
+                        chatContentView
+                    }
+                }
+            }
+            .navigationTitle("Coach")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                viewModel.subscribeToThread(using: convex)
+            }
+            .onDisappear {
+                viewModel.cleanup()
+            }
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingView: some View {
+        ProgressView()
+            .tint(Theme.Colors.primary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: Theme.Spacing.lg) {
+                // Coach avatar
+                Image(systemName: "brain.head.profile.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Theme.Colors.primary)
+                    .accessibilityHidden(true)
+
+                VStack(spacing: Theme.Spacing.sm) {
+                    Text("tonal.coach")
+                        .font(Theme.Typography.title2)
+                        .foregroundStyle(Theme.Colors.textPrimary)
+
+                    Text("Hi! I'm your AI training coach.")
+                        .font(Theme.Typography.body)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                }
+
+                // Suggestion chips
+                suggestionChips
+            }
+            .padding(.horizontal, Theme.Spacing.xl)
+
+            Spacer()
+
+            ChatInputBar(viewModel: viewModel)
+        }
+    }
+
+    private var suggestionChips: some View {
+        let suggestions = [
+            "Program my week",
+            "Analyze my training",
+            "Create a workout",
+            "Check my recovery",
+        ]
+
+        return LazyVGrid(
+            columns: [
+                GridItem(.flexible(), spacing: Theme.Spacing.sm),
+                GridItem(.flexible(), spacing: Theme.Spacing.sm),
+            ],
+            spacing: Theme.Spacing.sm
+        ) {
+            ForEach(suggestions, id: \.self) { suggestion in
+                Button {
+                    sendSuggestion(suggestion)
+                } label: {
+                    Text(suggestion)
+                        .font(Theme.Typography.calloutMedium)
+                        .foregroundStyle(Theme.Colors.textPrimary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, Theme.Spacing.md)
+                        .padding(.horizontal, Theme.Spacing.sm)
+                        .background(Theme.Colors.card)
+                        .clipShape(
+                            RoundedRectangle(
+                                cornerRadius: Theme.CornerRadius.lg,
+                                style: .continuous
+                            )
+                        )
+                        .overlay(
+                            RoundedRectangle(
+                                cornerRadius: Theme.CornerRadius.lg,
+                                style: .continuous
+                            )
+                            .stroke(Theme.Colors.border, lineWidth: 1)
+                        )
+                }
+                .accessibilityHint("Send this message to your coach")
+            }
+        }
+        .padding(.top, Theme.Spacing.sm)
+    }
+
+    // MARK: - Active Chat
+
+    private var chatContentView: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: Theme.Spacing.xs) {
+                        ForEach(groupedMessages, id: \.label) { group in
+                            dateDivider(group.label)
+
+                            ForEach(group.messages) { message in
+                                messageBubble(for: message)
+                                    .id(message.id)
+                            }
+                        }
+
+                        if showThinkingIndicator {
+                            ThinkingIndicator()
+                                .id("thinking")
+                        }
+
+                        // Bottom anchor for auto-scroll
+                        Color.clear
+                            .frame(height: 1)
+                            .id("bottom")
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.sm)
+                }
+                .onChange(of: viewModel.messages.count) { _, _ in
+                    withAnimation(.easeOut(duration: 0.3)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: showThinkingIndicator) { _, isThinking in
+                    if isThinking {
+                        withAnimation(.easeOut(duration: 0.3)) {
+                            proxy.scrollTo("bottom", anchor: .bottom)
+                        }
+                    }
+                }
+                .onAppear {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
+            }
+
+            // Error banner
+            if let error = viewModel.error {
+                errorBanner(error)
+            }
+
+            ChatInputBar(viewModel: viewModel)
+        }
+    }
+
+    // MARK: - Message Bubble
+
+    @ViewBuilder
+    private func messageBubble(for message: ChatMessage) -> some View {
+        MessageBubble(message: message) { approvalId, approved in
+            Task {
+                await viewModel.respondToApproval(
+                    approvalId: approvalId,
+                    approved: approved,
+                    using: convex
+                )
+            }
+        }
+        .padding(.vertical, Theme.Spacing.xs)
+    }
+
+    // MARK: - Date Divider
+
+    private func dateDivider(_ label: String) -> some View {
+        HStack {
+            Rectangle()
+                .fill(Theme.Colors.border)
+                .frame(height: 0.5)
+            Text(label)
+                .font(Theme.Typography.caption)
+                .foregroundStyle(Theme.Colors.textTertiary)
+                .layoutPriority(1)
+            Rectangle()
+                .fill(Theme.Colors.border)
+                .frame(height: 0.5)
+        }
+        .padding(.vertical, Theme.Spacing.sm)
+        .accessibilityLabel("Messages from \(label)")
+    }
+
+    // MARK: - Error Banner
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Theme.Colors.destructive)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(Theme.Typography.caption)
+                .foregroundStyle(Theme.Colors.destructive)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.Colors.destructive.opacity(0.1))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Error: \(message)")
+    }
+
+    // MARK: - Thinking Indicator State
+
+    private var showThinkingIndicator: Bool {
+        guard viewModel.isSending else { return false }
+        guard let last = viewModel.messages.last else { return true }
+        return last.isUser
+    }
+
+    // MARK: - Message Grouping
+
+    private struct MessageGroup {
+        let label: String
+        let messages: [ChatMessage]
+    }
+
+    private var groupedMessages: [MessageGroup] {
+        let calendar = Calendar.current
+        var groups: [MessageGroup] = []
+        var currentLabel = ""
+        var currentMessages: [ChatMessage] = []
+
+        for message in viewModel.messages {
+            let label = dateLabel(for: message.creationDate, calendar: calendar)
+            if label != currentLabel {
+                if !currentMessages.isEmpty {
+                    groups.append(MessageGroup(label: currentLabel, messages: currentMessages))
+                }
+                currentLabel = label
+                currentMessages = [message]
+            } else {
+                currentMessages.append(message)
+            }
+        }
+
+        if !currentMessages.isEmpty {
+            groups.append(MessageGroup(label: currentLabel, messages: currentMessages))
+        }
+
+        return groups
+    }
+
+    private func dateLabel(for date: Date, calendar: Calendar) -> String {
+        if calendar.isDateInToday(date) {
+            return "Today"
+        } else if calendar.isDateInYesterday(date) {
+            return "Yesterday"
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "MMM d"
+            return formatter.string(from: date)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func sendSuggestion(_ text: String) {
+        Task {
+            await viewModel.send(text: text, using: convex)
+        }
+    }
+}
+

--- a/ios/TonalCoach/Chat/ChatViewModel.swift
+++ b/ios/TonalCoach/Chat/ChatViewModel.swift
@@ -1,0 +1,304 @@
+import Combine
+import ConvexMobile
+import Foundation
+import SwiftUI
+
+// MARK: - Chat View Model
+
+/// Manages all chat state and operations for the AI Coach.
+///
+/// Key responsibilities:
+/// - Subscribe to `threads:getCurrentThread` for active thread
+/// - Subscribe to `chat:listMessages` for real-time message stream
+/// - Send messages via `chat:sendMessage` (creates thread) or `chat:sendMessageMutation`
+/// - Handle tool approvals via `chat:respondToToolApproval` + `chat:continueAfterApproval`
+/// - Image upload via `chat:generateImageUploadUrl`
+@Observable
+final class ChatViewModel {
+    // MARK: - State
+
+    var messages: [ChatMessage] = []
+    var currentThreadId: String?
+    var isSending = false
+    var isLoadingMessages = false
+    var error: String?
+
+    // Image attachments
+    var pendingImages: [PendingImage] = []
+    var isUploadingImages = false
+
+    // MARK: - Pending Image
+
+    struct PendingImage: Identifiable {
+        let id = UUID()
+        let data: Data
+        let preview: UIImage
+    }
+
+    // MARK: - Private
+
+    private var threadCancellable: AnyCancellable?
+    private var messageCancellable: AnyCancellable?
+
+    // MARK: - Thread Subscription
+
+    /// Subscribe to `threads:getCurrentThread` for the active thread.
+    /// When a thread is found, automatically subscribes to its messages.
+    func subscribeToThread(using manager: ConvexManager) {
+        threadCancellable?.cancel()
+
+        threadCancellable = manager.client
+            .subscribe(to: "threads:getCurrentThread", yielding: ChatThread?.self)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { [weak self] thread in
+                    guard let self else { return }
+                    let newId = thread?.threadId
+                    if newId != self.currentThreadId {
+                        self.currentThreadId = newId
+                        if let threadId = newId {
+                            self.subscribeToMessages(threadId: threadId, using: manager)
+                        }
+                    }
+                }
+            )
+    }
+
+    // MARK: - Message Subscription
+
+    /// Subscribe to `chat:listMessages` for real-time message streaming.
+    /// The @convex-dev/agent query returns paginated UIMessages with streaming state.
+    private func subscribeToMessages(threadId: String, using manager: ConvexManager) {
+        isLoadingMessages = true
+        messageCancellable?.cancel()
+
+        // listMessages requires: threadId, paginationOpts, streamArgs
+        // numItems must be Double (Convex v.float64)
+        let args: [String: ConvexEncodable?] = [
+            "threadId": threadId,
+            "paginationOpts": [
+                "numItems": Double(50),
+                "cursor": nil as String?,
+            ] as [String: ConvexEncodable?],
+            "streamArgs": [
+                "kind": "list",
+            ] as [String: ConvexEncodable?],
+        ]
+
+        messageCancellable = manager.client
+            .subscribe(to: "chat:listMessages", with: args, yielding: MessageListResponse.self)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] _ in
+                    self?.isLoadingMessages = false
+                },
+                receiveValue: { [weak self] response in
+                    guard let self else { return }
+                    self.messages = response.page
+                        .filter { $0.hasContent }
+                        .sorted { $0.sortKey < $1.sortKey }
+                    self.isLoadingMessages = false
+                }
+            )
+    }
+
+    // MARK: - Send Message
+
+    /// Send a text message (with optional images) to the coach.
+    ///
+    /// - When no thread exists: uses `chat:sendMessage` action (creates thread automatically).
+    /// - When a thread exists: uses `chat:sendMessageMutation` mutation (faster, schedules processing).
+    func send(text: String, using manager: ConvexManager) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        isSending = true
+        error = nil
+
+        do {
+            // Upload images if any
+            var imageStorageIds: [String] = []
+            if !pendingImages.isEmpty {
+                isUploadingImages = true
+                imageStorageIds = try await uploadImages(using: manager)
+                isUploadingImages = false
+            }
+
+            if let threadId = currentThreadId {
+                // Existing thread: use the fast mutation path
+                var args: [String: ConvexEncodable?] = [
+                    "prompt": trimmed,
+                    "threadId": threadId,
+                ]
+                if !imageStorageIds.isEmpty {
+                    args["imageStorageIds"] = imageStorageIds.map { $0 as ConvexEncodable? }
+                }
+
+                let _: SendMessageResult = try await manager.mutation(
+                    "chat:sendMessageMutation", with: args
+                )
+            } else {
+                // No thread: use the action that auto-creates one
+                var args: [String: ConvexEncodable?] = [
+                    "prompt": trimmed,
+                ]
+                if !imageStorageIds.isEmpty {
+                    args["imageStorageIds"] = imageStorageIds.map { $0 as ConvexEncodable? }
+                }
+
+                let result: SendMessageResult = try await manager.action(
+                    "chat:sendMessage", with: args
+                )
+                // Thread subscription will pick up the new thread,
+                // but set it eagerly so the UI updates immediately.
+                currentThreadId = result.threadId
+                subscribeToMessages(threadId: result.threadId, using: manager)
+            }
+
+            pendingImages.removeAll()
+        } catch {
+            self.error = parseError(error)
+        }
+
+        isUploadingImages = false
+        isSending = false
+    }
+
+    // MARK: - Tool Approval
+
+    /// Respond to a tool approval request and continue agent execution.
+    func respondToApproval(
+        approvalId: String,
+        approved: Bool,
+        using manager: ConvexManager
+    ) async {
+        guard let threadId = currentThreadId else { return }
+
+        do {
+            // Step 1: Record the approval/denial
+            let result: ToolApprovalResult = try await manager.mutation(
+                "chat:respondToToolApproval",
+                with: [
+                    "threadId": threadId,
+                    "approvalId": approvalId,
+                    "approved": approved,
+                ]
+            )
+
+            // Step 2: Continue agent execution
+            try await manager.action(
+                "chat:continueAfterApproval",
+                with: [
+                    "threadId": threadId,
+                    "messageId": result.messageId,
+                ]
+            )
+        } catch {
+            self.error = "Failed to process approval"
+        }
+    }
+
+    // MARK: - Image Management
+
+    /// Add an image from raw data. Validates size and count limits.
+    func addImage(_ data: Data) {
+        guard pendingImages.count < 4 else {
+            error = "Maximum 4 images per message"
+            return
+        }
+        guard data.count <= 10_000_000 else {
+            error = "Image must be under 10MB"
+            return
+        }
+        guard let image = UIImage(data: data) else {
+            error = "Could not read image"
+            return
+        }
+        pendingImages.append(PendingImage(data: data, preview: image))
+    }
+
+    /// Remove a pending image at the given index.
+    func removeImage(at index: Int) {
+        guard pendingImages.indices.contains(index) else { return }
+        pendingImages.remove(at: index)
+    }
+
+    // MARK: - Image Upload
+
+    /// Upload all pending images to Convex storage.
+    /// Returns an array of storage IDs for use in the send mutation.
+    private func uploadImages(using manager: ConvexManager) async throws -> [String] {
+        var storageIds: [String] = []
+
+        for image in pendingImages {
+            // Get a signed upload URL from Convex
+            let urlResult: UploadUrlResult = try await manager.mutation(
+                "chat:generateImageUploadUrl", with: [:]
+            )
+
+            guard let url = URL(string: urlResult.uploadUrl) else {
+                throw ChatError.uploadFailed("Invalid upload URL")
+            }
+
+            // POST the image data to the upload URL
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("image/jpeg", forHTTPHeaderField: "Content-Type")
+            request.httpBody = image.data
+
+            let (responseData, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200
+            else {
+                throw ChatError.uploadFailed("Upload returned non-200 status")
+            }
+
+            // Parse the storage ID from the JSON response body
+            let uploadResponse = try JSONDecoder().decode(UploadResponse.self, from: responseData)
+            storageIds.append(uploadResponse.storageId)
+        }
+
+        return storageIds
+    }
+
+    // MARK: - Cleanup
+
+    /// Cancel all active subscriptions. Call when the view disappears.
+    func cleanup() {
+        threadCancellable?.cancel()
+        messageCancellable?.cancel()
+        threadCancellable = nil
+        messageCancellable = nil
+    }
+
+    // MARK: - Error Parsing
+
+    private func parseError(_ error: Error) -> String {
+        let msg = error.localizedDescription.lowercased()
+        if msg.contains("dailymessages") || msg.contains("daily") {
+            return "Daily message limit reached. Try again tomorrow."
+        }
+        if msg.contains("rate") || msg.contains("limit") {
+            return "Slow down! Wait a moment before sending."
+        }
+        if msg.contains("network") || msg.contains("connection") {
+            return "Connection error. Check your internet."
+        }
+        if msg.contains("upload") {
+            return "Image upload failed. Please try again."
+        }
+        return "Something went wrong. Try again."
+    }
+}
+
+// MARK: - Chat Error
+
+private enum ChatError: LocalizedError {
+    case uploadFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .uploadFailed(let reason): return "Upload failed: \(reason)"
+        }
+    }
+}

--- a/ios/TonalCoach/Chat/MarkdownText.swift
+++ b/ios/TonalCoach/Chat/MarkdownText.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+// MARK: - Markdown Text
+
+/// Renders markdown-formatted text from coach messages.
+///
+/// Uses `AttributedString(markdown:)` for bold, italic, headings, lists, code, and links.
+/// Code blocks render in a monospace font with a muted background.
+/// Falls back to plain Text if markdown parsing fails.
+struct MarkdownText: View {
+    let content: String
+
+    var body: some View {
+        if content.isEmpty {
+            EmptyView()
+        } else if let blocks = parseBlocks(from: content), hasCodeBlocks(blocks) {
+            // Mixed content with code blocks: render block-by-block
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                    switch block {
+                    case .text(let text):
+                        inlineMarkdown(text)
+                    case .code(let code, _):
+                        codeBlock(code)
+                    }
+                }
+            }
+        } else {
+            // No code blocks: render as a single attributed string
+            inlineMarkdown(content)
+        }
+    }
+
+    // MARK: - Inline Markdown
+
+    @ViewBuilder
+    private func inlineMarkdown(_ text: String) -> some View {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            EmptyView()
+        } else if let attributed = parseAttributedString(trimmed) {
+            Text(attributed)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .tint(Theme.Colors.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            Text(trimmed)
+                .font(Theme.Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Code Block
+
+    private func codeBlock(_ code: String) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            Text(code)
+                .font(Theme.Typography.monoText)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.Colors.muted)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
+                .stroke(Theme.Colors.border, lineWidth: 1)
+        )
+    }
+
+    // MARK: - Parsing
+
+    private func parseAttributedString(_ text: String) -> AttributedString? {
+        var options = AttributedString.MarkdownParsingOptions()
+        options.interpretedSyntax = .inlineOnlyPreservingWhitespace
+        return try? AttributedString(markdown: text, options: options)
+    }
+
+    /// Splits content into text and code blocks for block-level rendering.
+    private func parseBlocks(from text: String) -> [ContentBlock]? {
+        let pattern = "```(?:\\w*)\n([\\s\\S]*?)```"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+
+        let nsString = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsString.length))
+        guard !matches.isEmpty else { return nil }
+
+        var blocks: [ContentBlock] = []
+        var cursor = 0
+
+        for match in matches {
+            let matchRange = match.range
+            // Text before the code block
+            if matchRange.location > cursor {
+                let textRange = NSRange(location: cursor, length: matchRange.location - cursor)
+                let textContent = nsString.substring(with: textRange)
+                if !textContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    blocks.append(.text(textContent))
+                }
+            }
+            // The code block content (capture group 1)
+            let codeRange = match.range(at: 1)
+            let codeContent = nsString.substring(with: codeRange)
+            blocks.append(.code(codeContent, language: nil))
+            cursor = matchRange.location + matchRange.length
+        }
+
+        // Remaining text after last code block
+        if cursor < nsString.length {
+            let remaining = nsString.substring(from: cursor)
+            if !remaining.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                blocks.append(.text(remaining))
+            }
+        }
+
+        return blocks
+    }
+
+    private func hasCodeBlocks(_ blocks: [ContentBlock]) -> Bool {
+        blocks.contains { if case .code = $0 { return true } else { return false } }
+    }
+}
+
+// MARK: - Content Block
+
+private enum ContentBlock {
+    case text(String)
+    case code(String, language: String?)
+}

--- a/ios/TonalCoach/Chat/MessageBubble.swift
+++ b/ios/TonalCoach/Chat/MessageBubble.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+
+// MARK: - Message Bubble
+
+/// Renders a single ChatMessage as either a user or coach bubble.
+///
+/// - **User bubble**: right-aligned, teal background, plain text + image thumbnails.
+/// - **Coach bubble**: left-aligned with sparkles avatar, card background, markdown text,
+///   streaming cursor, and inline tool call indicators.
+struct MessageBubble: View {
+    let message: ChatMessage
+    let onApprovalResponse: (String, Bool) -> Void
+
+    var body: some View {
+        if message.isUser {
+            userBubble
+        } else {
+            coachBubble
+        }
+    }
+
+    // MARK: - User Bubble
+
+    private var userBubble: some View {
+        HStack {
+            Spacer(minLength: UIScreen.main.bounds.width * 0.2)
+
+            VStack(alignment: .trailing, spacing: Theme.Spacing.xs) {
+                // Image thumbnails
+                if !message.imageUrls.isEmpty {
+                    imageGrid
+                }
+
+                // Text bubble
+                if !message.displayText.isEmpty {
+                    Text(message.displayText)
+                        .font(Theme.Typography.body)
+                        .foregroundStyle(Theme.Colors.primaryForeground)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, Theme.Spacing.lg)
+                        .padding(.vertical, Theme.Spacing.md)
+                        .background(Theme.Colors.primary)
+                        .clipShape(userBubbleShape)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("You said: \(message.displayText)")
+    }
+
+    // MARK: - Coach Bubble
+
+    private var coachBubble: some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+            // Coach avatar
+            coachAvatar
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                // Main text content
+                if !message.displayText.isEmpty || message.isStreaming {
+                    coachTextBubble
+                }
+
+                // Tool calls: approval cards and status chips
+                toolCallsSection
+            }
+            .frame(
+                maxWidth: UIScreen.main.bounds.width * 0.85,
+                alignment: .leading
+            )
+
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Coach Text Bubble
+
+    private var coachTextBubble: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if message.isStreaming {
+                streamingText
+            } else {
+                MarkdownText(content: message.displayText)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.vertical, Theme.Spacing.md)
+        .background(Theme.Colors.card)
+        .clipShape(coachBubbleShape)
+        .overlay(coachBubbleShape.stroke(Theme.Colors.border, lineWidth: 1))
+    }
+
+    // MARK: - Streaming Text
+
+    private var streamingText: some View {
+        HStack(alignment: .lastTextBaseline, spacing: 0) {
+            MarkdownText(content: message.displayText)
+            StreamingCursor()
+        }
+    }
+
+    // MARK: - Tool Calls Section
+
+    @ViewBuilder
+    private var toolCallsSection: some View {
+        let toolParts = message.toolCalls
+        if !toolParts.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                ForEach(toolParts) { part in
+                    toolPartView(part)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func toolPartView(_ part: MessagePart) -> some View {
+        if part.isApprovalRequested {
+            ToolApprovalCard(part: part) { approved in
+                guard let approvalId = part.approval?.id else { return }
+                onApprovalResponse(approvalId, approved)
+            }
+        } else if part.isApprovalResponded || part.state == "output-denied" {
+            approvalResultBadge(part)
+        } else if part.isToolRunning || part.isToolDone {
+            ToolCallChip(part: part)
+        }
+    }
+
+    // MARK: - Approval Result Badge
+
+    private func approvalResultBadge(_ part: MessagePart) -> some View {
+        let approved = part.approval?.approved ?? false
+        return Label(
+            approved ? "Approved" : "Denied",
+            systemImage: approved ? "checkmark.circle.fill" : "xmark.circle.fill"
+        )
+        .font(Theme.Typography.caption)
+        .foregroundStyle(approved ? Theme.Colors.success : Theme.Colors.destructive)
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, Theme.Spacing.xs)
+        .background((approved ? Theme.Colors.success : Theme.Colors.destructive).opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.sm, style: .continuous))
+    }
+
+    // MARK: - Image Grid
+
+    private var imageGrid: some View {
+        HStack(spacing: Theme.Spacing.xs) {
+            ForEach(Array(message.imageUrls.enumerated()), id: \.offset) { _, urlString in
+                AsyncImage(url: URL(string: urlString)) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(maxWidth: 120, maxHeight: 120)
+                            .clipShape(
+                                RoundedRectangle(
+                                    cornerRadius: Theme.CornerRadius.md, style: .continuous
+                                )
+                            )
+                    case .failure:
+                        imagePlaceholder(failed: true)
+                    case .empty:
+                        imagePlaceholder(failed: false)
+                    @unknown default:
+                        imagePlaceholder(failed: false)
+                    }
+                }
+                .frame(maxWidth: 120, maxHeight: 120)
+            }
+        }
+    }
+
+    private func imagePlaceholder(failed: Bool) -> some View {
+        RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
+            .fill(Theme.Colors.muted)
+            .frame(width: 80, height: 80)
+            .overlay(
+                Image(systemName: failed ? "photo.badge.exclamationmark" : "photo")
+                    .font(.system(size: 20))
+                    .foregroundStyle(Theme.Colors.textTertiary)
+            )
+    }
+
+    // MARK: - Coach Avatar
+
+    private var coachAvatar: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.Colors.primary, Color(hex: "9754ed")],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 28, height: 28)
+            Image(systemName: "sparkles")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Bubble Shapes
+
+    private var userBubbleShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            topLeadingRadius: 16,
+            bottomLeadingRadius: 16,
+            bottomTrailingRadius: 8,
+            topTrailingRadius: 16,
+            style: .continuous
+        )
+    }
+
+    private var coachBubbleShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            topLeadingRadius: 16,
+            bottomLeadingRadius: 8,
+            bottomTrailingRadius: 16,
+            topTrailingRadius: 16,
+            style: .continuous
+        )
+    }
+}
+
+// MARK: - Streaming Cursor
+
+/// Blinking cursor appended to streaming coach messages.
+private struct StreamingCursor: View {
+    @State private var visible = true
+
+    var body: some View {
+        Text("|")
+            .font(Theme.Typography.body)
+            .foregroundStyle(Theme.Colors.primary)
+            .opacity(visible ? 1.0 : 0.0)
+            .animation(
+                .easeInOut(duration: 0.5).repeatForever(autoreverses: true),
+                value: visible
+            )
+            .onAppear { visible = false }
+            .accessibilityHidden(true)
+    }
+}

--- a/ios/TonalCoach/Chat/ThinkingIndicator.swift
+++ b/ios/TonalCoach/Chat/ThinkingIndicator.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+// MARK: - Thinking Indicator
+
+/// Animated thinking dots shown while waiting for the coach to respond.
+///
+/// Left-aligned like a coach bubble, with the same sparkles avatar.
+/// Three dots pulse with staggered timing to convey active processing.
+struct ThinkingIndicator: View {
+    @State private var isAnimating = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+            // Coach avatar
+            coachAvatar
+
+            // Thinking dots bubble
+            HStack(spacing: 6) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(Theme.Colors.textTertiary)
+                        .frame(width: 8, height: 8)
+                        .opacity(isAnimating ? 1.0 : 0.3)
+                        .animation(
+                            .easeInOut(duration: 0.6)
+                                .repeatForever(autoreverses: true)
+                                .delay(Double(index) * 0.2),
+                            value: isAnimating
+                        )
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.vertical, Theme.Spacing.md)
+            .background(Theme.Colors.card)
+            .clipShape(bubbleShape)
+            .overlay(bubbleShape.stroke(Theme.Colors.border, lineWidth: 1))
+
+            Spacer()
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Coach is thinking")
+        .onAppear { isAnimating = true }
+    }
+
+    // MARK: - Coach Avatar
+
+    private var coachAvatar: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.Colors.primary, Color(hex: "9754ed")],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 28, height: 28)
+            Image(systemName: "sparkles")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+    }
+
+    // MARK: - Bubble Shape
+
+    private var bubbleShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            topLeadingRadius: 16,
+            bottomLeadingRadius: 8,
+            bottomTrailingRadius: 16,
+            topTrailingRadius: 16,
+            style: .continuous
+        )
+    }
+}

--- a/ios/TonalCoach/Chat/ToolApprovalCard.swift
+++ b/ios/TonalCoach/Chat/ToolApprovalCard.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+// MARK: - Tool Approval Card
+
+/// Interactive card for tool approval requests.
+///
+/// Displays what the coach wants to do and lets the user approve or deny.
+/// Shows a loading state while processing and a result badge when complete.
+struct ToolApprovalCard: View {
+    let part: MessagePart
+    let onRespond: (Bool) -> Void
+
+    @State private var status: ApprovalStatus = .pending
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            // Tool label
+            Text(part.toolLabel)
+                .font(Theme.Typography.headline)
+                .foregroundStyle(Theme.Colors.textPrimary)
+
+            // Description of what the tool does
+            Text(toolDescription)
+                .font(Theme.Typography.callout)
+                .foregroundStyle(Theme.Colors.textSecondary)
+
+            // Action area
+            actionArea
+        }
+        .padding(Theme.Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.Colors.card)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.lg, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.CornerRadius.lg, style: .continuous)
+                .stroke(Theme.Colors.primary.opacity(0.3), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Tool approval: \(part.toolLabel)")
+        .onChange(of: resolvedApproval) { _, resolved in
+            if let approved = resolved {
+                status = approved ? .approved : .denied
+            }
+        }
+    }
+
+    // MARK: - Action Area
+
+    @ViewBuilder
+    private var actionArea: some View {
+        switch status {
+        case .pending:
+            HStack(spacing: Theme.Spacing.md) {
+                // Approve button
+                Button {
+                    Theme.Haptics.medium()
+                    status = .processing
+                    onRespond(true)
+                } label: {
+                    Label("Approve", systemImage: "checkmark")
+                        .font(Theme.Typography.calloutMedium)
+                        .foregroundStyle(Theme.Colors.primaryForeground)
+                        .padding(.horizontal, Theme.Spacing.lg)
+                        .padding(.vertical, Theme.Spacing.sm)
+                        .background(Theme.Colors.success)
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
+                        )
+                }
+                .accessibilityHint("Allows the coach to proceed with this action")
+
+                // Deny button
+                Button {
+                    Theme.Haptics.medium()
+                    status = .processing
+                    onRespond(false)
+                } label: {
+                    Label("Deny", systemImage: "xmark")
+                        .font(Theme.Typography.calloutMedium)
+                        .foregroundStyle(Theme.Colors.foreground)
+                        .padding(.horizontal, Theme.Spacing.lg)
+                        .padding(.vertical, Theme.Spacing.sm)
+                        .background(Theme.Colors.muted)
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
+                                .stroke(Theme.Colors.border, lineWidth: 1)
+                        )
+                }
+                .accessibilityHint("Prevents the coach from performing this action")
+            }
+
+        case .processing:
+            HStack(spacing: Theme.Spacing.sm) {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(Theme.Colors.textSecondary)
+                Text("Processing...")
+                    .font(Theme.Typography.callout)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+            .accessibilityLabel("Processing approval")
+
+        case .approved:
+            resultBadge(approved: true)
+
+        case .denied:
+            resultBadge(approved: false)
+        }
+    }
+
+    // MARK: - Result Badge
+
+    private func resultBadge(approved: Bool) -> some View {
+        Label(
+            approved ? "Approved" : "Denied",
+            systemImage: approved ? "checkmark.circle.fill" : "xmark.circle.fill"
+        )
+        .font(Theme.Typography.calloutMedium)
+        .foregroundStyle(approved ? Theme.Colors.success : Theme.Colors.destructive)
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.xs)
+        .background((approved ? Theme.Colors.success : Theme.Colors.destructive).opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.sm, style: .continuous))
+    }
+
+    // MARK: - Tool Description
+
+    private var toolDescription: String {
+        switch part.toolName {
+        case "approve_week_plan":
+            return "The coach wants to push workouts to your Tonal."
+        case "create_workout":
+            return "The coach wants to create a workout on your Tonal."
+        case "delete_workout":
+            return "The coach wants to delete a workout from your Tonal."
+        case "delete_week_plan":
+            return "The coach wants to delete the current week plan."
+        default:
+            return "The coach wants to perform an action that requires your approval."
+        }
+    }
+
+    // MARK: - Resolved Approval
+
+    /// Reads the approval state from the message part to sync with server updates.
+    private var resolvedApproval: Bool? {
+        guard part.isApprovalResponded || part.state == "output-denied" else { return nil }
+        return part.approval?.approved
+    }
+}
+
+// MARK: - Approval Status
+
+private enum ApprovalStatus {
+    case pending
+    case processing
+    case approved
+    case denied
+}

--- a/ios/TonalCoach/Chat/ToolCallChip.swift
+++ b/ios/TonalCoach/Chat/ToolCallChip.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+// MARK: - Tool Call Chip
+
+/// Compact status indicator for tool execution within coach messages.
+///
+/// Shows three states:
+/// - **Running**: spinner + label + "..."
+/// - **Done**: green checkmark + label
+/// - **Denied**: red X + label
+struct ToolCallChip: View {
+    let part: MessagePart
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.xs) {
+            statusIcon
+            Text(statusLabel)
+                .font(Theme.Typography.caption)
+                .foregroundStyle(Theme.Colors.textSecondary)
+        }
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, Theme.Spacing.xs)
+        .background(Theme.Colors.muted)
+        .clipShape(Capsule())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    // MARK: - Status Icon
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        if part.isToolRunning {
+            ProgressView()
+                .controlSize(.mini)
+                .tint(Theme.Colors.textSecondary)
+        } else if part.isToolDone {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(Theme.Colors.success)
+        } else if isDenied {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(Theme.Colors.destructive)
+        }
+    }
+
+    // MARK: - Labels
+
+    private var statusLabel: String {
+        if part.isToolRunning {
+            return "\(part.toolLabel)..."
+        }
+        return part.toolLabel
+    }
+
+    private var isDenied: Bool {
+        part.state == "output-denied" || (part.isApprovalResponded && part.approval?.approved == false)
+    }
+
+    private var accessibilityDescription: String {
+        if part.isToolRunning {
+            return "\(part.toolLabel), in progress"
+        } else if part.isToolDone {
+            return "\(part.toolLabel), completed"
+        } else if isDenied {
+            return "\(part.toolLabel), denied"
+        }
+        return part.toolLabel
+    }
+}


### PR DESCRIPTION
## Summary

Complete AI Coach chat interface for the iOS app, replacing the Chat tab placeholder. Calls the same Convex backend as the web app - no backend changes.

### Features
- Real-time streaming messages via Convex subscription
- Welcome screen with suggestion chips for first-time users
- User/coach message bubbles with markdown rendering
- Tool call approval cards (approve/deny workout pushes, week programming)
- Tool execution status chips (running/done/denied)
- Image attachment via PhotosPicker (max 4, 10MB each)
- Animated thinking indicator while coach responds
- Auto-scroll to latest message
- Date dividers between message groups
- Keyboard-aware input bar

### New files (9)
- `Chat/ChatModels.swift` - Decodable types (ChatMessage, MessagePart, ToolApproval, etc.)
- `Chat/ChatViewModel.swift` - @Observable managing threads, messages, sending, approvals, uploads
- `Chat/ChatView.swift` - Main chat screen (welcome, message list, input)
- `Chat/ChatInputBar.swift` - Text input with image attachment and send button
- `Chat/MessageBubble.swift` - User/coach bubbles with streaming cursor
- `Chat/ToolApprovalCard.swift` - Interactive approve/deny card
- `Chat/ToolCallChip.swift` - Status chips for tool execution
- `Chat/ThinkingIndicator.swift` - Animated dots while coach thinks
- `Chat/MarkdownText.swift` - AttributedString markdown renderer

### Modified (1)
- `App/ContentView.swift` - Chat tab wired to ChatView

## Backend
No changes. Uses existing:
- `threads:getCurrentThread` (subscription)
- `chat:listMessages` (subscription with streaming)
- `chat:sendMessage` / `chat:sendMessageMutation`
- `chat:respondToToolApproval` + `chat:continueAfterApproval`
- `chat:generateImageUploadUrl`

## Test plan
- [ ] Chat tab shows welcome screen with suggestion chips
- [ ] Tapping suggestion sends first message
- [ ] Coach responds with streaming text
- [ ] User messages appear right-aligned in primary color
- [ ] Coach messages left-aligned with sparkle avatar and markdown
- [ ] Tool approval card appears for workout pushes
- [ ] Approve/deny works and agent continues
- [ ] Image attachment via picker, preview thumbnails
- [ ] Thinking indicator shows while waiting
- [ ] Auto-scroll to bottom on new messages
- [ ] Date dividers between message groups
- [ ] Kill app, relaunch -> conversation history loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)