### PR TITLE
fix: move Discord webhook URL to env var

### DIFF
--- a/convex/discord.ts
+++ b/convex/discord.ts
@@ -6,8 +6,9 @@
 import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
 
-const WEBHOOK_URL =
-  "https://discord.com/api/webhooks/1482961555363463270/cRsuQdz-rDFftePjkRZKoSNsppldhnbrePBnuYscoQ-PKR7yLKdqIcpBqfPsXcCcH6MW";
+function getWebhookUrl(): string | undefined {
+  return process.env.DISCORD_WEBHOOK_URL;
+}
 
 const COLORS = {
   signup: 0x00cacb, // teal — new signup
@@ -21,8 +22,11 @@ async function postToDiscord(embed: {
   color: number;
   fields?: { name: string; value: string; inline?: boolean }[];
 }) {
+  const url = getWebhookUrl();
+  if (!url) return;
+
   try {
-    await fetch(WEBHOOK_URL, {
+    await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Moved hardcoded Discord webhook URL to `DISCORD_WEBHOOK_URL` env var
- If the env var is not set, all Discord notifications silently skip
- Silences health check spam on dev deployments while keeping prod notifications active

## Test plan
- [x] Verified `DISCORD_WEBHOOK_URL` is set on prod Convex deployment
- [ ] Confirm dev Discord spam stops after deploy
- [ ] Confirm prod notifications still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)