### PR TITLE
chore: tighten gitignore and add gitleaks allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,8 @@ next-env.d.ts
 
 # Agent directories
 .agent/*
+.agents/*
 .claude/*
-!.claude/commands/
 .factory/*
 .junie/*
 .kiro/*

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known false positives in the tonal-coach repo"
+paths = [
+  # BYOK test fixtures. These strings look like real Gemini API keys because
+  # the tests exercise the format validator in convex/byok.ts, so they have
+  # to match /^AIza[A-Za-z0-9_-]{35}$/. They are alphabet-sequence fakes.
+  '''convex/byok\.test\.ts''',
+
+  # Tonal mobile app's Auth0 client ID. Client IDs are public identifiers by
+  # design and are exposed in every published Auth0 client application. This
+  # is the real value and is required for the Tonal integration to work.
+  '''convex/tonal/auth\.ts''',
+
+  # OpenAPI documentation example JWT. Already expired (exp: 2026-03-15) and
+  # serves only as a sample payload in the /v6/auth endpoint response schema.
+  '''docs/tonal-api\.yaml''',
+]


### PR DESCRIPTION
## Summary

Follow-up to the history scrub (not a separate PR — companion to the force-push). Two small changes:

1. **`.gitignore` tightening** to prevent scrubbed directories from coming back:
   - Added \`.agents/*\` (the 26 Convex AI tooling skill files we just scrubbed lived here; only \`.agent/*\` singular was ignored before)
   - Removed the \`!.claude/commands/\` exception (this was explicitly allowing the 5 scrubbed slash command files to be tracked)

2. **New \`.gitleaks.toml\`** with an allowlist for the 8 known false positives that remain in the current tree:
   - \`convex/byok.test.ts\` — BYOK test fixtures that look like real Gemini keys because they have to match the format regex
   - \`convex/tonal/auth.ts\` — Tonal mobile app's public Auth0 client ID (client IDs are public by design)
   - \`docs/tonal-api.yaml\` — expired OpenAPI example JWT (exp: 2026-03-15)

## Why this matters

The history scrub removed \`ios/\`, \`northstar.md\`, \`.agents/\`, \`.claude/commands/\`, and \`docs/superpowers/\` from git history (force-pushed to origin main as \`fec923e\`). Without this gitignore tightening, the scrubbed directories could silently be repopulated on the next \`npx convex install\` or Claude Code session.

## Verification

Running \`gitleaks git --config .gitleaks.toml --log-opts main\` reports \`no leaks found\` on the rewritten history. The allowlist correctly silences the 8 known false positives while still scanning everything else.

## Stats

- 2 files changed
- 21 lines added, 1 line removed
- \`.gitignore\`: +1/-1 (added .agents/*, removed .claude/commands/ exception)
- \`.gitleaks.toml\`: new file, 20 lines with comments explaining each allowlist entry

## Test plan

- [ ] CI passes
- [ ] Future \`npx convex\` operations don't accidentally track \`.agents/\`
- [ ] Future Claude Code sessions don't track \`.claude/commands/\`
- [ ] Running gitleaks against main (e.g., if added to CI) reports clean

## Context

This is the follow-up to the \`git filter-repo\` history scrub that force-pushed origin main from \`3a3c043\` to \`fec923e\`. The scrub removed:
- 81 \`ios/**\` files
- 1 \`northstar.md\`
- 26 \`.agents/**\` files
- 5 \`.claude/commands/**\` files
- 46 \`docs/superpowers/**\` files

The scrub also reduced history from 755 commits to 466 (289 now-empty commits collapsed), and dropped 2 PostHog API key findings (\`phc_\` prefix in the deleted \`2026-03-28-posthog-analytics.md\` planning doc). This PR ensures those directories can't silently return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)