### PR TITLE
fix: prevent empty curated sections on workouts page

### DIFF
--- a/src/app/workouts/_components/WorkoutBrowseClient.tsx
+++ b/src/app/workouts/_components/WorkoutBrowseClient.tsx
@@ -164,18 +164,23 @@ export function WorkoutBrowseClient({ initialWorkouts }: Props) {
         /* ---- CURATED VIEW ---- */
         <>
           {CURATED_SECTIONS.map((section) => {
-            // Diversify: max 2 per session type to avoid all-Push sections
+            // Prefer diversity (max 2 per session type) but fill remaining
+            // slots from overflow so sections still render when the initial
+            // page skews toward one session type.
             const matched = workouts.filter(section.filter);
             const counts = new Map<string, number>();
-            const filtered: WorkoutCardData[] = [];
+            const preferred: WorkoutCardData[] = [];
+            const rest: WorkoutCardData[] = [];
             for (const w of matched) {
               const n = counts.get(w.sessionType) ?? 0;
               if (n < 2) {
-                filtered.push(w);
+                preferred.push(w);
                 counts.set(w.sessionType, n + 1);
+              } else {
+                rest.push(w);
               }
-              if (filtered.length >= 8) break;
             }
+            const filtered = [...preferred, ...rest].slice(0, 8);
             return (
               <CuratedSection
                 key={section.title}


### PR DESCRIPTION
## Summary

- The workouts browse page (`/workouts`) showed zero workout cards because the curated section diversity limiter was too aggressive
- Root cause: the `libraryWorkouts` table scan returns all push workouts first (first non-push at index 149), so the initial 48-item page contained only `sessionType: "push"`. The diversity limiter capped at 2 per session type, giving each curated section at most 2 items -- below `CuratedSection`'s minimum of 3 to render
- Changed the diversity limiter from a hard cap (discard overflow) to a soft preference (prioritize diverse items, then fill remaining slots from overflow)

## Test plan

- [ ] Visit `/workouts` with no filters -- curated sections (Quick Workouts, Build Muscle, Beginner Friendly) should render with workout cards
- [ ] Visit `/workouts?goal=build_muscle` -- filtered view should still work as before
- [ ] Verify curated sections still prefer diverse session types when the data supports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)