### PR TITLE
fix: React best practices - server redirect and ThemeProvider reuse

### DIFF
--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,12 +1,5 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { redirect } from "next/navigation";
 
 export default function ProfilePage() {
-  const router = useRouter();
-  useEffect(() => {
-    router.replace("/settings");
-  }, [router]);
-  return null;
+  redirect("/settings");
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useConvexAuth, useQuery } from "convex/react";
@@ -22,6 +22,7 @@ import { CheckInBell } from "@/components/CheckInBell";
 import { ImpersonationBanner } from "@/components/admin/ImpersonationBanner";
 import { Button } from "@/components/ui/button";
 import { ReconnectModal } from "@/components/ReconnectModal";
+import { useTheme } from "@/components/ThemeProvider";
 
 const navLinks: Array<{
   href: string;
@@ -42,21 +43,18 @@ function mobileIsActive(pathname: string, href: string, exact?: boolean) {
 }
 
 function ThemeToggle() {
-  const [isDark, setIsDark] = useState(() =>
-    typeof document !== "undefined" ? document.documentElement.classList.contains("dark") : true,
-  );
-
-  const toggle = useCallback(() => {
-    const next = !isDark;
-    setIsDark(next);
-    document.documentElement.classList.toggle("dark", next);
-  }, [isDark]);
+  const { theme, setTheme } = useTheme();
+  const isDark =
+    theme === "dark" ||
+    (theme === "system" &&
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
 
   return (
     <Button
       variant="ghost"
       size="icon-sm"
-      onClick={toggle}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
       aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
       className="text-muted-foreground transition-colors duration-200 hover:text-foreground"
     >


### PR DESCRIPTION
## Summary

- Convert ProfilePage from client-side useEffect redirect to server component using Next.js `redirect()`, eliminating unnecessary JS bundle and render cycle
- Replace ThemeToggle's manual DOM classList manipulation with the existing `useTheme()` hook from ThemeProvider, consolidating to a single source of truth with localStorage persistence and system theme support

## Changes

**`src/app/(app)/profile/page.tsx`**
- Removed `"use client"` directive, `useRouter`, and `useEffect`
- Now a server component using `redirect("/settings")` from `next/navigation`

**`src/components/AppShell.tsx`**
- `ThemeToggle` now uses `useTheme()` from the existing `ThemeProvider` instead of standalone `useState` + direct DOM manipulation
- Removed unused `useCallback` import

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [ ] `npm test` passes (existing + new tests)
- [x] No file exceeds 300 lines
- [x] No function exceeds 60 lines
- [x] No new `any` types or unsafe `as` casts
- [ ] Tested in browser (if UI changes)
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- Verify `/profile` redirects to `/settings` without client-side flash
- Verify theme toggle still switches between light and dark mode
- Verify theme preference persists across page reloads (localStorage)