### PR TITLE
Add GitHub repo setup guide and maintainer script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in Tonal Coach. This is a personal project maintained by one person on a best-effort basis. PRs are welcome but may take time to review.
 
+Maintainers should also follow the GitHub repo setup checklist in [docs/github-repo-setup.md](docs/github-repo-setup.md) so the repository settings match the policy documented here.
+
 ## Before you file an issue
 
 Search existing issues first. Then pick the right channel:
@@ -40,6 +42,8 @@ All PRs must pass `npm test`, `npm run typecheck`, and `npm run lint`. CI enforc
 ## Pull request guidelines
 
 - One logical change per PR. Split unrelated work into separate PRs.
+- Open pull requests against `main`. Direct pushes to `main` should stay blocked by GitHub branch protection.
+- Name contributor branches with a short descriptive prefix such as `fix/login-timeout` or `docs/self-host-setup`.
 - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`. Commitlint enforces this.
 - All commit subject lines must be lowercase.
 - Write tests for new behavior. The test pattern in this codebase is Vitest with `vi.mock` for Convex modules (no `convex-test`).

--- a/docs/github-repo-setup.md
+++ b/docs/github-repo-setup.md
@@ -1,0 +1,111 @@
+# GitHub Repo Setup
+
+This repo already versions the contributor-facing files and automation:
+
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+- `.github/CODEOWNERS`
+- `.github/ISSUE_TEMPLATE/*`
+- `.github/pull_request_template.md`
+- `.github/workflows/*.yml`
+- `.github/dependabot.yml`
+- `.github/release-drafter.yml`
+
+What still has to be configured in GitHub is the repository settings and the `main` branch rules.
+
+## One-time maintainer setup
+
+### 1. Apply the repo defaults
+
+Run:
+
+```bash
+./scripts/configure-github-repo.sh
+```
+
+That script:
+
+- enables squash-only merges
+- enables automatic branch deletion after merge
+- keeps the OSS labels used by issue templates and Release Drafter in sync
+- applies baseline classic protection to `main`
+
+### 2. Create a `main` branch ruleset
+
+GitHub does not store branch protection in git. Configure this in:
+
+`Settings -> Rules -> Rulesets -> New branch ruleset`
+
+The setup script protects `main` with the classic branch protection API so the branch is not left open, but the ruleset should be treated as the final GitHub-side source of truth.
+
+Use these settings:
+
+- Ruleset name: `Protect main`
+- Enforcement status: `Active`
+- Target branches: `main`
+- Bypass list: repository admins only
+
+Enable these rules:
+
+- Restrict deletions
+- Block force pushes
+- Require a pull request before merging
+- Require approvals: `1`
+- Dismiss stale pull request approvals when new commits are pushed
+- Require review from Code Owners
+- Require conversation resolution before merging
+- Require branches to be up to date before merging
+- Require linear history
+
+### 3. Require status checks
+
+After the first green pull request run, add the checks that appear in the GitHub UI. For this repo, the expected checks are:
+
+- `CI / Lint & Format`
+- `CI / Type Check`
+- `CI / Test`
+- `CI / Build`
+- `CI / Security Audit`
+- `CI / E2E Smoke`
+- `Dependency Review / dependency-review`
+- `CodeQL / Analyze`
+
+GitHub sometimes shows slightly different check names, so select the exact names from a completed PR rather than typing them from memory.
+
+### 4. Verify merge settings
+
+In `Settings -> General`, use:
+
+- Default branch: `main`
+- Allow squash merging: enabled
+- Allow merge commits: disabled
+- Allow rebase merging: disabled
+- Automatically delete head branches: enabled
+
+### 5. Verify security automation
+
+In `Security -> Code security and analysis`, enable or verify:
+
+- Dependabot alerts
+- Dependabot security updates
+- Secret scanning, if available for the repo plan
+
+`CodeQL` and dependency review are already checked in as GitHub Actions workflows.
+
+## Labels used by automation
+
+These labels should exist because templates and Release Drafter depend on them:
+
+- `bug`
+- `enhancement`
+- `feature`
+- `docs`
+- `chore`
+- `refactor`
+- `test`
+- `major`
+- `breaking`
+
+The setup script keeps these labels in sync.

--- a/scripts/configure-github-repo.sh
+++ b/scripts/configure-github-repo.sh
@@ -80,6 +80,22 @@ protect_main_branch() {
 JSON
 }
 
+configure_repo_settings() {
+  gh api \
+    --method PATCH \
+    -H "Accept: application/vnd.github+json" \
+    "repos/$repo" \
+    --input - >/dev/null <<'JSON'
+{
+  "default_branch": "main",
+  "allow_squash_merge": true,
+  "allow_merge_commit": false,
+  "allow_rebase_merge": false,
+  "delete_branch_on_merge": true
+}
+JSON
+}
+
 require_command gh
 require_command git
 
@@ -89,12 +105,7 @@ repo="${repo_arg:-$(infer_repo)}"
 
 echo "Configuring GitHub repository settings for $repo"
 
-gh repo edit "$repo" \
-  --default-branch main \
-  --enable-squash-merge \
-  --disable-merge-commit \
-  --disable-rebase-merge \
-  --delete-branch-on-merge
+configure_repo_settings
 
 sync_label "bug" "d73a4a" "Something is broken"
 sync_label "enhancement" "a2eeef" "Improvement to an existing capability"

--- a/scripts/configure-github-repo.sh
+++ b/scripts/configure-github-repo.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_arg="${1:-}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+infer_repo() {
+  local remote_url
+
+  remote_url="$(git remote get-url origin 2>/dev/null || true)"
+  if [[ -z "$remote_url" ]]; then
+    echo "Could not infer the GitHub repo from origin. Pass owner/repo explicitly." >&2
+    exit 1
+  fi
+
+  case "$remote_url" in
+    git@github.com:*)
+      remote_url="${remote_url#git@github.com:}"
+      remote_url="${remote_url%.git}"
+      ;;
+    https://github.com/*)
+      remote_url="${remote_url#https://github.com/}"
+      remote_url="${remote_url%.git}"
+      ;;
+    git+https://github.com/*)
+      remote_url="${remote_url#git+https://github.com/}"
+      remote_url="${remote_url%.git}"
+      ;;
+    *)
+      echo "Unsupported Git remote format: $remote_url" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "$remote_url"
+}
+
+sync_label() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+
+  gh label create "$name" \
+    --repo "$repo" \
+    --color "$color" \
+    --description "$description" \
+    --force >/dev/null
+}
+
+protect_main_branch() {
+  gh api \
+    --method PUT \
+    -H "Accept: application/vnd.github+json" \
+    "repos/$repo/branches/main/protection" \
+    --input - >/dev/null <<'JSON'
+{
+  "required_status_checks": null,
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+JSON
+}
+
+require_command gh
+require_command git
+
+gh auth status >/dev/null
+
+repo="${repo_arg:-$(infer_repo)}"
+
+echo "Configuring GitHub repository settings for $repo"
+
+gh repo edit "$repo" \
+  --default-branch main \
+  --enable-squash-merge \
+  --disable-merge-commit \
+  --disable-rebase-merge \
+  --delete-branch-on-merge
+
+sync_label "bug" "d73a4a" "Something is broken"
+sync_label "enhancement" "a2eeef" "Improvement to an existing capability"
+sync_label "feature" "1d76db" "Net-new user-facing capability"
+sync_label "docs" "0075ca" "Documentation changes"
+sync_label "chore" "c5def5" "Maintenance work with no product behavior change"
+sync_label "refactor" "bfdadc" "Code restructuring without behavior change"
+sync_label "test" "5319e7" "Test coverage or test infrastructure"
+sync_label "major" "b60205" "Major release or breaking scope"
+sync_label "breaking" "b60205" "Introduces a breaking change"
+
+protect_main_branch
+
+cat <<EOF
+Repository defaults, labels, and baseline classic protection for main are configured.
+
+Next steps in the GitHub UI:
+1. Go to Settings -> Rules -> Rulesets and confirm the main ruleset matches docs/github-repo-setup.md.
+2. Add required status checks from a completed green pull request run.
+3. Verify Security -> Code security and analysis settings are enabled.
+EOF


### PR DESCRIPTION
## Summary

- add a maintainer checklist for GitHub repository settings that are not stored in git
- add a `gh`-based script to configure merge defaults, labels, and baseline `main` protection
- clarify contributor expectations around targeting `main` and using descriptive branch names

## Changes

- add `docs/github-repo-setup.md` with the recommended `main` ruleset, required checks, merge settings, and security settings
- add `scripts/configure-github-repo.sh` to sync labels, set repo merge defaults, and apply baseline classic branch protection
- update `CONTRIBUTING.md` to link the maintainer setup doc and document branch expectations for contributors

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [ ] New logic has tests (happy path + at least one error/edge case)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap
- [x] No function exceeds 60 lines
- [x] No new `any` types or unsafe `as` casts
- [ ] Tested in browser (if UI changes)
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- run `bash -n scripts/configure-github-repo.sh`
- run `npm run typecheck`
- run `npm run lint`
- run `npm test`
- review `git diff origin/main...` to confirm the PR only contains the repo setup docs and maintainer script
