### PR TITLE
fix: mark sitemap route as dynamic to prevent build failure

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next";
 import { fetchQuery } from "convex/nextjs";
 import { api } from "../../convex/_generated/api";
 
+export const dynamic = "force-dynamic";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date().toISOString();
 


### PR DESCRIPTION
## Summary

- Fixes build error where `/sitemap.xml` failed static rendering because Convex `fetchQuery` uses `revalidate: 0` internally
- Adds `export const dynamic = "force-dynamic"` so the route is server-rendered at request time instead

## Changes

- `src/app/sitemap.ts`: Added `dynamic = "force-dynamic"` export

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [ ] New logic has tests (happy path + at least one error/edge case) -- N/A, config-only change
- [x] No file exceeds 300 lines
- [x] No function exceeds 60 lines
- [x] No new `any` types or unsafe `as` casts
- [ ] Tested in browser (if UI changes) -- N/A, no UI changes
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- Verified `npx tsc --noEmit` passes
- The sitemap already has a try/catch fallback to static URLs if the Convex fetch fails at runtime