### PR TITLE
chore: disable vercel pr preview deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,8 @@
 {
-  "buildCommand": "npx convex deploy --cmd 'npm run build'"
+  "buildCommand": "npx convex deploy --cmd 'npm run build'",
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
 }


### PR DESCRIPTION
## Summary

GitHub Actions CI already gates lint, prettier, knip, file-size, type check, Vitest (with coverage), Next.js build, bundle-size budget, `npm audit`, and Playwright E2E on every PR. The Vercel PR preview deploy was duplicating the real build step and cluttering PR checks without adding coverage that GH Actions doesn't already provide.

Scoping `git.deploymentEnabled` to `main` only. Production deploys on main still work exactly the same; PR branches simply stop triggering Vercel entirely (no preview URL, no status check, no wasted compute).

## Trade-off

- **Lose**: Vercel preview URL on PRs (no more click-to-browse a built preview of a PR)
- **Keep**: All existing CI gates via GitHub Actions, production deploys on main, the actual Vercel-hosted app

Visual / interaction review can still be done locally via `npm run dev`, and Playwright E2E still runs against every PR build.

## Test plan

- [ ] Merge, confirm Vercel no longer posts status checks on new PRs
- [ ] Confirm next push to main still triggers the production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)