### PR TITLE
fix: use any valid token for catalog syncs

### DIFF
--- a/convex/tonal/movementSync.test.ts
+++ b/convex/tonal/movementSync.test.ts
@@ -251,21 +251,60 @@ describe("insert vs update decision", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Active user selection for sync
+// Token-based user selection for sync
 // ---------------------------------------------------------------------------
 
-describe("active user selection for sync", () => {
-  it("skips sync when no active users found", () => {
-    const activeUsers: Array<{ userId: string }> = [];
+describe("token user selection for sync", () => {
+  interface TokenUser {
+    userId: string;
+    tonalTokenExpiresAt: number | undefined;
+  }
 
-    const shouldSync = activeUsers.length > 0;
+  /** Mirrors the selection logic in getUserWithValidToken. */
+  function pickTokenUser(profiles: TokenUser[], now: number): TokenUser | null {
+    // Prefer a user with a non-expired token
+    const valid = profiles.find((p) => p.tonalTokenExpiresAt && p.tonalTokenExpiresAt > now);
+    if (valid) return valid;
+    // Fallback: any connected user (withTokenRetry can refresh)
+    return profiles[0] ?? null;
+  }
 
-    expect(shouldSync).toBe(false);
+  it("skips sync when no connected users exist", () => {
+    const result = pickTokenUser([], Date.now());
+
+    expect(result).toBeNull();
   });
 
-  it("uses first active user for token", () => {
-    const activeUsers = [{ userId: "user-1" }, { userId: "user-2" }];
+  it("prefers user with non-expired token", () => {
+    const now = Date.now();
+    const profiles: TokenUser[] = [
+      { userId: "expired-user", tonalTokenExpiresAt: now - 1000 },
+      { userId: "valid-user", tonalTokenExpiresAt: now + 3600_000 },
+    ];
 
-    expect(activeUsers[0].userId).toBe("user-1");
+    const result = pickTokenUser(profiles, now);
+
+    expect(result?.userId).toBe("valid-user");
+  });
+
+  it("falls back to any user when all tokens are expired", () => {
+    const now = Date.now();
+    const profiles: TokenUser[] = [
+      { userId: "expired-1", tonalTokenExpiresAt: now - 5000 },
+      { userId: "expired-2", tonalTokenExpiresAt: now - 1000 },
+    ];
+
+    const result = pickTokenUser(profiles, now);
+
+    expect(result?.userId).toBe("expired-1");
+  });
+
+  it("falls back to user with no expiry set", () => {
+    const now = Date.now();
+    const profiles: TokenUser[] = [{ userId: "no-expiry", tonalTokenExpiresAt: undefined }];
+
+    const result = pickTokenUser(profiles, now);
+
+    expect(result?.userId).toBe("no-expiry");
   });
 });

--- a/convex/tonal/movementSync.ts
+++ b/convex/tonal/movementSync.ts
@@ -43,18 +43,15 @@ export const syncMovementCatalog = internalAction({
     const MAX_RETRIES = 2;
     const RETRY_DELAY_MS = 10 * 60 * 1000; // 10 minutes
     try {
-      // Pick any active user's token (movements are global, any auth token works)
-      const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
-      const activeUsers = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
-        sinceTimestamp: oneDayAgo,
-      });
+      // Pick any user with a valid Tonal token (movements are global)
+      const tokenUser = await ctx.runQuery(internal.userProfiles.getUserWithValidToken);
 
-      if (activeUsers.length === 0) {
-        console.warn("[movementSync] No active users found — skipping catalog sync");
+      if (!tokenUser) {
+        console.warn("[movementSync] No connected users found - skipping catalog sync");
         return;
       }
 
-      const movements = await withTokenRetry(ctx, activeUsers[0].userId, (token) =>
+      const movements = await withTokenRetry(ctx, tokenUser.userId, (token) =>
         tonalFetch<Movement[]>(token, "/v6/movements"),
       );
       const now = Date.now();

--- a/convex/tonal/workoutCatalogSync.ts
+++ b/convex/tonal/workoutCatalogSync.ts
@@ -138,17 +138,14 @@ export const syncWorkoutCatalog = internalAction({
     const MAX_RETRIES = 2;
     const RETRY_DELAY_MS = 10 * 60 * 1000; // 10 minutes
     try {
-      const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
-      const activeUsers = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
-        sinceTimestamp: oneDayAgo,
-      });
+      const tokenUser = await ctx.runQuery(internal.userProfiles.getUserWithValidToken);
 
-      if (activeUsers.length === 0) {
-        console.warn("[workoutCatalogSync] No active users — skipping");
+      if (!tokenUser) {
+        console.warn("[workoutCatalogSync] No connected users - skipping");
         return;
       }
 
-      await withTokenRetry(ctx, activeUsers[0].userId, async (token) => {
+      await withTokenRetry(ctx, tokenUser.userId, async (token) => {
         // 1. Fetch and upsert training types
         const trainingTypes = await tonalFetch<TrainingType[]>(token, "/v6/training-types");
         const typeMap = new Map<string, string>();

--- a/convex/userProfiles.ts
+++ b/convex/userProfiles.ts
@@ -125,10 +125,7 @@ export const markTokenExpired = internalMutation({
       .query("userProfiles")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .unique();
-
-    if (profile) {
-      await ctx.db.patch(profile._id, { tonalTokenExpiresAt: 0 });
-    }
+    if (profile) await ctx.db.patch(profile._id, { tonalTokenExpiresAt: 0 });
   },
 });
 
@@ -149,6 +146,19 @@ export const getActiveUsers = internalQuery({
   handler: async (ctx, { sinceTimestamp }) => {
     const profiles = await ctx.db.query("userProfiles").collect();
     return profiles.filter((p) => p.lastActiveAt > sinceTimestamp);
+  },
+});
+
+/** Pick any user with a valid Tonal token for global API calls (catalog syncs). */
+export const getUserWithValidToken = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const valid = await ctx.db
+      .query("userProfiles")
+      .withIndex("by_tonalTokenExpiresAt", (q) => q.gt("tonalTokenExpiresAt", Date.now()))
+      .first();
+    // Fallback: any connected user (withTokenRetry can refresh expired tokens)
+    return valid ?? (await ctx.db.query("userProfiles").first());
   },
 });
 


### PR DESCRIPTION
## Summary
- Movement and workout catalog syncs required a user active in the last 24h to borrow a Tonal API token. During quiet periods, syncs silently skipped, leaving the health check alerting "Movement sync stale (never)" every 15 minutes.
- Added `getUserWithValidToken` query that picks any user with a non-expired token (via `by_tonalTokenExpiresAt` index), falling back to any connected user since `withTokenRetry` handles token refresh.
- Updated both `movementSync` and `workoutCatalogSync` to use the new query instead of `getActiveUsers`.

## Test plan
- [x] Updated `movementSync.test.ts` with 4 new tests covering token-based user selection (no users, prefer valid, fallback on expired, fallback on no expiry)
- [x] All 27 existing tests pass across healthCheck, movementSync, and workoutCatalogSync
- [x] Type-check passes
- [ ] Monitor Discord for absence of "Movement sync stale" alerts after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)