### PR TITLE
feat: add Conductor workspace config and slash commands

### DIFF
--- a/.claude/commands/backend-test.md
+++ b/.claude/commands/backend-test.md
@@ -1,0 +1,12 @@
+Run only Convex backend tests.
+
+```bash
+npx vitest run --project backend
+```
+
+If a specific file is mentioned in the conversation, run just that file:
+```bash
+npx vitest run convex/<file>.test.ts
+```
+
+Show the full output. Do not attempt to fix failures unless asked.

--- a/.claude/commands/backend-test.md
+++ b/.claude/commands/backend-test.md
@@ -5,6 +5,7 @@ npx vitest run --project backend
 ```
 
 If a specific file is mentioned in the conversation, run just that file:
+
 ```bash
 npx vitest run convex/<file>.test.ts
 ```

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,0 +1,30 @@
+Deploy Tonal Coach to production. This affects live users -- be careful.
+
+## Steps
+
+1. Run the full verification pipeline first:
+   - `npx tsc --noEmit`
+   - `npm run lint`
+   - `npm test`
+   - All must pass. Stop if any fail.
+
+2. Show a summary of what will be deployed:
+   - `git log --oneline main..HEAD` (commits being deployed)
+   - Flag any schema changes in `convex/schema.ts`
+   - Flag any new environment variables needed
+
+3. **Ask for explicit confirmation before proceeding.**
+
+4. Deploy Convex backend:
+   ```bash
+   npx convex deploy
+   ```
+
+5. Report the result. The Next.js frontend deploys automatically via Vercel on merge to main.
+
+## Rules
+
+- Never deploy without running verification first
+- Always ask for confirmation -- this is a production deployment
+- If schema changes exist, warn that they may require backfill
+- If new env vars are needed, list them and confirm they're set in production

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -16,6 +16,7 @@ Deploy Tonal Coach to production. This affects live users -- be careful.
 3. **Ask for explicit confirmation before proceeding.**
 
 4. Deploy Convex backend:
+
    ```bash
    npx convex deploy
    ```

--- a/.claude/commands/frontend-test.md
+++ b/.claude/commands/frontend-test.md
@@ -1,0 +1,12 @@
+Run only frontend tests.
+
+```bash
+npx vitest run --project frontend
+```
+
+If a specific file is mentioned in the conversation, run just that file:
+```bash
+npx vitest run src/<file>.test.tsx
+```
+
+Show the full output. Do not attempt to fix failures unless asked.

--- a/.claude/commands/frontend-test.md
+++ b/.claude/commands/frontend-test.md
@@ -5,6 +5,7 @@ npx vitest run --project frontend
 ```
 
 If a specific file is mentioned in the conversation, run just that file:
+
 ```bash
 npx vitest run src/<file>.test.tsx
 ```

--- a/.claude/commands/new-ai-tool.md
+++ b/.claude/commands/new-ai-tool.md
@@ -1,0 +1,31 @@
+Scaffold a new AI coach tool. Follow existing patterns exactly.
+
+## Steps
+
+1. Read the existing tool patterns:
+   - `convex/ai/tools.ts` -- tool definitions and implementations
+   - `convex/ai/agent.ts` -- agent configuration and tool registration
+
+2. Ask for:
+   - Tool name (verb phrase, e.g. "getStrengthScores")
+   - What it does (one sentence)
+   - What data it needs access to
+   - Whether it reads data or writes data (or both)
+
+3. Implement the tool following the existing pattern in `convex/ai/tools.ts`:
+   - Use the same tool definition structure as neighboring tools
+   - Add Zod input validation
+   - Use `getEffectiveUserId()` for auth if user-scoped
+   - For Tonal data: use the cached fetch pattern from `convex/tonal/`
+   - For DB writes: use mutations, not direct writes in the tool
+
+4. Register the tool in the agent configuration
+
+5. Run `npx tsc --noEmit` to verify
+
+## Rules
+
+- Match the exact patterns of existing tools -- do not introduce new conventions
+- Every tool must validate its inputs
+- Read-only tools should use queries, not actions
+- Tools that call external APIs must use actions

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,14 @@
+Full verification pipeline for Tonal Coach. Run after completing any code change.
+
+## Steps
+
+1. Run `npx tsc --noEmit` -- fix any type errors before continuing
+2. Run `npm run lint` -- fix any lint errors
+3. Run `npm run format:check` -- if failures, run `npm run format` then re-check
+4. Run `npm test` -- all tests must pass
+5. If any step fails, fix the issue and re-run that step before moving on
+
+## Output
+
+- PASS: All checks green
+- FAIL: [which step failed + error summary]

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ next-env.d.ts
 # Agent directories
 .agent/*
 .claude/*
+!.claude/commands/
 .factory/*
 .junie/*
 .kiro/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ Tonal Coach is an AI coaching companion for Tonal fitness machines. Users connec
 - **Package manager:** npm
 - **Deployment:** Vercel (web), Convex (backend)
 
+## Conductor Workspaces
+
+This project uses [Conductor](https://conductor.build) for parallel agent development. Each workspace is an isolated git worktree with its own branch.
+
+- **Environment files** (`.env.local`, `.env.sentry-build-plugin`) are symlinked from the repo root via the setup script -- do not copy or create them manually
+- **Dev server port**: Use `$CONDUCTOR_PORT` instead of hardcoding 3000. The run script handles this automatically
+- **Convex dev**: All workspaces share the same Convex dev deployment, so avoid running schema-altering backend changes in parallel. `npx convex dev` is started by the run script
+- **Workspace path**: Available as `$CONDUCTOR_WORKSPACE_PATH`. The repo root is `$CONDUCTOR_ROOT_PATH`
+- **Branch per workspace**: Each workspace gets a unique branch. Rename with `git branch -m new-name`
+
 ## Development Commands
 
 ```bash

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "setup": "[ -f \"$CONDUCTOR_ROOT_PATH/.env.local\" ] || { echo 'Missing .env.local in repo root — copy .env.example and fill in values'; exit 1; } && npm install && ln -sf \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local && ln -sf \"$CONDUCTOR_ROOT_PATH/.env.sentry-build-plugin\" .env.sentry-build-plugin",
+    "run": "trap 'kill 0' SIGTERM SIGINT; npx convex dev & npm run dev -- --port $CONDUCTOR_PORT & wait",
+    "archive": ""
+  },
+  "runScriptMode": "nonconcurrent"
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -214,7 +214,11 @@ function SettingsPageInner() {
                 className="gap-1.5"
                 nativeButton={false}
                 render={
-                  <a href="https://discord.gg/Sa5ewWP5M" target="_blank" rel="noopener noreferrer" />
+                  <a
+                    href="https://discord.gg/Sa5ewWP5M"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
                 }
               >
                 Discord


### PR DESCRIPTION
## Summary
- Add `conductor.json` with setup/run/archive scripts for automated workspace provisioning (env symlinks, npm install, dev servers)
- Add 5 project slash commands: `/verify`, `/deploy`, `/backend-test`, `/frontend-test`, `/new-ai-tool`
- Add Conductor workspace docs to CLAUDE.md (port handling, env files, shared Convex deployment)
- Unignore `.claude/commands/` in `.gitignore` so slash commands are committed

## Test plan
- [ ] Create a new Conductor workspace and verify setup script runs (env symlinks created, npm install completes)
- [ ] Verify run script starts both Convex dev and Next.js on `$CONDUCTOR_PORT`
- [ ] Test each slash command works in a Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)