### PR TITLE
fix: fill SEO gaps across metadata, accessibility, and images

### DIFF
--- a/src/app/(app)/exercises/page.tsx
+++ b/src/app/(app)/exercises/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ErrorAlert } from "@/components/ErrorAlert";
+import Image from "next/image";
 import { Dumbbell, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
@@ -65,10 +66,12 @@ function ExerciseThumbnail({ src, name }: { src: string; name: string }) {
   }
 
   return (
-    <img
+    <Image
       src={src}
       alt={`${name} demonstration`}
-      loading="lazy"
+      width={56}
+      height={56}
+      unoptimized
       onError={() => setFailed(true)}
       className="size-14 shrink-0 rounded-lg bg-muted/50 object-cover"
     />

--- a/src/app/JsonLd.tsx
+++ b/src/app/JsonLd.tsx
@@ -39,6 +39,11 @@ export function JsonLd() {
               url: "https://tonal.coach",
               logo: "https://tonal.coach/icon.svg",
               sameAs: ["https://discord.gg/Sa5ewWP5M"],
+              contactPoint: {
+                "@type": "ContactPoint",
+                contactType: "customer support",
+                url: "https://tonal.coach/contact",
+              },
             },
             {
               "@type": "WebSite",

--- a/src/app/contact/layout.tsx
+++ b/src/app/contact/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Contact — tonal.coach",
+  title: "Contact",
   description:
     "Get in touch with the tonal.coach team. Questions, feedback, or partnership inquiries.",
   alternates: { canonical: "/contact" },

--- a/src/app/features/_mockups.tsx
+++ b/src/app/features/_mockups.tsx
@@ -1,12 +1,27 @@
 import type { ReactNode } from "react";
 
-function MockCard({ children, className = "" }: { children: ReactNode; className?: string }) {
-  return <div className={`rounded-xl bg-card p-4 ring-1 ring-border ${className}`}>{children}</div>;
+function MockCard({
+  children,
+  className = "",
+  label,
+}: {
+  children: ReactNode;
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <div
+      className={`rounded-xl bg-card p-4 ring-1 ring-border ${className}`}
+      {...(label ? { role: "img", "aria-label": label } : {})}
+    >
+      {children}
+    </div>
+  );
 }
 
 export function MockChat() {
   return (
-    <MockCard>
+    <MockCard label="Mockup of AI coach chat creating a push day workout">
       <div className="space-y-3 text-sm">
         <div className="rounded-lg bg-muted px-3 py-2 text-foreground">
           Give me a push day for tomorrow
@@ -31,7 +46,7 @@ export function MockChat() {
 
 export function MockPushToTonal() {
   return (
-    <MockCard>
+    <MockCard label="Mockup of a custom workout pushed to Tonal">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         Custom Workout
       </p>
@@ -58,7 +73,7 @@ export function MockProgressChart() {
   const weeks = ["W1", "W2", "W3", "W4", "W5", "W6"];
   const heights = [40, 48, 52, 56, 62, 68];
   return (
-    <MockCard>
+    <MockCard label="Mockup bar chart showing bench press weight increasing over 6 weeks">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         Bench Press — Weight Over Time
       </p>
@@ -83,7 +98,7 @@ export function MockPeriodization() {
     { label: "Deload", active: false },
   ];
   return (
-    <MockCard>
+    <MockCard label="Mockup of training periodization phases with hypertrophy active">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         Training Phase
       </p>
@@ -121,7 +136,7 @@ export function MockInjuryMap() {
     ok: "text-emerald-400 bg-emerald-400/15",
   };
   return (
-    <MockCard>
+    <MockCard label="Mockup of injury flags showing shoulder avoidance and lower back caution">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         Injury Flags
       </p>
@@ -156,7 +171,7 @@ export function MockReadiness() {
   ];
   const dot = { green: "bg-emerald-400", yellow: "bg-yellow-400", red: "bg-red-400" };
   return (
-    <MockCard>
+    <MockCard label="Mockup of muscle readiness status for six muscle groups">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         Muscle Readiness
       </p>
@@ -176,7 +191,7 @@ export function MockRpe() {
   const scale = [6, 7, 8, 9, 10];
   const selected = 8;
   return (
-    <MockCard>
+    <MockCard label="Mockup of RPE rating scale with 8 selected">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         How did that set feel?
       </p>
@@ -217,7 +232,7 @@ export function MockCheckins() {
     },
   ];
   return (
-    <MockCard>
+    <MockCard label="Mockup of proactive coach check-in messages throughout the week">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         Coach Check-ins
       </p>

--- a/src/app/how-it-works/_mockups.tsx
+++ b/src/app/how-it-works/_mockups.tsx
@@ -1,12 +1,27 @@
 import type { ReactNode } from "react";
 
-function MockCard({ children, className = "" }: { children: ReactNode; className?: string }) {
-  return <div className={`rounded-xl bg-card p-4 ring-1 ring-border ${className}`}>{children}</div>;
+function MockCard({
+  children,
+  className = "",
+  label,
+}: {
+  children: ReactNode;
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <div
+      className={`rounded-xl bg-card p-4 ring-1 ring-border ${className}`}
+      {...(label ? { role: "img", "aria-label": label } : {})}
+    >
+      {children}
+    </div>
+  );
 }
 
 export function MockConnect() {
   return (
-    <MockCard>
+    <MockCard label="Mockup of Tonal account connection form">
       <div className="mb-4 flex items-center gap-2">
         <div className="flex size-8 items-center justify-center rounded-full bg-primary/20 text-primary">
           <svg
@@ -16,6 +31,7 @@ export function MockConnect() {
             stroke="currentColor"
             strokeWidth="2"
             className="size-4"
+            aria-hidden="true"
           >
             <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
             <path d="M7 11V7a5 5 0 0 1 10 0v4" />
@@ -51,7 +67,7 @@ export function MockGoals() {
   const splits = ["Full Body", "Upper / Lower", "Push / Pull / Legs", "Body Part Split"];
   const injuries = ["Lower Back", "Shoulder", "Knee", "Wrist"];
   return (
-    <MockCard>
+    <MockCard label="Mockup of training preferences including split, frequency, and injury flags">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         Training Preferences
       </p>
@@ -102,7 +118,7 @@ export function MockGoals() {
 
 export function MockWorkoutPushed() {
   return (
-    <MockCard>
+    <MockCard label="Mockup of a custom workout pushed to Tonal">
       <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
         Custom Workout
       </p>
@@ -131,6 +147,7 @@ export function MockWorkoutPushed() {
           stroke="currentColor"
           strokeWidth="2"
           className="size-4"
+          aria-hidden="true"
         >
           <path d="M20 6 9 17l-5-5" />
         </svg>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -6,6 +6,8 @@ export const metadata: Metadata = {
   title: "Privacy Policy",
   description:
     "Privacy policy for tonal.coach. Learn how we handle your data, Tonal credentials, and account information.",
+  alternates: { canonical: "/privacy" },
+  robots: { index: true, follow: true },
 };
 
 export default function PrivacyPage() {

--- a/src/app/reset-password/layout.tsx
+++ b/src/app/reset-password/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Reset Password",
+  robots: { index: false, follow: false },
+};
+
+export default function ResetPasswordLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -43,6 +43,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
     },
     {
+      url: "https://tonal.coach/contact",
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
       url: "https://tonal.coach/privacy",
       lastModified: now,
       changeFrequency: "monthly",

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 export const metadata: Metadata = {
   title: "Terms of Service",
   description: "Terms of service for tonal.coach.",
+  alternates: { canonical: "/terms" },
+  robots: { index: true, follow: true },
 };
 
 export default function TermsPage() {

--- a/src/app/waitlist/layout.tsx
+++ b/src/app/waitlist/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Waitlist — tonal.coach",
+  title: "Waitlist",
   description:
     "Beta spots are full. Join the waitlist to get notified when tonal.coach opens up again.",
   alternates: { canonical: "/waitlist" },

--- a/src/app/workouts/_components/WorkoutBlockDisplay.tsx
+++ b/src/app/workouts/_components/WorkoutBlockDisplay.tsx
@@ -74,6 +74,7 @@ export function WorkoutBlockDisplay({ blocks, movementDetails }: WorkoutBlockDis
                         alt={name}
                         width={48}
                         height={48}
+                        unoptimized
                         className="h-12 w-12 shrink-0 rounded bg-muted object-cover"
                       />
                     ) : (


### PR DESCRIPTION
## Summary

- **Metadata gaps filled**: Added missing `robots`/`canonical` to `/privacy` and `/terms`; fixed duplicate title suffix on `/contact` and `/waitlist` layouts; added `noindex` metadata to `/reset-password` via new layout file
- **Sitemap**: Added `/contact` to sitemap
- **Accessibility**: Added `aria-hidden` to decorative SVGs in how-it-works mockups; added `role="img"` + `aria-label` to all 11 mockup components across features and how-it-works pages
- **Image optimization**: Converted exercise thumbnails to `next/image` with `unoptimized` flag to bypass Vercel proxy for external Tonal CDN images; added `unoptimized` to workout block thumbnails
- **Structured data**: Added `contactPoint` to global Organization JSON-LD schema

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 66 test files pass (736 tests)
- [ ] Verify `/privacy`, `/terms` pages render correct `<meta>` tags in browser
- [ ] Verify `/reset-password` has `noindex` meta tag
- [ ] Verify `/contact` title renders as "Contact | tonal.coach" (not "Contact - tonal.coach | tonal.coach")
- [ ] Verify exercise thumbnails still load on `/exercises` page
- [ ] Spot-check mockup `aria-label` attributes in DevTools on `/features` and `/how-it-works`

🤖 Generated with [Claude Code](https://claude.com/claude-code)