### PR TITLE
feat: sync Tonal profile data to users table

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -110,6 +110,7 @@ import type * as tonal_historySyncMutations from "../tonal/historySyncMutations.
 import type * as tonal_movementSearch from "../tonal/movementSearch.js";
 import type * as tonal_movementSync from "../tonal/movementSync.js";
 import type * as tonal_mutations from "../tonal/mutations.js";
+import type * as tonal_profileBackfill from "../tonal/profileBackfill.js";
 import type * as tonal_proxy from "../tonal/proxy.js";
 import type * as tonal_tokenRefresh from "../tonal/tokenRefresh.js";
 import type * as tonal_tokenRetry from "../tonal/tokenRetry.js";
@@ -240,6 +241,7 @@ declare const fullApi: ApiFromModules<{
   "tonal/movementSearch": typeof tonal_movementSearch;
   "tonal/movementSync": typeof tonal_movementSync;
   "tonal/mutations": typeof tonal_mutations;
+  "tonal/profileBackfill": typeof tonal_profileBackfill;
   "tonal/proxy": typeof tonal_proxy;
   "tonal/tokenRefresh": typeof tonal_tokenRefresh;
   "tonal/tokenRetry": typeof tonal_tokenRetry;

--- a/convex/ai/context.test.ts
+++ b/convex/ai/context.test.ts
@@ -7,6 +7,7 @@ import {
   type SnapshotSection,
   trimSnapshot,
 } from "./context";
+import { computeAge } from "./snapshotHelpers";
 import type { ExternalActivity, Movement } from "../tonal/types";
 import type { OwnedAccessories } from "../tonal/accessories";
 
@@ -71,9 +72,7 @@ describe("trimSnapshot", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
 // HR intensity labels
-// ---------------------------------------------------------------------------
 
 describe("getHrIntensityLabel", () => {
   it("returns null for zero HR", () => {
@@ -101,9 +100,7 @@ describe("getHrIntensityLabel", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
 // Format line
-// ---------------------------------------------------------------------------
 
 describe("formatExternalActivityLine", () => {
   function makeExternal(overrides: Partial<ExternalActivity> = {}): ExternalActivity {
@@ -149,9 +146,7 @@ describe("formatExternalActivityLine", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
 // Recency labels
-// ---------------------------------------------------------------------------
 
 describe("getRecencyLabel", () => {
   it("returns 'today' for same-day timestamps", () => {
@@ -180,9 +175,7 @@ describe("getRecencyLabel", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
 // Exercise catalog section
-// ---------------------------------------------------------------------------
 
 describe("buildExerciseCatalogSection", () => {
   function makeMovement(overrides: Partial<Movement> = {}): Movement {
@@ -380,5 +373,27 @@ describe("buildExerciseCatalogSection", () => {
     const movements = [makeMovement()];
     const section = buildExerciseCatalogSection(movements, allOwned);
     expect(section!.priority).toBe(6.5);
+  });
+});
+
+// computeAge
+
+describe("computeAge", () => {
+  it("computes age correctly before birthday this year", () => {
+    const now = new Date("2026-03-28");
+    expect(computeAge("1993-12-15", now)).toBe(32);
+  });
+
+  it("computes age correctly after birthday this year", () => {
+    const now = new Date("2026-03-28");
+    expect(computeAge("1993-01-10", now)).toBe(33);
+  });
+
+  it("returns null for undefined dateOfBirth", () => {
+    expect(computeAge(undefined, new Date())).toBeNull();
+  });
+
+  it("returns null for invalid date string", () => {
+    expect(computeAge("not-a-date", new Date())).toBeNull();
   });
 });

--- a/convex/ai/context.ts
+++ b/convex/ai/context.ts
@@ -109,12 +109,8 @@ export async function buildTrainingSnapshot(
 
   // Priority 1: User profile + onboarding + preferences
   const profileLines: string[] = [];
-  const ageSuffix = pd.dateOfBirth
-    ? (() => {
-        const age = computeAge(pd.dateOfBirth, new Date());
-        return age !== null ? ` | Age: ${age}` : "";
-      })()
-    : "";
+  const age = computeAge(pd.dateOfBirth, new Date());
+  const ageSuffix = age !== null ? ` | Age: ${age}` : "";
   profileLines.push(
     `User: ${pd.firstName} ${pd.lastName} | ${pd.heightInches}"/${pd.weightPounds}lbs${ageSuffix} | Level: ${pd.level} | ${pd.workoutsPerWeek}x/week`,
   );

--- a/convex/ai/context.ts
+++ b/convex/ai/context.ts
@@ -17,6 +17,7 @@ import { getRecencyLabel } from "./timeDecay";
 import {
   buildExerciseCatalogSection,
   buildHealthSection,
+  computeAge,
   formatExternalActivityLine,
   getHrIntensityLabel,
   type HealthSnapshotData,
@@ -107,9 +108,16 @@ export async function buildTrainingSnapshot(
   const sections: SnapshotSection[] = [];
 
   // Priority 1: User profile + onboarding + preferences
-  const profileLines: string[] = [
-    `User: ${pd.firstName} ${pd.lastName} | ${pd.heightInches}"/${pd.weightPounds}lbs | Level: ${pd.level} | ${pd.workoutsPerWeek}x/week`,
-  ];
+  const profileLines: string[] = [];
+  const ageSuffix = pd.dateOfBirth
+    ? (() => {
+        const age = computeAge(pd.dateOfBirth, new Date());
+        return age !== null ? ` | Age: ${age}` : "";
+      })()
+    : "";
+  profileLines.push(
+    `User: ${pd.firstName} ${pd.lastName} | ${pd.heightInches}"/${pd.weightPounds}lbs${ageSuffix} | Level: ${pd.level} | ${pd.workoutsPerWeek}x/week`,
+  );
   const onboardingData = profile?.onboardingData;
   const trainingPrefs = profile?.trainingPreferences;
   if (onboardingData?.goal) {

--- a/convex/ai/snapshotHelpers.ts
+++ b/convex/ai/snapshotHelpers.ts
@@ -40,9 +40,7 @@ export function trimSnapshot(sections: SnapshotSection[], maxChars: number): str
   return [header, body, footer].filter(Boolean).join("\n");
 }
 
-// ---------------------------------------------------------------------------
 // External activity helpers
-// ---------------------------------------------------------------------------
 
 export function getHrIntensityLabel(hr: number): string | null {
   if (hr === 0) return null;
@@ -78,9 +76,7 @@ export function formatExternalActivityLine(a: ExternalActivity): string {
   return line;
 }
 
-// ---------------------------------------------------------------------------
 // Exercise catalog helpers
-// ---------------------------------------------------------------------------
 
 /** Placeholder movements that exist in the API but aren't real exercises. */
 const PLACEHOLDER_NAMES = new Set([
@@ -174,9 +170,7 @@ function resolveGroupName(apiAccessory: string | undefined): string {
   return ACCESSORY_DISPLAY[profileKey];
 }
 
-// ---------------------------------------------------------------------------
 // Health snapshot helpers
-// ---------------------------------------------------------------------------
 
 /** Minimal shape of a health snapshot document for the summary builder. */
 export interface HealthSnapshotData {
@@ -390,4 +384,17 @@ export function buildHealthSection(
   }
 
   return { priority: 8.5, lines: [header, ...lines] };
+}
+
+/** Compute age in years from an ISO date-of-birth string. Returns null if invalid. */
+export function computeAge(dateOfBirth: string | undefined, now: Date): number | null {
+  if (!dateOfBirth) return null;
+  const dob = new Date(dateOfBirth);
+  if (isNaN(dob.getTime())) return null;
+  let age = now.getFullYear() - dob.getFullYear();
+  const monthDiff = now.getMonth() - dob.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < dob.getDate())) {
+    age--;
+  }
+  return age;
 }

--- a/convex/ai/tools.ts
+++ b/convex/ai/tools.ts
@@ -247,9 +247,12 @@ export const createWorkoutTool = createTool({
 
       // Pre-validate movement IDs against the movements table
       const allMovementIds = input.blocks.flatMap((b) => b.exercises.map((e) => e.movementId));
-      const validatedMovements = await ctx.runQuery(internal.tonal.movementSync.getByTonalIds, {
-        tonalIds: allMovementIds,
-      });
+      const validatedMovements: Movement[] = await ctx.runQuery(
+        internal.tonal.movementSync.getByTonalIds,
+        {
+          tonalIds: allMovementIds,
+        },
+      );
       const validIds = new Set(validatedMovements.map((m) => m.id));
       const invalidIds = allMovementIds.filter((id) => !validIds.has(id));
       if (invalidIds.length > 0) {

--- a/convex/ai/weekTools.ts
+++ b/convex/ai/weekTools.ts
@@ -213,7 +213,7 @@ export const getWeekPlanDetailsTool = createTool({
       }
 
       // Load movement catalog for name resolution
-      const catalog = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
+      const catalog: Movement[] = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
       const movementMap = new Map(catalog.map((m) => [m.id, m]));
 
       // Resolve each day's workout details

--- a/convex/coach/weekModifications.ts
+++ b/convex/coach/weekModifications.ts
@@ -9,7 +9,7 @@
 import { v } from "convex/values";
 import { internalAction, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import type { Movement } from "../tonal/types";
 import { selectExercises } from "./exerciseSelection";
 import { computeExcludedAccessories } from "../tonal/accessories";
@@ -194,7 +194,12 @@ export const adjustDayDuration = internalAction({
       SESSION_DURATION_TO_MAX_EXERCISES[newDurationMinutes] ?? DEFAULT_MAX_EXERCISES;
 
     // Fetch catalog, recent movement IDs, user profile, and active injuries in parallel
-    const [catalog, lastUsedMovementIds, profile, activeInjuries] = await Promise.all([
+    const [catalog, lastUsedMovementIds, profile, activeInjuries]: [
+      Movement[],
+      string[],
+      Doc<"userProfiles"> | null,
+      Doc<"injuries">[],
+    ] = await Promise.all([
       ctx.runQuery(internal.tonal.movementSync.getAllMovements),
       ctx.runQuery(internal.workoutPlans.getRecentMovementIds, { userId }),
       ctx.runQuery(internal.userProfiles.getByUserId, { userId }),

--- a/convex/coach/weekProgramming.ts
+++ b/convex/coach/weekProgramming.ts
@@ -7,7 +7,7 @@ import { v } from "convex/values";
 import type { ActionCtx } from "../_generated/server";
 import { internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import {
   getWeekStartDateString,
   isValidWeekStartDateString,
@@ -58,7 +58,12 @@ export async function fetchAndComputePlanData(
   daySessions: { dayIndex: number; sessionType: SessionType }[];
   initialDays: { sessionType: SessionType | "rest"; status: "programmed" }[];
 }> {
-  const [profile, catalog, lastUsedMovementIds, activeInjuries] = await Promise.all([
+  const [profile, catalog, lastUsedMovementIds, activeInjuries]: [
+    Doc<"userProfiles"> | null,
+    Movement[],
+    string[],
+    Doc<"injuries">[],
+  ] = await Promise.all([
     ctx.runQuery(internal.userProfiles.getByUserId, { userId }),
     ctx.runQuery(internal.tonal.movementSync.getAllMovements),
     ctx.runQuery(internal.workoutPlans.getRecentMovementIds, { userId }),

--- a/convex/mcp/tools/analytics.ts
+++ b/convex/mcp/tools/analytics.ts
@@ -1,7 +1,12 @@
 import type { ToolContext, ToolDefinition, ToolHandler } from "../registry";
 import { internal } from "../../_generated/api";
 import { aggregateProgressMetrics, aggregateTrainingFrequency } from "./aggregations";
-import type { WorkoutActivityDetail } from "../../tonal/types";
+import type {
+  Activity,
+  FormattedWorkoutSummary,
+  Movement,
+  WorkoutActivityDetail,
+} from "../../tonal/types";
 
 // --- Tool handlers ---
 
@@ -10,10 +15,13 @@ async function listWorkoutHistory(
   args: Record<string, unknown>,
 ): Promise<{ content: Array<{ type: "text"; text: string }> }> {
   const limit = (args.limit as number | undefined) ?? 20;
-  const activities = await toolCtx.ctx.runAction(internal.tonal.proxy.fetchWorkoutHistory, {
-    userId: toolCtx.userId,
-    limit,
-  });
+  const activities: Activity[] = await toolCtx.ctx.runAction(
+    internal.tonal.proxy.fetchWorkoutHistory,
+    {
+      userId: toolCtx.userId,
+      limit,
+    },
+  );
 
   const summary = activities.map((a) => ({
     activityId: a.activityId,
@@ -54,7 +62,7 @@ async function getWorkoutMovements(
 ): Promise<{ content: Array<{ type: "text"; text: string }> }> {
   const activityId = args.activityId as string;
 
-  const [detail, formatted, movements] = await Promise.all([
+  const [detail, formatted, movements] = (await Promise.all([
     toolCtx.ctx.runAction(internal.tonal.proxy.fetchWorkoutDetail, {
       userId: toolCtx.userId,
       activityId,
@@ -66,7 +74,7 @@ async function getWorkoutMovements(
       })
       .catch(() => null),
     toolCtx.ctx.runQuery(internal.tonal.movementSync.getAllMovements),
-  ]);
+  ])) as [WorkoutActivityDetail | null, FormattedWorkoutSummary | null, Movement[]];
 
   if (!detail) {
     return { content: [{ type: "text", text: "Workout activity not found." }] };

--- a/convex/progressiveOverload.ts
+++ b/convex/progressiveOverload.ts
@@ -7,7 +7,12 @@
 import { v } from "convex/values";
 import { action, internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
-import type { FormattedWorkoutSummary, SetActivity, WorkoutActivityDetail } from "./tonal/types";
+import type {
+  FormattedWorkoutSummary,
+  Movement,
+  SetActivity,
+  WorkoutActivityDetail,
+} from "./tonal/types";
 import { generatePerformanceSummary } from "./coach/prDetection";
 
 const WEIGHT_STEP_LBS = 2.5;
@@ -187,7 +192,7 @@ export const getWorkoutPerformanceSummary = internalAction({
     });
 
     // 2. Get movement names from movements table
-    const movements = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
+    const movements: Movement[] = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
     const nameMap = new Map(movements.map((m) => [m.id, m.name]));
 
     // 3. Generate summary

--- a/convex/schedule.ts
+++ b/convex/schedule.ts
@@ -8,6 +8,7 @@ import { action } from "./_generated/server";
 import { api, internal } from "./_generated/api";
 import type { Doc } from "./_generated/dataModel";
 import type { EnrichedWeekPlan } from "./weekPlanEnriched";
+import type { Movement } from "./tonal/types";
 import { DAY_NAMES } from "./coach/weekProgrammingHelpers";
 
 // ---------------------------------------------------------------------------
@@ -99,7 +100,7 @@ export const getScheduleData = action({
     // 4. Fetch movement catalog for name resolution
     let movementMap = new Map<string, string>();
     if (allMovementIds.size > 0) {
-      const movements = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
+      const movements: Movement[] = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
       movementMap = new Map(movements.map((m) => [m.id, m.name]));
     }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -9,6 +9,10 @@ export default defineSchema({
   /** Override the auth users table to add admin impersonation fields. */
   users: defineTable({
     name: v.optional(v.string()),
+    /** First name from Tonal profile. */
+    firstName: v.optional(v.string()),
+    /** Last name from Tonal profile. */
+    lastName: v.optional(v.string()),
     image: v.optional(v.string()),
     email: v.optional(v.string()),
     emailVerificationTime: v.optional(v.number()),
@@ -41,6 +45,9 @@ export default defineSchema({
         workoutsPerWeek: v.number(),
         workoutDurationMin: v.number(),
         workoutDurationMax: v.number(),
+        dateOfBirth: v.optional(v.string()),
+        username: v.optional(v.string()),
+        tonalCreatedAt: v.optional(v.string()),
       }),
     ),
     lastActiveAt: v.number(),

--- a/convex/tonal/connect.ts
+++ b/convex/tonal/connect.ts
@@ -45,8 +45,11 @@ export const connectTonal = internalAction({
         gender: profile.gender,
         level: profile.tonalStatus ?? "",
         workoutsPerWeek: profile.workoutsPerWeek,
-        workoutDurationMin: (profile as unknown as Record<string, number>).workoutDurationMin ?? 0,
-        workoutDurationMax: (profile as unknown as Record<string, number>).workoutDurationMax ?? 0,
+        workoutDurationMin: profile.workoutDurationMin ?? 0,
+        workoutDurationMax: profile.workoutDurationMax ?? 0,
+        dateOfBirth: profile.dateOfBirth || undefined,
+        username: profile.username || undefined,
+        tonalCreatedAt: profile.createdAt || undefined,
       },
     });
 

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -11,7 +11,12 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
 import { aggregateDetailToSessions } from "../progressiveOverload";
-import type { Activity, FormattedWorkoutSummary, WorkoutActivityDetail } from "./types";
+import type {
+  Activity,
+  FormattedWorkoutSummary,
+  StrengthScoreHistoryEntry,
+  WorkoutActivityDetail,
+} from "./types";
 import type { performanceValidator, workoutValidator } from "./historySyncMutations";
 
 type WorkoutPayload = typeof workoutValidator.type;
@@ -151,9 +156,12 @@ async function syncActivitiesAndStrength(
 
   // Sync strength score history
   try {
-    const strengthHistory = await ctx.runAction(internal.tonal.proxy.fetchStrengthHistory, {
-      userId,
-    });
+    const strengthHistory: StrengthScoreHistoryEntry[] = await ctx.runAction(
+      internal.tonal.proxy.fetchStrengthHistory,
+      {
+        userId,
+      },
+    );
     if (strengthHistory.length > 0) {
       const snapshots = strengthHistory.map((entry) => ({
         date: entry.activityTime.slice(0, 10),

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -200,8 +200,11 @@ async function maybeRefreshProfile(ctx: ActionCtx, userId: Id<"users">): Promise
         gender: u.gender,
         level: u.tonalStatus ?? "",
         workoutsPerWeek: u.workoutsPerWeek,
-        workoutDurationMin: (u as unknown as Record<string, number>).workoutDurationMin ?? 0,
-        workoutDurationMax: (u as unknown as Record<string, number>).workoutDurationMax ?? 0,
+        workoutDurationMin: u.workoutDurationMin ?? 0,
+        workoutDurationMax: u.workoutDurationMax ?? 0,
+        dateOfBirth: u.dateOfBirth || undefined,
+        username: u.username || undefined,
+        tonalCreatedAt: u.createdAt || undefined,
       },
     });
   } catch (err) {

--- a/convex/tonal/profileBackfill.ts
+++ b/convex/tonal/profileBackfill.ts
@@ -1,5 +1,6 @@
 import { internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
+import type { Doc } from "../_generated/dataModel";
 
 /**
  * One-time backfill: fetch fresh Tonal profile for all users and sync
@@ -10,10 +11,13 @@ import { internal } from "../_generated/api";
  */
 export const backfillAllProfiles = internalAction({
   args: {},
-  handler: async (ctx) => {
-    const profiles = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
-      sinceTimestamp: 0,
-    });
+  handler: async (ctx): Promise<{ success: number; failed: number; total: number }> => {
+    const profiles: Doc<"userProfiles">[] = await ctx.runQuery(
+      internal.userProfiles.getActiveUsers,
+      {
+        sinceTimestamp: 0,
+      },
+    );
 
     let success = 0;
     let failed = 0;

--- a/convex/tonal/profileBackfill.ts
+++ b/convex/tonal/profileBackfill.ts
@@ -1,0 +1,55 @@
+import { internalAction } from "../_generated/server";
+import { internal } from "../_generated/api";
+
+/**
+ * One-time backfill: fetch fresh Tonal profile for all users and sync
+ * new fields (dateOfBirth, username, tonalCreatedAt) into userProfiles
+ * and name fields into the users table.
+ *
+ * Run manually: npx convex run --prod tonal/profileBackfill:backfillAllProfiles
+ */
+export const backfillAllProfiles = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const profiles = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
+      sinceTimestamp: 0,
+    });
+
+    let success = 0;
+    let failed = 0;
+
+    for (const profile of profiles) {
+      try {
+        const u = await ctx.runAction(internal.tonal.proxy.fetchUserProfile, {
+          userId: profile.userId,
+        });
+        await ctx.runMutation(internal.userProfiles.updateProfileData, {
+          userId: profile.userId,
+          profileData: {
+            firstName: u.firstName,
+            lastName: u.lastName,
+            heightInches: u.heightInches,
+            weightPounds: u.weightPounds,
+            gender: u.gender,
+            level: u.tonalStatus ?? "",
+            workoutsPerWeek: u.workoutsPerWeek,
+            workoutDurationMin: u.workoutDurationMin ?? 0,
+            workoutDurationMax: u.workoutDurationMax ?? 0,
+            dateOfBirth: u.dateOfBirth || undefined,
+            username: u.username || undefined,
+            tonalCreatedAt: u.createdAt || undefined,
+          },
+        });
+        success++;
+      } catch (err) {
+        failed++;
+        console.error(`[profileBackfill] Failed for user ${profile.userId}:`, err);
+      }
+    }
+
+    console.log(
+      `[profileBackfill] Complete: ${success} succeeded, ${failed} failed out of ${profiles.length} total`,
+    );
+    return { success, failed, total: profiles.length };
+  },
+});

--- a/convex/tonal/types.ts
+++ b/convex/tonal/types.ts
@@ -11,6 +11,8 @@ export interface TonalUser {
   dateOfBirth: string;
   username: string;
   workoutsPerWeek: number;
+  workoutDurationMin: number;
+  workoutDurationMax: number;
   tonalStatus: string;
   accountType: string;
   location: string;

--- a/convex/userProfiles.ts
+++ b/convex/userProfiles.ts
@@ -4,6 +4,21 @@ import { internal } from "./_generated/api";
 import { getEffectiveUserId } from "./lib/auth";
 import { computeBetaCapacity } from "./betaConfig";
 
+const profileDataValidator = v.object({
+  firstName: v.string(),
+  lastName: v.string(),
+  heightInches: v.number(),
+  weightPounds: v.number(),
+  gender: v.string(),
+  level: v.string(),
+  workoutsPerWeek: v.number(),
+  workoutDurationMin: v.number(),
+  workoutDurationMax: v.number(),
+  dateOfBirth: v.optional(v.string()),
+  username: v.optional(v.string()),
+  tonalCreatedAt: v.optional(v.string()),
+});
+
 export const getByUserId = internalQuery({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
@@ -22,21 +37,18 @@ export const create = internalMutation({
     tonalToken: v.string(),
     tonalRefreshToken: v.optional(v.string()),
     tonalTokenExpiresAt: v.optional(v.number()),
-    profileData: v.optional(
-      v.object({
-        firstName: v.string(),
-        lastName: v.string(),
-        heightInches: v.number(),
-        weightPounds: v.number(),
-        gender: v.string(),
-        level: v.string(),
-        workoutsPerWeek: v.number(),
-        workoutDurationMin: v.number(),
-        workoutDurationMax: v.number(),
-      }),
-    ),
+    profileData: v.optional(profileDataValidator),
   },
   handler: async (ctx, args) => {
+    // Sync first/last name to users table for direct access
+    if (args.profileData) {
+      await ctx.db.patch(args.userId, {
+        firstName: args.profileData.firstName,
+        lastName: args.profileData.lastName,
+        name: `${args.profileData.firstName} ${args.profileData.lastName}`,
+      });
+    }
+
     // Upsert: check if profile exists
     const existing = await ctx.db
       .query("userProfiles")
@@ -321,17 +333,7 @@ export const updateLastSyncedActivityDate = internalMutation({
 export const updateProfileData = internalMutation({
   args: {
     userId: v.id("users"),
-    profileData: v.object({
-      firstName: v.string(),
-      lastName: v.string(),
-      heightInches: v.number(),
-      weightPounds: v.number(),
-      gender: v.string(),
-      level: v.string(),
-      workoutsPerWeek: v.number(),
-      workoutDurationMin: v.number(),
-      workoutDurationMax: v.number(),
-    }),
+    profileData: profileDataValidator,
   },
   handler: async (ctx, { userId, profileData }) => {
     const profile = await ctx.db
@@ -342,6 +344,13 @@ export const updateProfileData = internalMutation({
     await ctx.db.patch(profile._id, {
       profileData,
       profileDataRefreshedAt: Date.now(),
+    });
+
+    // Sync first/last name to users table for direct access
+    await ctx.db.patch(userId, {
+      firstName: profileData.firstName,
+      lastName: profileData.lastName,
+      name: `${profileData.firstName} ${profileData.lastName}`,
     });
   },
 });

--- a/convex/userProfiles.ts
+++ b/convex/userProfiles.ts
@@ -40,7 +40,6 @@ export const create = internalMutation({
     profileData: v.optional(profileDataValidator),
   },
   handler: async (ctx, args) => {
-    // Sync first/last name to users table for direct access
     if (args.profileData) {
       await ctx.db.patch(args.userId, {
         firstName: args.profileData.firstName,
@@ -49,7 +48,6 @@ export const create = internalMutation({
       });
     }
 
-    // Upsert: check if profile exists
     const existing = await ctx.db
       .query("userProfiles")
       .withIndex("by_userId", (q) => q.eq("userId", args.userId))
@@ -105,9 +103,7 @@ export const updateTonalToken = internalMutation({
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .unique();
 
-    if (!profile) {
-      throw new Error("User profile not found");
-    }
+    if (!profile) throw new Error("User profile not found");
 
     // Freshness guard: skip if DB already has a newer token.
     // Prevents race between cron refresh and on-demand withTokenRetry.
@@ -341,12 +337,8 @@ export const updateProfileData = internalMutation({
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .unique();
     if (!profile) throw new Error("User profile not found");
-    await ctx.db.patch(profile._id, {
-      profileData,
-      profileDataRefreshedAt: Date.now(),
-    });
+    await ctx.db.patch(profile._id, { profileData, profileDataRefreshedAt: Date.now() });
 
-    // Sync first/last name to users table for direct access
     await ctx.db.patch(userId, {
       firstName: profileData.firstName,
       lastName: profileData.lastName,
@@ -389,9 +381,7 @@ export const releaseTokenRefreshLock = internalMutation({
       .query("userProfiles")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .unique();
-    if (profile) {
-      await ctx.db.patch(profile._id, { tokenRefreshInProgress: undefined });
-    }
+    if (profile) await ctx.db.patch(profile._id, { tokenRefreshInProgress: undefined });
   },
 });
 

--- a/convex/workoutDetail.ts
+++ b/convex/workoutDetail.ts
@@ -58,19 +58,21 @@ export const getWorkoutDetail = action({
     const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 
-    const [detail, movements, formattedSummary] = await Promise.all([
-      ctx.runAction(internal.tonal.proxy.fetchWorkoutDetail, {
-        userId,
-        activityId: args.activityId,
-      }),
-      ctx.runQuery(internal.tonal.movementSync.getAllMovements),
-      ctx
-        .runAction(internal.tonal.proxy.fetchFormattedSummary, {
+    const [detail, movements, formattedSummary]: [unknown, Movement[], unknown] = await Promise.all(
+      [
+        ctx.runAction(internal.tonal.proxy.fetchWorkoutDetail, {
           userId,
-          summaryId: args.activityId,
-        })
-        .catch((): null => null),
-    ]);
+          activityId: args.activityId,
+        }),
+        ctx.runQuery(internal.tonal.movementSync.getAllMovements),
+        ctx
+          .runAction(internal.tonal.proxy.fetchFormattedSummary, {
+            userId,
+            summaryId: args.activityId,
+          })
+          .catch((): null => null),
+      ],
+    );
     if (!detail) throw new Error("Workout not found");
     const movementMap = new Map(movements.map((m) => [m.id, m]));
 

--- a/docs/superpowers/plans/2026-03-28-tonal-profile-sync.md
+++ b/docs/superpowers/plans/2026-03-28-tonal-profile-sync.md
@@ -1,0 +1,571 @@
+# Tonal Profile Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sync additional Tonal profile fields (firstName, lastName, dateOfBirth, username, tonalCreatedAt) into the `users` and `userProfiles` tables, fix the `TonalUser` type, add age to AI context, and provide a one-time backfill action.
+
+**Architecture:** Extend `TonalUser` type with missing fields, add optional fields to both `users` and `userProfiles` schemas, update the connect and refresh flows to write the new fields, and add a backfill action that iterates all existing users. The existing 24h profile refresh (via `maybeRefreshProfile`) handles recurring sync with no new cron needed.
+
+**Tech Stack:** Convex (schema, mutations, actions), TypeScript
+
+---
+
+### Task 1: Fix TonalUser type
+
+**Files:**
+
+- Modify: `convex/tonal/types.ts:2-19`
+
+- [ ] **Step 1: Add workoutDurationMin and workoutDurationMax to TonalUser**
+
+```typescript
+// User profile from GET /v6/users/{userId}
+export interface TonalUser {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  gender: string;
+  heightInches: number;
+  weightPounds: number;
+  auth0Id: string;
+  dateOfBirth: string;
+  username: string;
+  workoutsPerWeek: number;
+  workoutDurationMin: number;
+  workoutDurationMax: number;
+  tonalStatus: string;
+  accountType: string;
+  location: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (new fields are additive; the `as unknown` casts in connect.ts and historySync.ts will still compile but are now unnecessary - we fix those in later tasks)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add convex/tonal/types.ts
+git commit -m "fix: add workoutDurationMin/Max to TonalUser type"
+```
+
+---
+
+### Task 2: Extend schemas
+
+**Files:**
+
+- Modify: `convex/schema.ts:10-24` (users table)
+- Modify: `convex/schema.ts:33-45` (userProfiles.profileData)
+
+- [ ] **Step 1: Add firstName and lastName to users table**
+
+In `convex/schema.ts`, add two fields to the `users` table definition, after the `name` field:
+
+```typescript
+  users: defineTable({
+    name: v.optional(v.string()),
+    /** First name from Tonal profile. */
+    firstName: v.optional(v.string()),
+    /** Last name from Tonal profile. */
+    lastName: v.optional(v.string()),
+    image: v.optional(v.string()),
+    email: v.optional(v.string()),
+    emailVerificationTime: v.optional(v.number()),
+    phone: v.optional(v.string()),
+    phoneVerificationTime: v.optional(v.number()),
+    isAnonymous: v.optional(v.boolean()),
+    /** Whether this user has admin privileges. */
+    isAdmin: v.optional(v.boolean()),
+    /** When set, the admin sees the app as this user. */
+    impersonatingUserId: v.optional(v.id("users")),
+  })
+    .index("email", ["email"])
+    .index("phone", ["phone"]),
+```
+
+- [ ] **Step 2: Add new fields to userProfiles.profileData**
+
+In `convex/schema.ts`, extend the `profileData` object to include the three new optional fields:
+
+```typescript
+    profileData: v.optional(
+      v.object({
+        firstName: v.string(),
+        lastName: v.string(),
+        heightInches: v.number(),
+        weightPounds: v.number(),
+        gender: v.string(),
+        level: v.string(),
+        workoutsPerWeek: v.number(),
+        workoutDurationMin: v.number(),
+        workoutDurationMax: v.number(),
+        dateOfBirth: v.optional(v.string()),
+        username: v.optional(v.string()),
+        tonalCreatedAt: v.optional(v.string()),
+      }),
+    ),
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: FAIL - the `profileData` object shape in `userProfiles.ts` (create mutation args and updateProfileData args) no longer matches the schema. We fix these in the next tasks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add convex/schema.ts
+git commit -m "feat: add Tonal profile fields to users and userProfiles schemas"
+```
+
+---
+
+### Task 3: Update userProfiles mutations
+
+**Files:**
+
+- Modify: `convex/userProfiles.ts:17-66` (create mutation)
+- Modify: `convex/userProfiles.ts:311-337` (updateProfileData mutation)
+
+- [ ] **Step 1: Extend create mutation args and handler to include new profileData fields and patch users table**
+
+Replace the `create` mutation's `profileData` arg validator to include the new optional fields, and update the handler to also patch the `users` table:
+
+```typescript
+export const create = internalMutation({
+  args: {
+    userId: v.id("users"),
+    tonalUserId: v.string(),
+    tonalEmail: v.optional(v.string()),
+    tonalToken: v.string(),
+    tonalRefreshToken: v.optional(v.string()),
+    tonalTokenExpiresAt: v.optional(v.number()),
+    profileData: v.optional(
+      v.object({
+        firstName: v.string(),
+        lastName: v.string(),
+        heightInches: v.number(),
+        weightPounds: v.number(),
+        gender: v.string(),
+        level: v.string(),
+        workoutsPerWeek: v.number(),
+        workoutDurationMin: v.number(),
+        workoutDurationMax: v.number(),
+        dateOfBirth: v.optional(v.string()),
+        username: v.optional(v.string()),
+        tonalCreatedAt: v.optional(v.string()),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    // Sync name fields to users table
+    if (args.profileData) {
+      await ctx.db.patch(args.userId, {
+        firstName: args.profileData.firstName,
+        lastName: args.profileData.lastName,
+        name: `${args.profileData.firstName} ${args.profileData.lastName}`,
+      });
+    }
+
+    // Upsert: check if profile exists
+    const existing = await ctx.db
+      .query("userProfiles")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        tonalUserId: args.tonalUserId,
+        tonalEmail: args.tonalEmail,
+        tonalToken: args.tonalToken,
+        tonalRefreshToken: args.tonalRefreshToken,
+        tonalTokenExpiresAt: args.tonalTokenExpiresAt,
+        profileData: args.profileData,
+        lastActiveAt: Date.now(),
+      });
+      return existing._id;
+    }
+
+    const now = Date.now();
+    return await ctx.db.insert("userProfiles", {
+      ...args,
+      lastActiveAt: now,
+      tonalConnectedAt: now,
+    });
+  },
+});
+```
+
+- [ ] **Step 2: Extend updateProfileData mutation to include new fields and patch users table**
+
+Replace the `updateProfileData` mutation:
+
+```typescript
+/** Refresh cached profile data from Tonal API response. */
+export const updateProfileData = internalMutation({
+  args: {
+    userId: v.id("users"),
+    profileData: v.object({
+      firstName: v.string(),
+      lastName: v.string(),
+      heightInches: v.number(),
+      weightPounds: v.number(),
+      gender: v.string(),
+      level: v.string(),
+      workoutsPerWeek: v.number(),
+      workoutDurationMin: v.number(),
+      workoutDurationMax: v.number(),
+      dateOfBirth: v.optional(v.string()),
+      username: v.optional(v.string()),
+      tonalCreatedAt: v.optional(v.string()),
+    }),
+  },
+  handler: async (ctx, { userId, profileData }) => {
+    const profile = await ctx.db
+      .query("userProfiles")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+    if (!profile) throw new Error("User profile not found");
+    await ctx.db.patch(profile._id, {
+      profileData,
+      profileDataRefreshedAt: Date.now(),
+    });
+
+    // Sync name fields to users table
+    await ctx.db.patch(userId, {
+      firstName: profileData.firstName,
+      lastName: profileData.lastName,
+      name: `${profileData.firstName} ${profileData.lastName}`,
+    });
+  },
+});
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: FAIL - `connect.ts` and `historySync.ts` still pass the old shape (missing new fields). We fix those next.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add convex/userProfiles.ts
+git commit -m "feat: extend create and updateProfileData with new Tonal fields"
+```
+
+---
+
+### Task 4: Update connect flow
+
+**Files:**
+
+- Modify: `convex/tonal/connect.ts:40-51`
+
+- [ ] **Step 1: Include new fields in profileData and remove unsafe casts**
+
+Replace the `profileData` object in the `connectTonal` action:
+
+```typescript
+      profileData: {
+        firstName: profile.firstName,
+        lastName: profile.lastName,
+        heightInches: profile.heightInches,
+        weightPounds: profile.weightPounds,
+        gender: profile.gender,
+        level: profile.tonalStatus ?? "",
+        workoutsPerWeek: profile.workoutsPerWeek,
+        workoutDurationMin: profile.workoutDurationMin ?? 0,
+        workoutDurationMax: profile.workoutDurationMax ?? 0,
+        dateOfBirth: profile.dateOfBirth || undefined,
+        username: profile.username || undefined,
+        tonalCreatedAt: profile.createdAt || undefined,
+      },
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: FAIL - `historySync.ts` still has the old casts. We fix that next.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add convex/tonal/connect.ts
+git commit -m "feat: sync new Tonal profile fields on connect"
+```
+
+---
+
+### Task 5: Update profile refresh in historySync
+
+**Files:**
+
+- Modify: `convex/tonal/historySync.ts:191-206`
+
+- [ ] **Step 1: Update maybeRefreshProfile to include new fields and remove unsafe casts**
+
+Replace the `profileData` object inside `maybeRefreshProfile`:
+
+```typescript
+await ctx.runMutation(internal.userProfiles.updateProfileData, {
+  userId,
+  profileData: {
+    firstName: u.firstName,
+    lastName: u.lastName,
+    heightInches: u.heightInches,
+    weightPounds: u.weightPounds,
+    gender: u.gender,
+    level: u.tonalStatus ?? "",
+    workoutsPerWeek: u.workoutsPerWeek,
+    workoutDurationMin: u.workoutDurationMin ?? 0,
+    workoutDurationMax: u.workoutDurationMax ?? 0,
+    dateOfBirth: u.dateOfBirth || undefined,
+    username: u.username || undefined,
+    tonalCreatedAt: u.createdAt || undefined,
+  },
+});
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS - all `profileData` shapes now match the schema.
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `npx vitest run --project backend`
+Expected: PASS - no behavior changed, only additive optional fields.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add convex/tonal/historySync.ts
+git commit -m "fix: remove unsafe casts, include new fields in profile refresh"
+```
+
+---
+
+### Task 6: Add age to AI context
+
+**Files:**
+
+- Modify: `convex/ai/context.ts:110-111`
+- Test: `convex/ai/context.test.ts`
+
+- [ ] **Step 1: Write a test for age in the profile line**
+
+Add a new test at the end of `convex/ai/context.test.ts`, after the existing `buildExerciseCatalogSection` describe block. We cannot test `buildTrainingSnapshot` directly (it needs Convex runtime), but we can verify the age computation helper. Add a `computeAge` helper to `convex/ai/snapshotHelpers.ts` and test it:
+
+First, add to `convex/ai/snapshotHelpers.ts` (at the end of the file):
+
+```typescript
+/** Compute age in years from an ISO date-of-birth string. Returns null if invalid. */
+export function computeAge(dateOfBirth: string | undefined, now: Date): number | null {
+  if (!dateOfBirth) return null;
+  const dob = new Date(dateOfBirth);
+  if (isNaN(dob.getTime())) return null;
+  let age = now.getFullYear() - dob.getFullYear();
+  const monthDiff = now.getMonth() - dob.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < dob.getDate())) {
+    age--;
+  }
+  return age;
+}
+```
+
+Then add the test to `convex/ai/context.test.ts`:
+
+```typescript
+import { computeAge } from "./snapshotHelpers";
+
+describe("computeAge", () => {
+  it("computes age correctly before birthday this year", () => {
+    const now = new Date("2026-03-28");
+    expect(computeAge("1993-12-15", now)).toBe(32);
+  });
+
+  it("computes age correctly after birthday this year", () => {
+    const now = new Date("2026-03-28");
+    expect(computeAge("1993-01-10", now)).toBe(33);
+  });
+
+  it("returns null for undefined dateOfBirth", () => {
+    expect(computeAge(undefined, new Date())).toBeNull();
+  });
+
+  it("returns null for invalid date string", () => {
+    expect(computeAge("not-a-date", new Date())).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run convex/ai/context.test.ts`
+Expected: FAIL - `computeAge` not yet exported from snapshotHelpers (we added the function but haven't saved it yet if doing TDD strictly, but since we need to add both the function and test, save both and verify the test passes).
+
+- [ ] **Step 3: Verify tests pass**
+
+Run: `npx vitest run convex/ai/context.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Update context.ts to include age in profile line**
+
+In `convex/ai/context.ts`, add the import and modify the profile line:
+
+Add to imports at the top of `convex/ai/context.ts`:
+
+```typescript
+import { computeAge } from "./snapshotHelpers";
+```
+
+Note: `computeAge` should be added to the existing import from `"./snapshotHelpers"`. The file already imports `buildExerciseCatalogSection`, `buildHealthSection`, `formatExternalActivityLine`, `getHrIntensityLabel`, `type HealthSnapshotData`, `SNAPSHOT_MAX_CHARS`, `type SnapshotSection`, and `trimSnapshot` from this module.
+
+Then replace the profile line (line 110-112 area):
+
+```typescript
+const profileLines: string[] = [];
+const ageSuffix = pd.dateOfBirth
+  ? (() => {
+      const age = computeAge(pd.dateOfBirth, new Date());
+      return age !== null ? ` | Age: ${age}` : "";
+    })()
+  : "";
+profileLines.push(
+  `User: ${pd.firstName} ${pd.lastName} | ${pd.heightInches}"/${pd.weightPounds}lbs${ageSuffix} | Level: ${pd.level} | ${pd.workoutsPerWeek}x/week`,
+);
+```
+
+- [ ] **Step 5: Run typecheck and tests**
+
+Run: `npx tsc --noEmit && npx vitest run convex/ai/context.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add convex/ai/snapshotHelpers.ts convex/ai/context.ts convex/ai/context.test.ts
+git commit -m "feat: add user age from Tonal profile to AI context snapshot"
+```
+
+---
+
+### Task 7: Add backfill action
+
+**Files:**
+
+- Create: `convex/tonal/profileBackfill.ts`
+
+- [ ] **Step 1: Create the backfill action**
+
+Create `convex/tonal/profileBackfill.ts`:
+
+```typescript
+import { internalAction } from "../_generated/server";
+import { internal } from "../_generated/api";
+
+/**
+ * One-time backfill: fetch fresh Tonal profile for all users and sync
+ * new fields (dateOfBirth, username, tonalCreatedAt) into userProfiles
+ * and name fields into the users table.
+ *
+ * Run manually: npx convex run --prod tonal/profileBackfill:backfillAllProfiles
+ */
+export const backfillAllProfiles = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const threeDaysAgo = 0; // Get ALL users, not just active
+    const profiles = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
+      sinceTimestamp: threeDaysAgo,
+    });
+
+    let success = 0;
+    let failed = 0;
+
+    for (const profile of profiles) {
+      try {
+        const u = await ctx.runAction(internal.tonal.proxy.fetchUserProfile, {
+          userId: profile.userId,
+        });
+        await ctx.runMutation(internal.userProfiles.updateProfileData, {
+          userId: profile.userId,
+          profileData: {
+            firstName: u.firstName,
+            lastName: u.lastName,
+            heightInches: u.heightInches,
+            weightPounds: u.weightPounds,
+            gender: u.gender,
+            level: u.tonalStatus ?? "",
+            workoutsPerWeek: u.workoutsPerWeek,
+            workoutDurationMin: u.workoutDurationMin ?? 0,
+            workoutDurationMax: u.workoutDurationMax ?? 0,
+            dateOfBirth: u.dateOfBirth || undefined,
+            username: u.username || undefined,
+            tonalCreatedAt: u.createdAt || undefined,
+          },
+        });
+        success++;
+      } catch (err) {
+        failed++;
+        console.error(`[profileBackfill] Failed for user ${profile.userId}:`, err);
+      }
+    }
+
+    console.log(
+      `[profileBackfill] Complete: ${success} succeeded, ${failed} failed out of ${profiles.length} total`,
+    );
+    return { success, failed, total: profiles.length };
+  },
+});
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Run all backend tests**
+
+Run: `npx vitest run --project backend`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add convex/tonal/profileBackfill.ts
+git commit -m "feat: add one-time Tonal profile backfill action"
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Run full typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npm test`
+Expected: PASS
+
+- [ ] **Step 3: Verify no unsafe casts remain**
+
+Run: `grep -r "as unknown as Record" convex/tonal/connect.ts convex/tonal/historySync.ts`
+Expected: No matches
+
+- [ ] **Step 4: Verify new fields are in schema**
+
+Run: `grep -n "dateOfBirth\|tonalCreatedAt\|username" convex/schema.ts`
+Expected: Three matches in the profileData object
+
+- [ ] **Step 5: Commit any remaining changes**
+
+Only if the formatter modified files during previous commits.

--- a/docs/superpowers/specs/2026-03-28-tonal-profile-sync-design.md
+++ b/docs/superpowers/specs/2026-03-28-tonal-profile-sync-design.md
@@ -1,0 +1,114 @@
+# Tonal Profile Sync Design
+
+Sync additional Tonal profile fields into the `users` and `userProfiles` tables, with a one-time backfill and recurring refresh.
+
+## Problem
+
+The Tonal API returns rich user profile data (name, date of birth, username, account creation date, workout duration preferences), but we only store a subset in `userProfiles.profileData`. The `users` table has no name fields from Tonal at all -- it only has whatever the user typed at signup. Several fields are accessed via unsafe `as unknown as Record<string, number>` casts because `TonalUser` is incomplete.
+
+## Changes
+
+### 1. TonalUser Type (`convex/tonal/types.ts`)
+
+Add missing fields that the API actually returns:
+
+```typescript
+export interface TonalUser {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  gender: string;
+  heightInches: number;
+  weightPounds: number;
+  auth0Id: string;
+  dateOfBirth: string;
+  username: string;
+  workoutsPerWeek: number;
+  workoutDurationMin: number; // NEW
+  workoutDurationMax: number; // NEW
+  tonalStatus: string;
+  accountType: string;
+  location: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 2. Schema (`convex/schema.ts`)
+
+**`users` table** -- add:
+
+- `firstName: v.optional(v.string())`
+- `lastName: v.optional(v.string())`
+
+**`userProfiles.profileData`** -- add three optional fields:
+
+- `dateOfBirth: v.optional(v.string())`
+- `username: v.optional(v.string())`
+- `tonalCreatedAt: v.optional(v.string())`
+
+All additive optional fields. No migration needed for existing rows.
+
+### 3. Connect Flow (`convex/tonal/connect.ts`)
+
+After fetching the Tonal profile, write the new fields:
+
+- Include `dateOfBirth`, `username`, `tonalCreatedAt` (from `profile.createdAt`) in the `profileData` object passed to `userProfiles.create`
+- Patch the `users` table with `firstName`, `lastName`, and `name: "${firstName} ${lastName}"`
+
+### 4. Profile Refresh (`convex/userProfiles.ts` + `convex/tonal/historySync.ts`)
+
+**`updateProfileData` mutation** -- expand args to accept the new `profileData` fields plus a `userId` that it uses to also patch `users.firstName`, `users.lastName`, `users.name`.
+
+**`maybeRefreshProfile`** -- include the new fields when calling `updateProfileData`. Remove the `as unknown as Record<string, number>` casts for `workoutDurationMin`/`workoutDurationMax` (now typed properly on `TonalUser`).
+
+**`userProfiles.create`** -- same treatment: accept and store the new fields, patch `users` table.
+
+### 5. One-Time Backfill (`convex/tonal/profileBackfill.ts`)
+
+New internal action:
+
+- Query all `userProfiles` documents
+- For each, call `fetchUserProfile` to get fresh Tonal data
+- Update `userProfiles.profileData` with all fields (including new ones)
+- Patch `users` table with `firstName`, `lastName`, `name`
+- Sequential iteration with per-user try/catch so one failure doesn't block others
+- Log successes and failures
+
+Triggered manually via `npx convex run`.
+
+### 6. AI Context (`convex/ai/context.ts`)
+
+Add the user's age (computed from `dateOfBirth`) to the profile snapshot line:
+
+```
+User: Jeff Otano | 72"/185lbs | Age: 32 | Level: Advanced | 5x/week
+```
+
+Age is useful for recovery recommendations, heart rate zone guidance, and volume scaling.
+
+### 7. Recurring Sync
+
+No new cron. The existing `refresh-tonal-cache` cron (every 30 min) calls `cacheRefresh.refreshActiveUsers`, which calls `historySync.syncUserHistory`, which calls `maybeRefreshProfile` with a 24h staleness guard. Since we're extending `maybeRefreshProfile` to include the new fields, active users get their profile data refreshed daily automatically.
+
+## Files Modified
+
+| File                              | Change                                                                  |
+| --------------------------------- | ----------------------------------------------------------------------- |
+| `convex/tonal/types.ts`           | Add `workoutDurationMin`, `workoutDurationMax` to `TonalUser`           |
+| `convex/schema.ts`                | Add fields to `users` and `userProfiles.profileData`                    |
+| `convex/tonal/connect.ts`         | Write new fields on connect, patch `users` table                        |
+| `convex/userProfiles.ts`          | Extend `create` and `updateProfileData` with new fields + `users` patch |
+| `convex/tonal/historySync.ts`     | Update `maybeRefreshProfile` with new fields, remove unsafe casts       |
+| `convex/ai/context.ts`            | Add age to profile snapshot                                             |
+| `convex/tonal/profileBackfill.ts` | New file: one-time backfill action                                      |
+
+## Verification
+
+- `npx tsc --noEmit` passes
+- Existing tests pass
+- Backfill action runs successfully against prod (manual trigger)
+- New user connecting Tonal gets all fields populated in both tables
+- AI context snapshot includes age
+- No `as unknown` casts remain for `workoutDurationMin`/`workoutDurationMax`


### PR DESCRIPTION
## Summary

- Add `firstName`/`lastName` to the `users` table from Tonal profile data
- Add `dateOfBirth`, `username`, `tonalCreatedAt` to `userProfiles.profileData`
- Fix `TonalUser` type with missing `workoutDurationMin`/`workoutDurationMax` fields, removing unsafe `as unknown` casts
- Include user's age (computed from DOB) in the AI coach's context snapshot
- Add one-time backfill action (`tonal/profileBackfill:backfillAllProfiles`) for existing users
- Recurring sync handled by existing 24h profile refresh in `maybeRefreshProfile`

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 745 tests pass (including 4 new `computeAge` tests)
- [x] Zero `as unknown as Record` casts remain in connect/historySync
- [ ] Run backfill on prod: `npx convex run --prod tonal/profileBackfill:backfillAllProfiles`
- [ ] Verify new user connecting Tonal gets `firstName`/`lastName` on `users` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)