### PR TITLE
fix: harden open source readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,20 @@ NEXT_PUBLIC_CONVEX_URL=https://your-deployment-name.convex.cloud
 # The OpenSourceBanner only shows when this is set.
 NEXT_PUBLIC_GITHUB_REPO_URL=
 
+# Optional: set to true to enable the public /contact form UI for this deployment.
+# The server-side DISCORD_CONTACT_WEBHOOK secret must also be configured.
+NEXT_PUBLIC_CONTACT_FORM_ENABLED=false
+
+# Optional: client-side PostHog analytics
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
+NEXT_PUBLIC_POSTHOG_HOST=/ingest
+
+# Optional: client-side Sentry error reporting. Self-hosted deployments default to off.
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0
+NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
+NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=0
+
 # ---------------------------------------------------------------------------
 # Convex backend secrets — set these via `npx convex env set KEY value`
 # They are NOT read from .env.local at runtime; this block is for reference only.
@@ -28,5 +42,17 @@ NEXT_PUBLIC_GITHUB_REPO_URL=
 # Generate: openssl rand -hex 32
 # npx convex env set TOKEN_ENCRYPTION_KEY your-64-char-hex
 
-# Public app URL — used for OAuth redirects
-# npx convex env set APP_URL http://localhost:3000
+# Optional: contact form destination webhook used by /contact
+# npx convex env set DISCORD_CONTACT_WEBHOOK https://discord.com/api/webhooks/...
+
+# Optional: operator notifications for signups / errors / Tonal connections
+# npx convex env set DISCORD_WEBHOOK_URL https://discord.com/api/webhooks/...
+
+# Optional: server-side PostHog analytics
+# npx convex env set POSTHOG_PROJECT_TOKEN your-posthog-project-token
+
+# Optional: disable BYOK enforcement and force the shared Gemini key for all users
+# npx convex env set BYOK_DISABLED true
+
+# Optional: temporary old key used only during TOKEN_ENCRYPTION_KEY rotation
+# npx convex env set TOKEN_ENCRYPTION_KEY_OLD your-previous-64-char-hex

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ npm run dev
 
 `npx convex dev` and `npm run dev` need to run concurrently in separate terminals.
 
+By default, self-hosted deployments start with analytics, Sentry, and the public contact form disabled. Those integrations are opt-in and can be enabled later with the optional environment variables below.
+
 ## Environment Variables
 
 ### Convex backend - set via `npx convex env set KEY value`
@@ -103,15 +105,38 @@ npm run dev
 | `GOOGLE_GENERATIVE_AI_API_KEY` | Google AI Studio API key. Used for the shared Gemini key and embeddings |
 | `AUTH_RESEND_KEY`              | Optional Resend API key (`re_...`). Sends password-reset OTP emails     |
 | `TOKEN_ENCRYPTION_KEY`         | 64-char hex string. Encrypts Tonal OAuth tokens and BYOK Gemini keys    |
+| `DISCORD_CONTACT_WEBHOOK`      | Optional Discord webhook for the public `/contact` form                 |
+| `DISCORD_WEBHOOK_URL`          | Optional Discord webhook for operator notifications                     |
+| `POSTHOG_PROJECT_TOKEN`        | Optional PostHog project token for server-side analytics                |
+| `BYOK_DISABLED`                | Optional kill switch that forces all users onto the shared Gemini key   |
+| `TOKEN_ENCRYPTION_KEY_OLD`     | Optional old key used only during encryption-key rotation               |
 | `CONVEX_SITE_URL`              | Set automatically by Convex. Do not set manually                        |
 
 ### Next.js - set in `.env.local`
 
-| Variable                      | Description                                                                  |
-| ----------------------------- | ---------------------------------------------------------------------------- |
-| `CONVEX_DEPLOYMENT`           | Written automatically by `npx convex dev`. Do not edit                       |
-| `NEXT_PUBLIC_CONVEX_URL`      | Convex deployment URL (`https://<name>.convex.cloud`). Written automatically |
-| `NEXT_PUBLIC_GITHUB_REPO_URL` | Optional public GitHub repo URL. Enables the OSS banner                      |
+| Variable                                          | Description                                                                  |
+| ------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `CONVEX_DEPLOYMENT`                               | Written automatically by `npx convex dev`. Do not edit                       |
+| `NEXT_PUBLIC_CONVEX_URL`                          | Convex deployment URL (`https://<name>.convex.cloud`). Written automatically |
+| `NEXT_PUBLIC_GITHUB_REPO_URL`                     | Optional public GitHub repo URL. Enables the OSS banner                      |
+| `NEXT_PUBLIC_CONTACT_FORM_ENABLED`                | Optional `true` flag that enables the public `/contact` form UI              |
+| `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`               | Optional PostHog token for browser analytics                                 |
+| `NEXT_PUBLIC_POSTHOG_HOST`                        | Optional PostHog host. Defaults to `/ingest`                                 |
+| `NEXT_PUBLIC_SENTRY_DSN`                          | Optional Sentry DSN. Browser/server error reporting is off unless set        |
+| `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE`           | Optional trace sample rate from `0` to `1`                                   |
+| `NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE`  | Optional session replay sample rate from `0` to `1`                          |
+| `NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE` | Optional replay-on-error sample rate from `0` to `1`                         |
+
+### Build-time deployment variables
+
+These are only needed if you want Sentry source-map uploads during production builds.
+
+| Variable                    | Description                                            |
+| --------------------------- | ------------------------------------------------------ |
+| `SENTRY_AUTH_TOKEN`         | Sentry auth token used by the Next.js build plugin     |
+| `SENTRY_ORG`                | Sentry organization slug                               |
+| `SENTRY_PROJECT`            | Sentry project slug                                    |
+| `SENTRY_TRACES_SAMPLE_RATE` | Optional server/edge trace sample rate from `0` to `1` |
 
 ## Project Structure
 
@@ -188,7 +213,9 @@ This is the build-command pattern used for Vercel deployments: deploy the Convex
    - `CONVEX_DEPLOY_KEY` - get from Convex dashboard (Settings > Deploy keys)
    - `NEXT_PUBLIC_CONVEX_URL` - your production Convex URL (`https://<name>.convex.cloud`)
    - `NEXT_PUBLIC_GITHUB_REPO_URL` - optional, enables the OSS banner in production
-   - Sentry variables if using error tracking (`SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`)
+   - `NEXT_PUBLIC_CONTACT_FORM_ENABLED` - optional, set to `true` only if `DISCORD_CONTACT_WEBHOOK` is configured
+   - PostHog variables if using analytics (`NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`, `NEXT_PUBLIC_POSTHOG_HOST`)
+   - Sentry variables if using error tracking (`NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`)
 3. Set production secrets in the Convex dashboard (same keys as the env table above, with production values)
 4. Push to `main` - Vercel auto-deploys on every push
 

--- a/convex/contact.ts
+++ b/convex/contact.ts
@@ -10,7 +10,9 @@ export const send = action({
   },
   handler: async (_ctx, { name, email, message }) => {
     const webhookUrl = process.env.DISCORD_CONTACT_WEBHOOK;
-    if (!webhookUrl) throw new Error("Contact webhook not configured");
+    if (!webhookUrl) {
+      throw new Error("Contact form is not configured for this deployment");
+    }
 
     const embed = {
       title: "New Contact Form Message",

--- a/docs/tonal-api.yaml
+++ b/docs/tonal-api.yaml
@@ -58,228 +58,228 @@ paths:
             schema:
               type: object
               properties:
-                ? '{"id":"165d3760-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:16.726058Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Account","platform":"mobile"}}
+                ? '{"id":"165d3760-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:16.726058Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Account","platform":"mobile"}}
 
-                  {"id":"165dd3a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:16.729957Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                  {"id":"165dd3a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:16.729957Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                  {"id":"197dd850-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Account Updated","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:21.973738Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"fieldUpdated":"firstName","firstName":"Jef","lastName":"Otano","userName":"jephpho","email":"otano.jeffrey@gmail.com","location":"Colorado","gender":"male","userLevel":"advanced","userGoal":"
-                  build muscle","daysPerWeek":"4","height":"69","weight":"174","birthday":"1995-03-29","platform":"mobile"}}
+                  {"id":"197dd850-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Account Updated","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:21.973738Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"fieldUpdated":"firstName","firstName":"Alex","lastName":"Trainer","userName":"alexfit","email":"alex.trainer@example.com","location":"Denver","gender":"nonbinary","userLevel":"intermediate","userGoal":"
+                  build strength","daysPerWeek":"3","height":"70","weight":"180","birthday":"1990-01-01","platform":"mobile"}}
 
-                  {"id":"1a7fdf00-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:23.656593Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Edit
+                  {"id":"1a7fdf00-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:23.656593Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Edit
                   Account","platform":"mobile"}}
 
-                  {"id":"1bf281d0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.093204Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Account","platform":"mobile"}}
+                  {"id":"1bf281d0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.093204Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Account","platform":"mobile"}}
 
-                  {"id":"1bf2f700-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.096567Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                  {"id":"1bf2f700-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.096567Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                  {"id":"1c6c1ea0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Account Updated","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.890215Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"fieldUpdated":"firstName","firstName":"Jeff","lastName":"Otano","userName":"jephpho","email":"otano.jeffrey@gmail.com","location":"Colorado","gender":"male","userLevel":"advanced","userGoal":"
-                  build muscle","daysPerWeek":"4","height":"69","weight":"174","birthday":"1995-03-29","platform":"mobile"}}
+                  {"id":"1c6c1ea0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Account Updated","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.890215Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"fieldUpdated":"firstName","firstName":"Alex","lastName":"Trainer","userName":"alexfit","email":"alex.trainer@example.com","location":"Denver","gender":"nonbinary","userLevel":"intermediate","userGoal":"
+                  build strength","daysPerWeek":"3","height":"70","weight":"180","birthday":"1990-01-01","platform":"mobile"}}
 
-                  {"id":"1d537160-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:28.399287Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Membership","platform":"mobile"}}
+                  {"id":"1d537160-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:28.399287Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Membership","platform":"mobile"}}
 
-                  {"id":"1e592190-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:30.116244Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Linked
+                  {"id":"1e592190-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:30.116244Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Linked
                   Your Orders","platform":"mobile"}}
 
-                  {"id":"1ffdf7f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:32.816888Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Body '
+                  {"id":"1ffdf7f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:32.816888Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Body '
                 : type: string
                 ? ' Health","platform":"mobile"}}
 
-                  {"id":"22d3fb50-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.637412Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Body '
+                  {"id":"22d3fb50-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.637412Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Body '
                 : type: string
                 ? ' Health","platform":"mobile"}}
 
-                  {"id":"22d50cc0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.644168Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                  {"id":"22d50cc0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.644168Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                  {"id":"22f035e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Body Health Set","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.822155Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"weightPounds":"171","platform":"mobile"}}
+                  {"id":"22f035e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Body Health Set","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.822155Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"weightPounds":"171","platform":"mobile"}}
 
-                  {"id":"2ba95590-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:52.395178Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Push
+                  {"id":"2ba95590-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:52.395178Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Push
                   Notification Settings","platform":"mobile"}}
 
-                  {"id":"2d7478a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:55.466188Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom","platform":"mobile"}}
+                  {"id":"2d7478a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:55.466188Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom","platform":"mobile"}}
 
-                  {"id":"2f11ade0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:58.174487Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Explore","platform":"mobile"}}
+                  {"id":"2f11ade0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:58.174487Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Explore","platform":"mobile"}}
 
-                  {"id":"301673b0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:59.883538Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Explore:
+                  {"id":"301673b0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:59.883538Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Explore:
                   Movements - Filters","platform":"mobile"}}
 
-                  {"id":"3134b4f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:01.759347Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom","platform":"mobile"}}
+                  {"id":"3134b4f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:01.759347Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom","platform":"mobile"}}
 
-                  {"id":"3476e7a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:07.226140Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Delete
+                  {"id":"3476e7a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:07.226140Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Delete
                   workout","platform":"mobile"}}
 
-                  {"id":"34f78950-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:08.069474Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
+                  {"id":"34f78950-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:08.069474Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                  {"id":"36b2f4f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:10.975498Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Name
+                  {"id":"36b2f4f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:10.975498Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Name
                   Your Workout","platform":"mobile"}}
 
-                  {"id":"37878300-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:12.367910Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Create","modalTitle":"TonalDialog","platform":"mobile"}}
+                  {"id":"37878300-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:12.367910Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Create","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                  {"id":"37aa7450-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:12.578150Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom
+                  {"id":"37aa7450-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:12.578150Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom
                   Workout Draft Screen","platform":"mobile"}}
 
-                  {"id":"396da820-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:15.554752Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Custom
+                  {"id":"396da820-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:15.554752Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Custom
                   Workout Draft Screen","platform":"mobile"}}
 
-                  {"id":"39706740-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:15.572332Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                  {"id":"39706740-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:15.572332Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
                   {"id":"39b9a540-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Custom Workout
-                  Created","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:16.051790Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"customWorkoutId":"cae56f5e-effa-4c7a-b2f7-1a2ffc9f5669","customWorkoutDuration":"24","customWorkoutName":"PPL
+                  Created","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:16.051790Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"customWorkoutId":"cae56f5e-effa-4c7a-b2f7-1a2ffc9f5669","customWorkoutDuration":"24","customWorkoutName":"PPL
                   - Week 1: Pull (copy)","description":"","numberOfBlocks":"1","numberOfMoves":"5","platform":"mobile","howCreated":"Scratch"}}
 
-                  {"id":"39bc6460-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:16.057871Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom
+                  {"id":"39bc6460-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:16.057871Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom
                   Workout Confirmation Screen","platform":"mobile"}}
 
-                  {"id":"3a986c80-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:17.512390Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Not
+                  {"id":"3a986c80-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:17.512390Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Not
                   Now","screenTitle":"Custom Workout Confirmation Screen","platform":"mobile"}}
 
-                  {"id":"3bb240f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:19.359741Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Delete
+                  {"id":"3bb240f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:19.359741Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Delete
                   workout","platform":"mobile"}}
 
-                  {"id":"3c18a3e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:20.030359Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
+                  {"id":"3c18a3e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:20.030359Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                  {"id":"3d1f6580-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:21.752290Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Delete
+                  {"id":"3d1f6580-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:21.752290Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Delete
                   workout","platform":"mobile"}}
 
-                  {"id":"3d830950-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:22.405100Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
+                  {"id":"3d830950-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:22.405100Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                  {"id":"3e559b90-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:23.785684Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Delete
+                  {"id":"3e559b90-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:23.785684Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Delete
                   workout","platform":"mobile"}}
 
-                  {"id":"3eb2fdd0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:24.397357Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
+                  {"id":"3eb2fdd0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:24.397357Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                  {"id":"4008f0e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:26.637891Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Add
+                  {"id":"4008f0e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:26.637891Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Add
                   Custom Workout","screenTitle":"Custom Workouts","destination":"Custom Workout Draft Screen","platform":"mobile"}}
 
-                  {"id":"5851ad40-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:07.380696Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                  {"id":"5851ad40-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:07.380696Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                  {"id":"588196e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:07.682306Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom
+                  {"id":"588196e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:07.682306Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom
                   Workout Draft Screen","platform":"mobile"}}
 
-                  {"id":"5a91b230-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Block Added","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:11.155103Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"WorkoutId":"b0d0d838-4db3-40b5-92c9-15014e9dc220","WorkoutName":"Push
+                  {"id":"5a91b230-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Block Added","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:11.155103Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"WorkoutId":"b0d0d838-4db3-40b5-92c9-15014e9dc220","WorkoutName":"Push
                   C","numberOfBlocks":"4","platform":"mobile"}}
 
-                  {"id":"5a91b231-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:11.155296Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Add
+                  {"id":"5a91b231-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:11.155296Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Add
                   Block","screenTitle":"Custom Workout Draft Screen","platform":"mobile"}}
 
-                  {"id":"5b5465f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:12.431078Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Add
+                  {"id":"5b5465f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:12.431078Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Add
                   Move","screenTitle":"Custom Workout Draft Screen","platform":"mobile"}}
 
-                  {"id":"5b60c200-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:12.433212Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Movement
+                  {"id":"5b60c200-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:12.433212Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Movement
                   Picker screen","platform":"mobile"}}
 
-                  {"id":"5cec9220-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:15.041794Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Edit
+                  {"id":"5cec9220-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:15.041794Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Edit
                   Movement","platform":"mobile"}}'
                 : type: string
             example:
-              ? '{"id":"165d3760-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:16.726058Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Account","platform":"mobile"}}
+              ? '{"id":"165d3760-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:16.726058Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Account","platform":"mobile"}}
 
-                {"id":"165dd3a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:16.729957Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                {"id":"165dd3a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:16.729957Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                {"id":"197dd850-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Account Updated","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:21.973738Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"fieldUpdated":"firstName","firstName":"Jef","lastName":"Otano","userName":"jephpho","email":"otano.jeffrey@gmail.com","location":"Colorado","gender":"male","userLevel":"advanced","userGoal":"build
-                muscle","daysPerWeek":"4","height":"69","weight":"174","birthday":"1995-03-29","platform":"mobile"}}
+                {"id":"197dd850-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Account Updated","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:21.973738Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"fieldUpdated":"firstName","firstName":"Alex","lastName":"Trainer","userName":"alexfit","email":"alex.trainer@example.com","location":"Denver","gender":"nonbinary","userLevel":"intermediate","userGoal":"build
+                muscle","daysPerWeek":"3","height":"70","weight":"180","birthday":"1990-01-01","platform":"mobile"}}
 
-                {"id":"1a7fdf00-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:23.656593Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Edit
+                {"id":"1a7fdf00-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:23.656593Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Edit
                 Account","platform":"mobile"}}
 
-                {"id":"1bf281d0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.093204Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Account","platform":"mobile"}}
+                {"id":"1bf281d0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.093204Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Account","platform":"mobile"}}
 
-                {"id":"1bf2f700-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.096567Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                {"id":"1bf2f700-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.096567Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                {"id":"1c6c1ea0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Account Updated","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.890215Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"fieldUpdated":"firstName","firstName":"Jeff","lastName":"Otano","userName":"jephpho","email":"otano.jeffrey@gmail.com","location":"Colorado","gender":"male","userLevel":"advanced","userGoal":"build
-                muscle","daysPerWeek":"4","height":"69","weight":"174","birthday":"1995-03-29","platform":"mobile"}}
+                {"id":"1c6c1ea0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Account Updated","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:26.890215Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"fieldUpdated":"firstName","firstName":"Alex","lastName":"Trainer","userName":"alexfit","email":"alex.trainer@example.com","location":"Denver","gender":"nonbinary","userLevel":"intermediate","userGoal":"build
+                muscle","daysPerWeek":"3","height":"70","weight":"180","birthday":"1990-01-01","platform":"mobile"}}
 
-                {"id":"1d537160-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:28.399287Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Membership","platform":"mobile"}}
+                {"id":"1d537160-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:28.399287Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Membership","platform":"mobile"}}
 
-                {"id":"1e592190-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:30.116244Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Linked
+                {"id":"1e592190-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:30.116244Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Linked
                 Your Orders","platform":"mobile"}}
 
-                {"id":"1ffdf7f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:32.816888Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Body '
+                {"id":"1ffdf7f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:32.816888Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Body '
               : ""
               ? ' Health","platform":"mobile"}}
 
-                {"id":"22d3fb50-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.637412Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Body '
+                {"id":"22d3fb50-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.637412Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Body '
               : ""
               ? ' Health","platform":"mobile"}}
 
-                {"id":"22d50cc0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.644168Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                {"id":"22d50cc0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.644168Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                {"id":"22f035e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Body Health Set","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.822155Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"weightPounds":"171","platform":"mobile"}}
+                {"id":"22f035e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Body Health Set","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:37.822155Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"weightPounds":"171","platform":"mobile"}}
 
-                {"id":"2ba95590-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:52.395178Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Push
+                {"id":"2ba95590-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:52.395178Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Push
                 Notification Settings","platform":"mobile"}}
 
-                {"id":"2d7478a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:55.466188Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom","platform":"mobile"}}
+                {"id":"2d7478a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:55.466188Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom","platform":"mobile"}}
 
-                {"id":"2f11ade0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:58.174487Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Explore","platform":"mobile"}}
+                {"id":"2f11ade0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:58.174487Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Explore","platform":"mobile"}}
 
-                {"id":"301673b0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:59.883538Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Explore:
+                {"id":"301673b0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:52:59.883538Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Explore:
                 Movements - Filters","platform":"mobile"}}
 
-                {"id":"3134b4f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:01.759347Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom","platform":"mobile"}}
+                {"id":"3134b4f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:01.759347Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom","platform":"mobile"}}
 
-                {"id":"3476e7a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:07.226140Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Delete
+                {"id":"3476e7a0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:07.226140Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Delete
                 workout","platform":"mobile"}}
 
-                {"id":"34f78950-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:08.069474Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
+                {"id":"34f78950-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:08.069474Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                {"id":"36b2f4f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:10.975498Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Name
+                {"id":"36b2f4f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:10.975498Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Name
                 Your Workout","platform":"mobile"}}
 
-                {"id":"37878300-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:12.367910Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Create","modalTitle":"TonalDialog","platform":"mobile"}}
+                {"id":"37878300-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:12.367910Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Create","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                {"id":"37aa7450-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:12.578150Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom
+                {"id":"37aa7450-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:12.578150Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom
                 Workout Draft Screen","platform":"mobile"}}
 
-                {"id":"396da820-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:15.554752Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Custom
+                {"id":"396da820-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:15.554752Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Save","screenTitle":"Custom
                 Workout Draft Screen","platform":"mobile"}}
 
-                {"id":"39706740-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:15.572332Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                {"id":"39706740-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:15.572332Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                {"id":"39b9a540-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Custom Workout Created","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:16.051790Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"customWorkoutId":"cae56f5e-effa-4c7a-b2f7-1a2ffc9f5669","customWorkoutDuration":"24","customWorkoutName":"PPL
+                {"id":"39b9a540-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Custom Workout Created","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:16.051790Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"customWorkoutId":"cae56f5e-effa-4c7a-b2f7-1a2ffc9f5669","customWorkoutDuration":"24","customWorkoutName":"PPL
                 - Week 1: Pull (copy)","description":"","numberOfBlocks":"1","numberOfMoves":"5","platform":"mobile","howCreated":"Scratch"}}
 
-                {"id":"39bc6460-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:16.057871Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom
+                {"id":"39bc6460-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:16.057871Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom
                 Workout Confirmation Screen","platform":"mobile"}}
 
-                {"id":"3a986c80-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:17.512390Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Not
+                {"id":"3a986c80-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:17.512390Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Not
                 Now","screenTitle":"Custom Workout Confirmation Screen","platform":"mobile"}}
 
-                {"id":"3bb240f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:19.359741Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Delete
+                {"id":"3bb240f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:19.359741Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Delete
                 workout","platform":"mobile"}}
 
-                {"id":"3c18a3e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:20.030359Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
+                {"id":"3c18a3e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:20.030359Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                {"id":"3d1f6580-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:21.752290Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Delete
+                {"id":"3d1f6580-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:21.752290Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Delete
                 workout","platform":"mobile"}}
 
-                {"id":"3d830950-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:22.405100Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
+                {"id":"3d830950-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:22.405100Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                {"id":"3e559b90-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:23.785684Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"Delete
+                {"id":"3e559b90-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:23.785684Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"Delete
                 workout","platform":"mobile"}}
 
-                {"id":"3eb2fdd0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:24.397357Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
+                {"id":"3eb2fdd0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:24.397357Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Delete","modalTitle":"TonalDialog","platform":"mobile"}}
 
-                {"id":"4008f0e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:26.637891Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Add
+                {"id":"4008f0e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:53:26.637891Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Add
                 Custom Workout","screenTitle":"Custom Workouts","destination":"Custom Workout Draft Screen","platform":"mobile"}}
 
-                {"id":"5851ad40-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:07.380696Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
+                {"id":"5851ad40-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Modal Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:07.380696Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"modalName":"loading","platform":"mobile"}}
 
-                {"id":"588196e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:07.682306Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Custom
+                {"id":"588196e0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:07.682306Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Custom
                 Workout Draft Screen","platform":"mobile"}}
 
-                {"id":"5a91b230-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Block Added","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:11.155103Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"WorkoutId":"b0d0d838-4db3-40b5-92c9-15014e9dc220","WorkoutName":"Push
+                {"id":"5a91b230-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Block Added","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:11.155103Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"WorkoutId":"b0d0d838-4db3-40b5-92c9-15014e9dc220","WorkoutName":"Push
                 C","numberOfBlocks":"4","platform":"mobile"}}
 
-                {"id":"5a91b231-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:11.155296Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Add
+                {"id":"5a91b231-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:11.155296Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Add
                 Block","screenTitle":"Custom Workout Draft Screen","platform":"mobile"}}
 
-                {"id":"5b5465f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:12.431078Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"buttonText":"Add
+                {"id":"5b5465f0-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Button Tapped","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:12.431078Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"buttonText":"Add
                 Move","screenTitle":"Custom Workout Draft Screen","platform":"mobile"}}
 
-                {"id":"5b60c200-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:12.433212Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Movement
+                {"id":"5b60c200-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:12.433212Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Movement
                 Picker screen","platform":"mobile"}}
 
-                {"id":"5cec9220-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"02fd9c65-209f-11f1-9cd8-970e5a3e8a59","deviceId":"8DD0117A-7697-402A-8037-C9EA2E96C995","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:15.041794Z","anonymousId":"8DD0117A-7697-402A-8037-C9EA2E96C995","userId":"f12eafc8-b9b1-3146-b0cf-eb39a08203e2","osBuild":"","properties":{"screenTitle":"Edit
+                {"id":"5cec9220-20a0-11f1-9cd8-970e5a3e8a59","type":"UserEvent","source":"Mobile","name":"Screen Viewed","sessionId":"00000000-0000-4000-8000-000000000002","deviceId":"00000000-0000-4000-8000-000000000001","deviceModel":"iPhone18,1","deviceVersion":"","appName":"Tonal","appVersion":"8.8.0","appBuild":"4004631","osVersion":"26.4","osName":"ios","timezone":"America/Denver","timestamp":"2026-03-15T18:54:15.041794Z","anonymousId":"00000000-0000-4000-8000-000000000001","userId":"00000000-0000-4000-8000-000000000003","osBuild":"","properties":{"screenTitle":"Edit
                 Movement","platform":"mobile"}}'
               : ""
       tags:
@@ -6905,7 +6905,7 @@ paths:
                       workoutId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       resourceId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       assetId: 27b1f756-be25-42df-8993-2a6334927f79
-                      title: Jeff's Daily Lift
+                      title: Alex's Daily Lift
                       duration: 3178
                       level: ADVANCED
                       targetArea: UPPER BODY
@@ -8271,7 +8271,7 @@ paths:
                       workoutId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       resourceId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       assetId: 27b1f756-be25-42df-8993-2a6334927f79
-                      title: Jeff's Daily Lift
+                      title: Alex's Daily Lift
                       duration: 3178
                       level: ADVANCED
                       targetArea: UPPER BODY
@@ -9288,7 +9288,7 @@ paths:
               example:
                 id: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                 deletedAt: null
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 name: Push B
                 workoutId: 5849f69c-35e3-47b3-821d-fcc31e82990f
                 isInProgram: false
@@ -10017,7 +10017,7 @@ paths:
                         repetitionTotal: 4
                         triggeredFeedback:
                           - id: b6288fc9-a38e-3443-afd9-1bacc0f914b8
-                            userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                            userId: 00000000-0000-4000-8000-000000000003
                             createdAt: "2026-03-12T00:58:00.582413Z"
                             setActivityId: 6eb6526e-ad78-40af-b3bb-cd36a7861861
                             movementId: 8571813d-b302-4cbe-a3b5-cc805a046b7d
@@ -10106,7 +10106,7 @@ paths:
                         repetitionTotal: 4
                         triggeredFeedback:
                           - id: 72f9fbc5-1a6c-3526-ba16-94f0b0b8a7d8
-                            userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                            userId: 00000000-0000-4000-8000-000000000003
                             createdAt: "2026-03-12T01:03:51.926874Z"
                             setActivityId: 4c84bb25-f6f9-40b1-92df-77ff5cd897ea
                             movementId: 8571813d-b302-4cbe-a3b5-cc805a046b7d
@@ -10149,7 +10149,7 @@ paths:
                 lastWorkoutSummary:
                   id: eb8e6a83-f501-4f71-9db6-a97ddcc0450b
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   name: Push B
                   workoutId: 5849f69c-35e3-47b3-821d-fcc31e82990f
                   isInProgram: false
@@ -10216,7 +10216,7 @@ paths:
                           repetitionTotal: 5
                           triggeredFeedback:
                             - id: ee8af2d5-4d94-37d1-a622-da7c3f291703
-                              userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                              userId: 00000000-0000-4000-8000-000000000003
                               createdAt: "2026-01-26T15:07:25.796677Z"
                               setActivityId: d2af647a-396f-41ff-9709-31ef22198adc
                               movementId: 8edc0211-4594-4e5e-8e1b-b05dfc1d67c7
@@ -10240,7 +10240,7 @@ paths:
                               priority: 20
                               shownInSetSummary: false
                             - id: f8bd179a-206d-3934-978e-ba64e5074c35
-                              userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                              userId: 00000000-0000-4000-8000-000000000003
                               createdAt: "2026-01-26T15:07:25.796677Z"
                               setActivityId: d2af647a-396f-41ff-9709-31ef22198adc
                               movementId: 8edc0211-4594-4e5e-8e1b-b05dfc1d67c7
@@ -10373,7 +10373,7 @@ paths:
                           repetitionTotal: 4
                           triggeredFeedback:
                             - id: d32fe070-17e4-34f3-b0dc-0c8fe52b845c
-                              userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                              userId: 00000000-0000-4000-8000-000000000003
                               createdAt: "2026-01-26T15:18:00.237643Z"
                               setActivityId: 7ed88cf5-17f1-40c7-8c4a-36135cda99e9
                               movementId: 03c61400-a790-4fa9-bd34-961500820437
@@ -10395,7 +10395,7 @@ paths:
                               priority: 20
                               shownInSetSummary: false
                             - id: e3ea72f6-4983-319c-889a-21285ca1d6e0
-                              userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                              userId: 00000000-0000-4000-8000-000000000003
                               createdAt: "2026-01-26T15:18:00.237643Z"
                               setActivityId: 7ed88cf5-17f1-40c7-8c4a-36135cda99e9
                               movementId: 03c61400-a790-4fa9-bd34-961500820437
@@ -10442,7 +10442,7 @@ paths:
                           repetitionTotal: 4
                           triggeredFeedback:
                             - id: 2999714f-af18-385b-af02-d8db3a4b0c87
-                              userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                              userId: 00000000-0000-4000-8000-000000000003
                               createdAt: "2026-01-26T15:21:02.83745Z"
                               setActivityId: 19984167-e970-4b3b-a102-50cdb43e2249
                               movementId: 03c61400-a790-4fa9-bd34-961500820437
@@ -10515,7 +10515,7 @@ paths:
                           repetitionTotal: 4
                           triggeredFeedback:
                             - id: 0b0678da-812e-3599-b220-c130df076fc4
-                              userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                              userId: 00000000-0000-4000-8000-000000000003
                               createdAt: "2026-01-26T15:27:32.449066Z"
                               setActivityId: 7e9dd1d0-fff0-4236-a17d-7f375db1da2f
                               movementId: 03c61400-a790-4fa9-bd34-961500820437
@@ -11173,7 +11173,7 @@ paths:
               example:
                 - id: 8b6b9aae-a5a9-4931-96a1-5add13d21b72
                   name: Get Lean
-                  description: Burn calories and build muscle to shift your body composition.
+                  description: Burn calories and build strength to shift your body composition.
                   active: true
                   filterItemId: 1ca9ca28-82e9-4584-94b3-364178382c03
                 - id: b27138bc-0624-4abb-babf-9b4be911dd5b
@@ -11486,10 +11486,10 @@ paths:
                   isFollowing:
                     type: boolean
               example:
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 leaderboardId: f8fb8884-7ab1-422a-9826-d0b80c58923a
-                username: jephpho
-                dateOfBirth: "1995-03-29T00:00:00Z"
+                username: alexfit
+                dateOfBirth: "1990-01-01T00:00:00Z"
                 sex: MALE
                 rank: 40664
                 score: 5.00313
@@ -12557,7 +12557,7 @@ paths:
                     Old school bodybuilding meets modern training science in this high-volume, hypertrophy program
                     designed to build and define muscle. Utilizing a classic bodybuilding split–back, chest, legs, shoulders/core,
                     and arms–to drive maximum muscle growth while optimizing for recovery, these workouts incorporate eccentric
-                    loading, Drop Sets, and more advanced techniques to accelerate results. This precise and targeted training
+                    loading, Drop Sets, and more intermediate techniques to accelerate results. This precise and targeted training
                     method pushes your limits intelligently for impressive muscle gains.
                   productionCode: AC_EM_ST_ADV_2026_01_16_NY
                   workoutsPerWeek: 5
@@ -13919,7 +13919,7 @@ paths:
                   seriously shredded. You’ll follow the science-backed method of periodization, alternating between phases
                   of accumulation (high-rep sets for hypertrophy) and intensification (heavy lifting for strength gains) to
                   stimulate all your muscle fibers for ultimate gains. Bust through plateaus and continue challenging yourself
-                  by rotating through different advanced lifting techniques, including pre-fatigue training, cluster sets,
+                  by rotating through different intermediate lifting techniques, including pre-fatigue training, cluster sets,
                   and drop sets.
                 productionCode: JO_RO_TFLP_1358_NY
                 workoutsPerWeek: 4
@@ -14727,10 +14727,10 @@ paths:
                     type: string
               example:
                 id: b958435e-38dd-4749-bdf9-5a57855dc185
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 role: mobile
                 connectionId: b5987a32-36eb-4aa4-89c1-bf6723d2863f
-                deviceId: 8DD0117A-7697-402A-8037-C9EA2E96C995
+                deviceId: 00000000-0000-4000-8000-000000000001
       parameters:
         - name: userId
           in: path
@@ -15103,11 +15103,11 @@ paths:
                 id: 83a421b8-d9f9-44f6-bc37-42dc968ade50
                 createdAt: "2025-09-03T20:32:51.166124Z"
                 updatedAt: "2025-09-03T20:34:57.630276Z"
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 externalCustomerId: cus_SzM4bzZzCfvyTs
                 taxLocValid: true
                 taxLocUpdatedAt: "2025-09-03T20:34:37.030404Z"
-                email: otano.jeffrey@gmail.com
+                email: alex.trainer@example.com
                 receiveInvoices: true
                 planTypeId: e38dd932-0059-44c8-bc17-1da7a3d56d47
                 cusTypeId: 6f6373dc-1f05-5ab0-a0bc-21a2f38c9898
@@ -15584,7 +15584,7 @@ paths:
                     filterItemId: 8f1c9652-a14f-498f-91b9-220596bc95c0
                   - id: 8b6b9aae-a5a9-4931-96a1-5add13d21b72
                     name: Get Lean
-                    description: Burn calories and build muscle to shift your body composition.
+                    description: Burn calories and build strength to shift your body composition.
                     active: true
                     filterItemId: 1ca9ca28-82e9-4584-94b3-364178382c03
                   - id: b27138bc-0624-4abb-babf-9b4be911dd5b
@@ -15688,7 +15688,7 @@ paths:
                   name: Strength
                   description:
                     "Strength is the foundation of fitness and the signature Tonal format. Choose from over a hundred
-                    workouts based on science to help you build muscle, improve fitness, or get lean.  "
+                    workouts based on science to help you build strength, improve fitness, or get lean.  "
                   assetId: 3582c15c-0dd5-41e4-9a45-2c83f4893489
                   infoVidId: 00000000-0000-0000-0000-000000000000
                   filterItemId: 5ee70f4c-1734-4135-a14f-854138302fae
@@ -15696,7 +15696,7 @@ paths:
                   name: High Intensity
                   description:
                     "These high intensity strength workouts will get you sweaty and strong. You’ll battle the clock
-                    with full body routines designed to max out your heart rate while helping you build muscle and endurance. "
+                    with full body routines designed to max out your heart rate while helping you build strength and endurance. "
                   assetId: 07915b86-3939-40f4-a9a9-ae8d2b6105ec
                   infoVidId: 00000000-0000-0000-0000-000000000000
                   filterItemId: 085e4ca0-cda4-41f9-b826-e805c067e458
@@ -15917,7 +15917,7 @@ paths:
                   publishedAt: "2026-03-12T01:36:34.524855Z"
                   localPublishedAt: "2026-03-11T19:36:34-06:00"
                   type: Custom
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   style: 2020-Branding
                   trainingType: Custom
                   trainingTypeIds: null
@@ -15966,7 +15966,7 @@ paths:
                   publishedAt: "2025-11-30T19:39:35.910791Z"
                   localPublishedAt: "2025-11-30T12:39:35-07:00"
                   type: Custom
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   style: 2020-Branding
                   trainingType: Custom
                   trainingTypeIds: null
@@ -16022,7 +16022,7 @@ paths:
                   publishedAt: "2025-11-27T20:32:48.479968Z"
                   localPublishedAt: "2025-11-27T13:32:48-07:00"
                   type: Custom
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   style: 2020-Branding
                   trainingType: Custom
                   trainingTypeIds: null
@@ -16076,7 +16076,7 @@ paths:
                   publishedAt: "2025-11-27T16:19:01.919546Z"
                   localPublishedAt: "2025-11-27T09:19:01-07:00"
                   type: Custom
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   style: 2020-Branding
                   trainingType: Custom
                   trainingTypeIds: null
@@ -16131,7 +16131,7 @@ paths:
                   publishedAt: "2025-09-05T02:47:26.131661Z"
                   localPublishedAt: "2025-09-04T20:47:26-06:00"
                   type: Custom
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   style: 2020-Branding
                   trainingType: Custom
                   trainingTypeIds: null
@@ -16183,7 +16183,7 @@ paths:
                   publishedAt: "2025-09-05T02:42:07.63095Z"
                   localPublishedAt: "2025-09-04T20:42:07-06:00"
                   type: Custom
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   style: 2020-Branding
                   trainingType: Custom
                   trainingTypeIds: null
@@ -16236,7 +16236,7 @@ paths:
                   publishedAt: "2025-09-05T02:36:54.449747Z"
                   localPublishedAt: "2025-09-04T20:36:54-06:00"
                   type: Custom
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   style: 2020-Branding
                   trainingType: Custom
                   trainingTypeIds: null
@@ -16730,7 +16730,7 @@ paths:
                 publishedAt: "2026-03-15T18:54:32.277855218Z"
                 localPublishedAt: "2026-03-15T12:54:32-06:00"
                 type: Custom
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 style: 2020-Branding
                 trainingType: Custom
                 trainingTypeIds: null
@@ -17509,7 +17509,7 @@ paths:
                 publishedAt: "2026-03-12T01:36:34.524855Z"
                 localPublishedAt: "2026-03-11T19:36:34-06:00"
                 type: Custom
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 style: 2020-Branding
                 trainingType: Custom
                 trainingTypeIds: null
@@ -18235,7 +18235,7 @@ paths:
                 publishedAt: "2026-03-12T01:36:34.524855Z"
                 localPublishedAt: "2026-03-11T19:36:34-06:00"
                 type: Custom
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 style: 2020-Branding
                 trainingType: Custom
                 trainingTypeIds: null
@@ -18648,25 +18648,25 @@ paths:
                   primaryDeviceType:
                     type: string
               example:
-                id: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                id: 00000000-0000-4000-8000-000000000003
                 createdAt: 2025-08-08T23:00:55.351+0000
                 updatedAt: "2026-03-15T18:52:37.687537Z"
                 deletedAt: null
-                email: otano.jeffrey@gmail.com
-                firstName: Jeff
-                lastName: Otano
+                email: alex.trainer@example.com
+                firstName: Alex
+                lastName: Trainer
                 gender: MALE
                 heightInches: 69
                 weightPounds: 171
                 auth0Id: auth0|689681a6f5657a6d3ca0f610
-                dateOfBirth: "1995-03-29"
+                dateOfBirth: "1990-01-01"
                 isGuestAccount: false
                 isDemoAccount: false
                 watchedSafetyVideo: true
                 recentMobileDevice:
                   deviceId: 66dcf74c-83d1-44f1-b550-5f7a0bf85340
-                  tonalDeviceId: 8DD0117A-7697-402A-8037-C9EA2E96C995
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  tonalDeviceId: 00000000-0000-4000-8000-000000000001
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2025-08-08T23:00:56.681777Z"
                   updatedAt: "2026-03-15T18:44:48.718637Z"
                   loggedIn: true
@@ -18681,33 +18681,33 @@ paths:
                   appVersion: 8.8.0
                   platform: ios
                 emailVerified: true
-                username: jephpho
+                username: alexfit
                 workoutsPerWeek: 4
                 tonalStatus: purchased
                 social: null
                 profileAssetID: null
                 mobileWorkoutsEnabled: true
                 accountType: PublicUser
-                location: Colorado
+                location: Denver
                 sharingCustomWorkoutsDisabled: false
                 purpose: Residential
                 level: ADVANCED
                 goalId: b27138bc-0624-4abb-babf-9b4be911dd5b
                 goals:
                   - id: 2b1dfeaa-b0f4-476f-9586-ff2d2a3f9b0b
-                    userID: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userID: 00000000-0000-4000-8000-000000000003
                     goalID: b27138bc-0624-4abb-babf-9b4be911dd5b
                     tier: 1
                   - id: 560bb02a-ce9d-42b7-b7c1-3bcba1b0edd2
-                    userID: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userID: 00000000-0000-4000-8000-000000000003
                     goalID: 04bae524-6a6d-4ed8-bf40-e17260364649
                     tier: 2
                   - id: 46412f7d-03fd-4e23-b552-3b6bd723db2c
-                    userID: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userID: 00000000-0000-4000-8000-000000000003
                     goalID: d1eaa16e-fb4c-4d5e-8077-5ab6a35c13a6
                     tier: 3
                   - id: d3aad4e1-65dc-42a7-8392-50984c115797
-                    userID: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userID: 00000000-0000-4000-8000-000000000003
                     goalID: d165ab32-17cf-4c6d-859a-e423eac0e591
                     tier: 3
                 workoutDurationMin: 2700
@@ -18969,7 +18969,7 @@ paths:
                   completedAchievements:
                     - id: 0ebc5863-a213-442c-8a1a-b162e4b40ddc
                       achievementId: 46c4e699-6a39-4a93-be68-71344d097cc7
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-10-19T18:16:00.540664Z"
                       name: 10 Workouts
                       description: Way to show up! You just earned a new workout milestone.
@@ -18992,7 +18992,7 @@ paths:
                       localTimestamp: "2025-10-19T12:16:00.540664-06:00"
                     - id: 8d8e33ee-2155-4f77-b707-4de7180b4e1d
                       achievementId: f1198fd6-b5a6-4d06-92b1-ec2f7abf01af
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-11-29T21:02:07.040178Z"
                       name: 25 Workouts
                       description: Way to show up! You just earned a new workout milestone.
@@ -19129,7 +19129,7 @@ paths:
                   completedAchievements:
                     - id: 36c41596-c361-450a-9d0a-30f5313343ed
                       achievementId: 8fb0e573-3223-4bec-adac-9154185933db
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-10-19T18:16:00.540666Z"
                       name: 50,000 lbs
                       description: That's a lot of lifting! You just earned a new volume milestone.
@@ -19152,7 +19152,7 @@ paths:
                       localTimestamp: "2025-10-19T12:16:00.540666-06:00"
                     - id: f79e2e62-1ace-4ac2-adc2-34d7ea3a827b
                       achievementId: 64eb0a73-d3ce-4839-9e9f-3f33f4484a07
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-10-30T01:51:39.732476Z"
                       name: 100,000 lbs
                       description: That's a lot of lifting! You just earned a new volume milestone.
@@ -19289,7 +19289,7 @@ paths:
                   completedAchievements:
                     - id: bdc8188d-cb21-4dc6-81dd-9035c0441aac
                       achievementId: 3ffb8393-4ad2-4764-ba65-46f7a1ee1340
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-11-04T02:30:10.713568Z"
                       name: 5 Week Streak
                       description: You're on fire! You just earned a new streak milestone.
@@ -19312,7 +19312,7 @@ paths:
                       localTimestamp: "2025-11-03T19:30:10.713568-07:00"
                     - id: 2501f215-313c-4291-a366-d39eeeb49768
                       achievementId: cfdbdd03-0d1b-402f-8cd2-735b3033a8a1
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-12-13T04:16:36.826846Z"
                       name: 10 Week Streak
                       description: You're on fire! You just earned a new streak milestone.
@@ -19452,7 +19452,7 @@ paths:
                   completedAchievements:
                     - id: 358bdd0e-8553-40b1-a21d-725ff41b9261
                       achievementId: 0ca6f424-252c-4188-9c1f-fffdc41b69b3
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-11-29T21:03:57.883735Z"
                       name: Power Pose
                       description: You shared your post-workout selfie with the world. Keep shining!
@@ -19474,7 +19474,7 @@ paths:
                       localTimestamp: "2025-11-29T14:03:57.883735-07:00"
                     - id: 1083bca0-4435-4a9a-adb6-92466ad5c41c
                       achievementId: 7dac1d8e-3216-411f-bb57-a22f2166feda
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-11-27T21:54:42.143178Z"
                       name: Turkey Burn
                       description: You worked out on Thanksgiving
@@ -19497,7 +19497,7 @@ paths:
                       localTimestamp: "2025-11-27T14:54:42.143178-07:00"
                     - id: d03157dd-6da7-41ba-8844-a47aaafed319
                       achievementId: 2964d327-67e8-4e92-8d2a-ee23d259c94d
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-11-20T02:37:57.645228Z"
                       name: Ankle Straps
                       description: You crushed your first Ankle Straps workout! Your legs will thank you later.
@@ -19520,7 +19520,7 @@ paths:
                       localTimestamp: "2025-11-19T19:37:57.645228-07:00"
                     - id: d443d0f8-8d18-440f-a0c6-782a64db6d17
                       achievementId: 3a1d8743-a32f-4430-99fd-1e1a73075f49
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-11-20T02:37:57.624194Z"
                       name: 25% Stronger
                       description: High five! Your Strength Score has increased 25%.
@@ -19543,7 +19543,7 @@ paths:
                       localTimestamp: "2025-11-19T19:37:57.624194-07:00"
                     - id: 0d97d185-dd4a-4a0d-a47e-2363baa4e13a
                       achievementId: 20e33518-0b15-49b9-8907-6696b54df875
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-10-08T01:01:39.933376Z"
                       name: Stronger Together
                       description: Tonal for Two! You completed a partner workout.
@@ -19566,7 +19566,7 @@ paths:
                       localTimestamp: "2025-10-07T19:01:39.933376-06:00"
                     - id: 3b7c4d08-7a05-4023-b184-0e21594a9448
                       achievementId: 0b30d0bd-5e06-493f-89dc-0217d771a441
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-09-10T02:02:30.537752Z"
                       name: DIY
                       description: You created and completed your own custom workout!
@@ -19589,7 +19589,7 @@ paths:
                       localTimestamp: "2025-09-09T20:02:30.537752-06:00"
                     - id: be4e7c1d-0d5a-4b0a-b0e1-5b6232074180
                       achievementId: e6edccef-2347-4940-a8a7-b68b47d472bc
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-09-04T03:15:09.304703Z"
                       name: Starting Weights
                       description: You've completed your Tonal strength assessment. Never worry about setting your weights again!
@@ -19612,7 +19612,7 @@ paths:
                       localTimestamp: "2025-09-03T21:15:09.304703-06:00"
                     - id: 2c925942-ae25-4dfb-88e8-c50b92b2dc25
                       achievementId: 024ddd7f-2e15-4942-abaa-b7be4e8acda4
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-09-04T02:17:59.236015Z"
                       name: Night Owl
                       description: You worked out after 8pm!
@@ -19635,7 +19635,7 @@ paths:
                       localTimestamp: "2025-09-03T20:17:59.236015-06:00"
                     - id: 2a42fc15-d04d-4af1-924c-03f93f797f99
                       achievementId: 977b2e9f-c2fc-4349-a0cd-e45a24d123a8
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-08-12T01:37:29.808896Z"
                       name: Fitness Fusionist
                       description: You logged your first non-Tonal activity!
@@ -19658,7 +19658,7 @@ paths:
                       localTimestamp: "2025-08-11T19:37:29.808896-06:00"
                     - id: 7e66d76e-7518-4007-bb58-a541f7d24f90
                       achievementId: eca6ed84-3607-4128-8dbe-8f6936d99ebc
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-08-08T23:01:28.24461Z"
                       name: Goal-setter
                       description: Way to set your Training Goals!
@@ -19689,7 +19689,7 @@ paths:
                   completedAchievements:
                     - id: 397dca8c-5c64-4819-adf6-1005943b3031
                       achievementId: 8c076cad-c20c-415e-a795-0229b11e6e98
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-09-10T02:03:08.20401Z"
                       name: First Weekly Target Hit
                       description: You’re on the path to progress! You just earned a new weekly target milestone.
@@ -19712,7 +19712,7 @@ paths:
                       localTimestamp: "2025-09-09T20:03:08.20401-06:00"
                     - id: ccc4804a-a9fb-49b1-b805-8418a71b1308
                       achievementId: 7c18132d-7069-40f5-b902-df11d8cdd9f4
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-10-19T18:16:28.122161Z"
                       name: 5 Weekly Targets Hit
                       description: You’re on the path to progress! You just earned a new weekly target milestone.
@@ -19735,7 +19735,7 @@ paths:
                       localTimestamp: "2025-10-19T12:16:28.122161-06:00"
                     - id: 031eb2d0-932c-450c-9df6-955e7127be7b
                       achievementId: eb7824c4-a60f-43c5-b460-c1783da7a8f2
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2025-10-30T01:52:25.278566Z"
                       name: 10 Weekly Targets Hit
                       description: You’re on the path to progress! You just earned a new weekly target milestone.
@@ -19758,7 +19758,7 @@ paths:
                       localTimestamp: "2025-10-29T19:52:25.278566-06:00"
                     - id: d3b48851-6c8f-4331-b31e-bb21e11a31f5
                       achievementId: 9ebee08c-6ced-4b7e-b367-6860836aa8c3
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2026-02-16T01:26:40.664281Z"
                       name: 25 Weekly Targets Hit
                       description: You’re on the path to progress! You just earned a new weekly target milestone.
@@ -19840,7 +19840,7 @@ paths:
                   completedAchievements:
                     - id: fc149d74-d559-4a89-bc7b-5a3f7e52bc08
                       achievementId: 705e8294-0faa-453d-8987-7be69854c2b9
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2026-01-03T04:14:14.228688Z"
                       name: 1 Hour of Time Under Tension
                       description: Nice job lifting with control! You've earned a new time under tension milestone.
@@ -19862,7 +19862,7 @@ paths:
                       localTimestamp: "2026-01-02T21:14:14.228688-07:00"
                     - id: 5983495b-9733-4858-9d45-866dd516ec87
                       achievementId: ba8adcc9-a990-4407-a1f4-8e025fd1c1f5
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       createdAt: "2026-02-16T01:25:47.666611Z"
                       name: 5 Hours of Time Under Tension
                       description: Nice job lifting with control! You've earned a new time under tension milestone.
@@ -20179,7 +20179,7 @@ paths:
               example:
                 - id: d3b48851-6c8f-4331-b31e-bb21e11a31f5
                   achievementId: 9ebee08c-6ced-4b7e-b367-6860836aa8c3
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2026-02-16T01:26:40.664281Z"
                   name: 25 Weekly Targets Hit
                   description: You’re on the path to progress! You just earned a new weekly target milestone.
@@ -20205,7 +20205,7 @@ paths:
                   localTimestamp: "2026-02-15T18:26:40.664281-07:00"
                 - id: 5983495b-9733-4858-9d45-866dd516ec87
                   achievementId: ba8adcc9-a990-4407-a1f4-8e025fd1c1f5
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2026-02-16T01:25:47.666611Z"
                   name: 5 Hours of Time Under Tension
                   description: Nice job lifting with control! You've earned a new time under tension milestone.
@@ -20231,7 +20231,7 @@ paths:
                   localTimestamp: "2026-02-15T18:25:47.666611-07:00"
                 - id: fc149d74-d559-4a89-bc7b-5a3f7e52bc08
                   achievementId: 705e8294-0faa-453d-8987-7be69854c2b9
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2026-01-03T04:14:14.228688Z"
                   name: 1 Hour of Time Under Tension
                   description: Nice job lifting with control! You've earned a new time under tension milestone.
@@ -20256,7 +20256,7 @@ paths:
                   localTimestamp: "2026-01-02T21:14:14.228688-07:00"
                 - id: 2501f215-313c-4291-a366-d39eeeb49768
                   achievementId: cfdbdd03-0d1b-402f-8cd2-735b3033a8a1
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2025-12-13T04:16:36.826846Z"
                   name: 10 Week Streak
                   description: You're on fire! You just earned a new streak milestone.
@@ -20282,7 +20282,7 @@ paths:
                   localTimestamp: "2025-12-12T21:16:36.826846-07:00"
                 - id: 358bdd0e-8553-40b1-a21d-725ff41b9261
                   achievementId: 0ca6f424-252c-4188-9c1f-fffdc41b69b3
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2025-11-29T21:03:57.883735Z"
                   name: Power Pose
                   description: You shared your post-workout selfie with the world. Keep shining!
@@ -20307,7 +20307,7 @@ paths:
                   localTimestamp: "2025-11-29T14:03:57.883735-07:00"
                 - id: 8d8e33ee-2155-4f77-b707-4de7180b4e1d
                   achievementId: f1198fd6-b5a6-4d06-92b1-ec2f7abf01af
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2025-11-29T21:02:07.040178Z"
                   name: 25 Workouts
                   description: Way to show up! You just earned a new workout milestone.
@@ -20333,7 +20333,7 @@ paths:
                   localTimestamp: "2025-11-29T14:02:07.040178-07:00"
                 - id: 1083bca0-4435-4a9a-adb6-92466ad5c41c
                   achievementId: 7dac1d8e-3216-411f-bb57-a22f2166feda
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2025-11-27T21:54:42.143178Z"
                   name: Turkey Burn
                   description: You worked out on Thanksgiving
@@ -20359,7 +20359,7 @@ paths:
                   localTimestamp: "2025-11-27T14:54:42.143178-07:00"
                 - id: d03157dd-6da7-41ba-8844-a47aaafed319
                   achievementId: 2964d327-67e8-4e92-8d2a-ee23d259c94d
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2025-11-20T02:37:57.645228Z"
                   name: Ankle Straps
                   description: You crushed your first Ankle Straps workout! Your legs will thank you later.
@@ -20385,7 +20385,7 @@ paths:
                   localTimestamp: "2025-11-19T19:37:57.645228-07:00"
                 - id: d443d0f8-8d18-440f-a0c6-782a64db6d17
                   achievementId: 3a1d8743-a32f-4430-99fd-1e1a73075f49
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2025-11-20T02:37:57.624194Z"
                   name: 25% Stronger
                   description: High five! Your Strength Score has increased 25%.
@@ -20411,7 +20411,7 @@ paths:
                   localTimestamp: "2025-11-19T19:37:57.624194-07:00"
                 - id: bdc8188d-cb21-4dc6-81dd-9035c0441aac
                   achievementId: 3ffb8393-4ad2-4764-ba65-46f7a1ee1340
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   createdAt: "2025-11-04T02:30:10.713568Z"
                   name: 5 Week Streak
                   description: You're on fire! You just earned a new streak milestone.
@@ -20736,7 +20736,7 @@ paths:
                     facebookId: null
                     following: true
                 - activityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   activityTime: "2026-03-11T23:36:30.959895Z"
                   activityType: Internal
                   workoutPreview:
@@ -20759,14 +20759,14 @@ paths:
                     totalAchievements: 0
                     activityType: Internal
                   socialProfileTile:
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     createdAt: "2025-08-08T23:03:32.961056Z"
                     updatedAt: "0001-01-01T00:00:00Z"
-                    username: jephpho
+                    username: alexfit
                     facebookId: null
                     following: false
                 - activityId: ed6c6ecd-83fa-45f1-8883-2f90279cbac8
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   activityTime: "2026-03-10T14:01:20.198741Z"
                   activityType: Internal
                   workoutPreview:
@@ -20789,14 +20789,14 @@ paths:
                     totalAchievements: 0
                     activityType: Internal
                   socialProfileTile:
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     createdAt: "2025-08-08T23:03:32.961056Z"
                     updatedAt: "0001-01-01T00:00:00Z"
-                    username: jephpho
+                    username: alexfit
                     facebookId: null
                     following: false
                 - activityId: b0ef7cd2-2db5-4551-9f5b-0e53f99ad34d
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   activityTime: "2026-03-08T18:18:56.617476Z"
                   activityType: External
                   workoutPreview:
@@ -20821,14 +20821,14 @@ paths:
                     source: Apple Watch
                     externalWorkoutType: walking
                   socialProfileTile:
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     createdAt: "2025-08-08T23:03:32.961056Z"
                     updatedAt: "0001-01-01T00:00:00Z"
-                    username: jephpho
+                    username: alexfit
                     facebookId: null
                     following: false
                 - activityId: 9c277172-8c1e-47ed-b82b-9cfefcbf825f
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   activityTime: "2026-03-03T02:24:21.274173Z"
                   activityType: External
                   workoutPreview:
@@ -20853,14 +20853,14 @@ paths:
                     source: Apple Watch
                     externalWorkoutType: pickleball
                   socialProfileTile:
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     createdAt: "2025-08-08T23:03:32.961056Z"
                     updatedAt: "0001-01-01T00:00:00Z"
-                    username: jephpho
+                    username: alexfit
                     facebookId: null
                     following: false
                 - activityId: 7e8c4efc-c861-4001-8c99-5e7860e29264
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   activityTime: "2026-02-25T01:38:36.546221Z"
                   activityType: External
                   workoutPreview:
@@ -20885,14 +20885,14 @@ paths:
                     source: Apple Watch
                     externalWorkoutType: pickleball
                   socialProfileTile:
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     createdAt: "2025-08-08T23:03:32.961056Z"
                     updatedAt: "0001-01-01T00:00:00Z"
-                    username: jephpho
+                    username: alexfit
                     facebookId: null
                     following: false
                 - activityId: 116a064a-9d9a-4400-b9ca-bb5e311a22cc
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   activityTime: "2026-02-22T18:41:16.999143Z"
                   activityType: Internal
                   workoutPreview:
@@ -20915,14 +20915,14 @@ paths:
                     totalAchievements: 0
                     activityType: Internal
                   socialProfileTile:
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     createdAt: "2025-08-08T23:03:32.961056Z"
                     updatedAt: "0001-01-01T00:00:00Z"
-                    username: jephpho
+                    username: alexfit
                     facebookId: null
                     following: false
                 - activityId: d342538b-7df3-4c32-8d11-fe97bba85257
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   activityTime: "2026-02-21T19:21:01.926736Z"
                   activityType: Internal
                   workoutPreview:
@@ -20945,10 +20945,10 @@ paths:
                     totalAchievements: 0
                     activityType: Internal
                   socialProfileTile:
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     createdAt: "2025-08-08T23:03:32.961056Z"
                     updatedAt: "0001-01-01T00:00:00Z"
-                    username: jephpho
+                    username: alexfit
                     facebookId: null
                     following: false
                 - activityId: efcb265f-d4f7-4481-a578-3148c953dc85
@@ -20982,7 +20982,7 @@ paths:
                     facebookId: null
                     following: true
                 - activityId: 5141900c-70f9-45f2-9976-14ee7cd82625
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   activityTime: "2026-02-18T19:59:58.406782Z"
                   activityType: External
                   workoutPreview:
@@ -21007,10 +21007,10 @@ paths:
                     source: Apple Watch
                     externalWorkoutType: pickleball
                   socialProfileTile:
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     createdAt: "2025-08-08T23:03:32.961056Z"
                     updatedAt: "0001-01-01T00:00:00Z"
-                    username: jephpho
+                    username: alexfit
                     facebookId: null
                     following: false
       parameters:
@@ -21103,7 +21103,7 @@ paths:
               example:
                 - id: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   name: Push B
                   workoutId: 5849f69c-35e3-47b3-821d-fcc31e82990f
                   isInProgram: false
@@ -21135,7 +21135,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: ed6c6ecd-83fa-45f1-8883-2f90279cbac8
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   name: Pull B - Short
                   workoutId: 346816ee-1c13-4994-a0f6-78acd3fcd795
                   isInProgram: false
@@ -21167,7 +21167,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: b0ef7cd2-2db5-4551-9f5b-0e53f99ad34d
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutId: 00000000-0000-0000-0000-000000000000
                   isInProgram: false
                   isGuidedWorkout: false
@@ -21206,7 +21206,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: 9c277172-8c1e-47ed-b82b-9cfefcbf825f
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutId: 00000000-0000-0000-0000-000000000000
                   isInProgram: false
                   isGuidedWorkout: false
@@ -21244,7 +21244,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: 7e8c4efc-c861-4001-8c99-5e7860e29264
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutId: 00000000-0000-0000-0000-000000000000
                   isInProgram: false
                   isGuidedWorkout: false
@@ -21282,7 +21282,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: 116a064a-9d9a-4400-b9ca-bb5e311a22cc
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   name: Pull A
                   workoutId: db121ec6-93dd-4597-b705-cf99e5928dbd
                   isInProgram: false
@@ -21314,7 +21314,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: d342538b-7df3-4c32-8d11-fe97bba85257
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   name: Push A
                   workoutId: 45079946-ecc9-472e-8bb6-7c51ac4bda3d
                   isInProgram: false
@@ -21346,7 +21346,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: 5141900c-70f9-45f2-9976-14ee7cd82625
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutId: 00000000-0000-0000-0000-000000000000
                   isInProgram: false
                   isGuidedWorkout: false
@@ -21384,7 +21384,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: 3eae8966-b344-4865-90b5-9d259ca2d93a
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   name: Total-Body Throwdown
                   workoutId: d251ac03-4bd7-45ad-9e21-7e4012c2a5d4
                   isInProgram: false
@@ -21421,7 +21421,7 @@ paths:
                   triggeredTimedWeightOff: false
                 - id: a2464175-af58-491a-b88b-f6c0da9820bc
                   deletedAt: null
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutId: 00000000-0000-0000-0000-000000000000
                   isInProgram: false
                   isGuidedWorkout: false
@@ -21680,7 +21680,7 @@ paths:
                           programWorkoutId: c82e05bc-9a92-42e2-b8da-e0b2f362d884
                       - type: DAILY_LIFT_WORKOUT
                         assetId: 27b1f756-be25-42df-8993-2a6334927f79
-                        title: Jeff's Daily Lift
+                        title: Alex's Daily Lift
                         duration: 3178
                         level: ADVANCED
                         trainingTypeIds:
@@ -22018,7 +22018,7 @@ paths:
                   allowAllContent:
                     type: boolean
               example:
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 deviceType: T3
                 accessories:
                   - Mat
@@ -22247,7 +22247,7 @@ paths:
                     type:
                       type: string
               example:
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: 2fd33d14-7d5a-4f25-b808-1a1619045dad
                   type: program
       parameters:
@@ -22350,7 +22350,7 @@ paths:
           in: query
           schema:
             type: string
-          example: adamhhall93@gmail.com
+          example: user@example.com
         - name: chunk
           in: query
           schema:
@@ -22416,61 +22416,61 @@ paths:
                       type: array
                       items: {}
               example:
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: 5491c1e8-0bf3-4ced-a19a-33380f8b5925
                   contentType: Live
                   globalCount: 3
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: 21615693-6c66-45da-abe3-649c18c5d81e
                   contentType: Live
                   globalCount: 9
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: 31e0476d-4775-4063-b0b4-b8e30a5b21d8
                   contentType: Live
                   globalCount: 1
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: ac6083d7-f367-48f1-b2ff-69dd57f7fdbe
                   contentType: Live
                   globalCount: 24
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: c11efa5a-998a-4778-a5f1-f09aec9286bf
                   contentType: Live
                   globalCount: 5
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: ed488653-bace-49b5-90f5-acfc2c04c046
                   contentType: Live
                   globalCount: 4
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: 7ee096e1-be69-4764-834c-8d2ca7f92e6d
                   contentType: Live
                   globalCount: 21
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: 32a80bfb-06da-4d29-8d8e-3b5b849ca694
                   contentType: Live
                   globalCount: 36
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: d78cd8ce-d8ed-4718-8a4a-c459a5c95ad0
                   contentType: Live
                   globalCount: 24
                   followingCount: 0
                   topFollowings: []
-                - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                - userId: 00000000-0000-4000-8000-000000000003
                   contentId: 2867abe8-2a1f-430d-8898-55e03db28a77
                   contentType: Live
                   globalCount: 34
@@ -22514,289 +22514,289 @@ paths:
                         type: number
               example:
                 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 26396
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 23345
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 17212
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 7952
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 9848
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202601
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 12377
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202550
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 11386
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202549
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 12334
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202548
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 50125
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202547
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     score: 47494
                 2b09a416-3950-4695-8ee0-7a26498ca11c:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 66963.25492277331
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 59331.311358797146
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 43764.114364444096
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 21482.790872505524
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 27875.283521510002
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202601
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 32197.409835251587
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202550
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 28480.27863191132
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202549
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 35462.465477397374
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202548
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 132007.7679784738
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202547
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     score: 106201.77070408562
                 5b8646fd-1df0-4b19-8c5b-72f8ad816955:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 35.8956358956359
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 32.77533656139243
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 74.68291387210306
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 0
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 19.541011030372733
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202601
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 38.76541261862362
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202550
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 0
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202549
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 36.36363636363636
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202548
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 127.85496489704317
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202547
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     score: 93.92036596940733
                 81f42024-999a-4878-b593-3c001d98c874:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 21.333333333333332
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 11.57916666666667
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 11.6875
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 7.5
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 3.166666666666667
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202601
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 2.25
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202550
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 10
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202549
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 9.25
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202548
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 32.25
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202547
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     score: 16.783333333333335
                 a354b978-a53c-4481-bd43-97fc40acf60b:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 33.7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 7.199999999999999
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 271
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 22.599999999999998
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 2.1999999999999997
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202601
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 151.10000000000002
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202550
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 37
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202549
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 44.599999999999994
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202548
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 242
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202547
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     score: 413.6
                 b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 49.5
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 41.15
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 18.875
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 19
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 15.666666666666666
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202601
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 24.25
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202550
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 26
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202549
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 19
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202548
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 70.45
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202547
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     score: 63.675
                 e46f85cf-a9bc-42b4-836e-52c6621e7481:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 59.87935133522827
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 25.247090955139956
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 100
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 0
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 0
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202601
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 21.926848468356397
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202550
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 21.167698826597135
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202549
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 21.70550847457627
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202548
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 249.14397407489813
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202547
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     score: 160.40729944313404
@@ -23631,7 +23631,7 @@ paths:
                     type: number
               example:
                 id: 8365919f-70b5-4aaa-9ed4-845f05562320
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 programId: 7d4d1d3d-9da9-4722-9e8c-fb65e45845a8
                 programName: 12 Weeks to Jacked
                 coachId: e10feb85-d8fc-4d74-b50f-8dc495ea199a
@@ -23666,7 +23666,7 @@ paths:
                 workoutSummaries:
                   - id: d28adc3a-25a5-42b2-9215-a2b07c7665be
                     deletedAt: null
-                    userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                    userId: 00000000-0000-4000-8000-000000000003
                     programName: 12 Weeks to Jacked
                     name: "SL: Twelve Weeks to Jacked (Joe) - Part 1/Weeks1-4 - WO1 (W1D1)"
                     workoutId: 5765d849-f04f-4dca-a974-9c5f73b22cae
@@ -24508,7 +24508,7 @@ paths:
                   updatedByActivityId:
                     type: string
               example:
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 currentStreak: 1
                 currentStreakStartDate: "2026-03-09T00:00:00Z"
                 lastUpdatedWeek: "2026-03-09T00:00:00Z"
@@ -24581,7 +24581,7 @@ paths:
                 - id: 80dc92d3-1086-4d77-ad61-80da724c8068
                   createdAt: "2026-03-12T01:04:50.808008Z"
                   updatedAt: "2026-03-12T01:04:50.808008Z"
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                   strengthBodyRegion: Upper Body
                   bodyRegionDisplay: Upper
@@ -24591,7 +24591,7 @@ paths:
                     - id: 9ab91b0b-948e-4426-98db-9975a6b74773
                       createdAt: "2026-03-10T14:01:20.198741Z"
                       updatedAt: "2026-03-10T14:01:20.198741Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: ed6c6ecd-83fa-45f1-8883-2f90279cbac8
                       strengthFamily: Back
                       strengthBodyRegion: Upper Body
@@ -24600,7 +24600,7 @@ paths:
                     - id: 4329600b-fd0e-4e17-afe2-87cac31f2364
                       createdAt: "2026-03-10T14:01:20.198741Z"
                       updatedAt: "2026-03-10T14:01:20.198741Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: ed6c6ecd-83fa-45f1-8883-2f90279cbac8
                       strengthFamily: Biceps
                       strengthBodyRegion: Upper Body
@@ -24609,7 +24609,7 @@ paths:
                     - id: 7b55561d-82f2-4497-9a03-4a2b3b1b2676
                       createdAt: "2026-03-11T23:36:30.959895Z"
                       updatedAt: "2026-03-11T23:36:30.959895Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                       strengthFamily: Chest
                       strengthBodyRegion: Upper Body
@@ -24618,7 +24618,7 @@ paths:
                     - id: fff216cf-a876-4152-b533-9034126ebf7f
                       createdAt: "2026-03-11T23:36:30.959895Z"
                       updatedAt: "2026-03-11T23:36:30.959895Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                       strengthFamily: Shoulders
                       strengthBodyRegion: Upper Body
@@ -24627,7 +24627,7 @@ paths:
                     - id: 122d37e7-d258-4bc9-9d72-54c34172a1a2
                       createdAt: "2026-03-11T23:36:30.959895Z"
                       updatedAt: "2026-03-11T23:36:30.959895Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                       strengthFamily: Triceps
                       strengthBodyRegion: Upper Body
@@ -24636,7 +24636,7 @@ paths:
                 - id: b6727444-0e2d-477e-82d4-4335ff4fc1a0
                   createdAt: "2026-02-21T20:27:22.501559Z"
                   updatedAt: "2026-02-21T20:27:22.501559Z"
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: d342538b-7df3-4c32-8d11-fe97bba85257
                   strengthBodyRegion: Core
                   bodyRegionDisplay: Core
@@ -24646,7 +24646,7 @@ paths:
                     - id: 62aadd42-22e2-4f13-a5f1-f321431908b1
                       createdAt: "2026-02-21T19:21:01.926736Z"
                       updatedAt: "2026-02-21T19:21:01.926736Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: d342538b-7df3-4c32-8d11-fe97bba85257
                       strengthFamily: Abs
                       strengthBodyRegion: Core
@@ -24655,7 +24655,7 @@ paths:
                     - id: eddf8f10-aaad-4776-ab9d-e6371b910bfe
                       createdAt: "2026-02-16T00:15:39.022448Z"
                       updatedAt: "2026-02-16T00:15:39.022448Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: 3eae8966-b344-4865-90b5-9d259ca2d93a
                       strengthFamily: Obliques
                       strengthBodyRegion: Core
@@ -24664,7 +24664,7 @@ paths:
                 - id: a48cf3c3-bee5-451a-ae59-21d152d61509
                   createdAt: "2026-03-12T01:04:50.808008Z"
                   updatedAt: "2026-03-12T01:04:50.808008Z"
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                   strengthBodyRegion: Lower Body
                   bodyRegionDisplay: Lower
@@ -24674,7 +24674,7 @@ paths:
                     - id: 4119aa61-1398-4428-931b-5d565bec1092
                       createdAt: "2026-03-11T23:36:30.959895Z"
                       updatedAt: "2026-03-11T23:36:30.959895Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                       strengthFamily: Glutes
                       strengthBodyRegion: Lower Body
@@ -24683,7 +24683,7 @@ paths:
                     - id: cc4c85f6-4a18-4936-8f78-92f597238ecf
                       createdAt: "2026-03-11T23:36:30.959895Z"
                       updatedAt: "2026-03-11T23:36:30.959895Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                       strengthFamily: Hamstrings
                       strengthBodyRegion: Lower Body
@@ -24692,7 +24692,7 @@ paths:
                     - id: d610a306-57fa-40a2-b05a-7b9691779988
                       createdAt: "2026-03-11T23:36:30.959895Z"
                       updatedAt: "2026-03-11T23:36:30.959895Z"
-                      userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                      userId: 00000000-0000-4000-8000-000000000003
                       workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                       strengthFamily: Quads
                       strengthBodyRegion: Lower Body
@@ -24701,7 +24701,7 @@ paths:
                 - id: 5577d14c-f616-4936-bbc6-9444b75d1159
                   createdAt: "0001-01-01T00:00:00Z"
                   updatedAt: "0001-01-01T00:00:00Z"
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: 00000000-0000-0000-0000-000000000000
                   strengthBodyRegion: Overall
                   bodyRegionDisplay: ""
@@ -24781,7 +24781,7 @@ paths:
                       type: string
               example:
                 - id: 4effd04e-329c-49d1-89fa-49d468a28dad
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: 3bab392d-7f4b-4c61-bc06-58a74bfdf998
                   upper: 813
                   lower: 766
@@ -24789,7 +24789,7 @@ paths:
                   overall: 817
                   activityTime: "2026-03-11T17:36:30-06:00"
                 - id: 4209cba5-dac6-42ef-abf3-ad8d4be3085a
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: ed6c6ecd-83fa-45f1-8883-2f90279cbac8
                   upper: 812
                   lower: 766
@@ -24797,7 +24797,7 @@ paths:
                   overall: 816
                   activityTime: "2026-03-10T08:01:20-06:00"
                 - id: 311eb4ee-8bf4-46fc-aa9b-3b89025bd631
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: 116a064a-9d9a-4400-b9ca-bb5e311a22cc
                   upper: 813
                   lower: 766
@@ -24805,7 +24805,7 @@ paths:
                   overall: 817
                   activityTime: "2026-02-22T11:41:16-07:00"
                 - id: 0e58936b-07d6-4c5d-ac9f-926c717d4278
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: d342538b-7df3-4c32-8d11-fe97bba85257
                   upper: 817
                   lower: 766
@@ -24813,7 +24813,7 @@ paths:
                   overall: 818
                   activityTime: "2026-02-21T12:21:01-07:00"
                 - id: 37380cdf-6dd0-43ce-babc-f37c4398c268
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: 3eae8966-b344-4865-90b5-9d259ca2d93a
                   upper: 821
                   lower: 766
@@ -24821,7 +24821,7 @@ paths:
                   overall: 820
                   activityTime: "2026-02-15T17:15:39-07:00"
                 - id: 70e2358d-e6ad-40ce-83b6-73149cc6d0a8
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: eb8e6a83-f501-4f71-9db6-a97ddcc0450b
                   upper: 820
                   lower: 758
@@ -24829,7 +24829,7 @@ paths:
                   overall: 816
                   activityTime: "2026-01-26T08:02:25-07:00"
                 - id: c1c74f5f-86bf-4da3-aa0b-020b9a86bcc2
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: 6778ec56-8a62-4055-8b4b-6f9f3b261cad
                   upper: 804
                   lower: 758
@@ -24837,7 +24837,7 @@ paths:
                   overall: 811
                   activityTime: "2026-01-24T19:26:59-07:00"
                 - id: f4bed8ce-dde6-4df3-9920-c2bc98608157
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: d28adc3a-25a5-42b2-9215-a2b07c7665be
                   upper: 810
                   lower: 758
@@ -24845,7 +24845,7 @@ paths:
                   overall: 813
                   activityTime: "2026-01-02T20:27:18-07:00"
                 - id: e084049a-31fd-477d-b566-3f33d882d9d7
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: 03309aee-4089-46ba-ac95-6a56cdff3e6b
                   upper: 810
                   lower: 758
@@ -24853,7 +24853,7 @@ paths:
                   overall: 813
                   activityTime: "2025-12-12T20:23:45-07:00"
                 - id: 9f733f99-570c-469c-8b4c-f488b98153d0
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   workoutActivityId: b8b30043-8140-4468-a635-9af4591250bd
                   upper: 791
                   lower: 758
@@ -24907,385 +24907,385 @@ paths:
                         type: number
               example:
                 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9033
                     lowRange: 7742
                     highRange: 10323
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202610
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9033
                     lowRange: 7742
                     highRange: 10323
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202609
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9033
                     lowRange: 7742
                     highRange: 10323
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9033
                     lowRange: 7742
                     highRange: 10323
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9033
                     lowRange: 7742
                     highRange: 10323
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202606
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9033
                     lowRange: 7742
                     highRange: 10323
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9777
                     lowRange: 8380
                     highRange: 11174
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9777
                     lowRange: 8380
                     highRange: 11174
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202603
                     metricId: 2a2f499e-ae13-45d1-b501-aa1d25ff6a4a
                     target: 9777
                     lowRange: 8380
                     highRange: 11174
                 2b09a416-3950-4695-8ee0-7a26498ca11c:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 25371
                     lowRange: 21747
                     highRange: 28996
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202610
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 25371
                     lowRange: 21747
                     highRange: 28996
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202609
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 25371
                     lowRange: 21747
                     highRange: 28996
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 25371
                     lowRange: 21747
                     highRange: 28996
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 25371
                     lowRange: 21747
                     highRange: 28996
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202606
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 25371
                     lowRange: 21747
                     highRange: 28996
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 27325
                     lowRange: 23421
                     highRange: 31229
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 27325
                     lowRange: 23421
                     highRange: 31229
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202603
                     metricId: 2b09a416-3950-4695-8ee0-7a26498ca11c
                     target: 27325
                     lowRange: 23421
                     highRange: 31229
                 5b8646fd-1df0-4b19-8c5b-72f8ad816955:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202610
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202609
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202606
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202603
                     metricId: 5b8646fd-1df0-4b19-8c5b-72f8ad816955
                     target: 63
                     lowRange: 54
                     highRange: 72
                 81f42024-999a-4878-b593-3c001d98c874:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202610
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202609
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202606
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202603
                     metricId: 81f42024-999a-4878-b593-3c001d98c874
                     target: 6
                     lowRange: 5
                     highRange: 7
                 a354b978-a53c-4481-bd43-97fc40acf60b:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 24
                     lowRange: 21
                     highRange: 28
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202610
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 24
                     lowRange: 21
                     highRange: 28
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202609
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 24
                     lowRange: 21
                     highRange: 28
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 100
                     lowRange: 85
                     highRange: 114
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 24
                     lowRange: 21
                     highRange: 28
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202606
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 24
                     lowRange: 21
                     highRange: 28
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 24
                     lowRange: 21
                     highRange: 28
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 24
                     lowRange: 21
                     highRange: 28
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202603
                     metricId: a354b978-a53c-4481-bd43-97fc40acf60b
                     target: 24
                     lowRange: 21
                     highRange: 28
                 b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 12
                     lowRange: 10
                     highRange: 14
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202610
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 12
                     lowRange: 10
                     highRange: 14
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202609
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 14
                     lowRange: 12
                     highRange: 16
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 12
                     lowRange: 10
                     highRange: 14
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 12
                     lowRange: 10
                     highRange: 14
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202606
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 12
                     lowRange: 10
                     highRange: 14
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 12
                     lowRange: 10
                     highRange: 14
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 12
                     lowRange: 10
                     highRange: 14
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202603
                     metricId: b9bb5c52-a6d4-48ed-bbc5-3a645bb89e15
                     target: 12
                     lowRange: 10
                     highRange: 14
                 e46f85cf-a9bc-42b4-836e-52c6621e7481:
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202611
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202610
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202609
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202608
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202607
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202606
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202605
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202604
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
                     lowRange: 54
                     highRange: 72
-                  - userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  - userId: 00000000-0000-4000-8000-000000000003
                     weekNumber: 202603
                     metricId: e46f85cf-a9bc-42b4-836e-52c6621e7481
                     target: 63
@@ -25330,17 +25330,17 @@ paths:
                       type: string
               example:
                 - id: e13ff449-6e19-426a-92b8-ebd3dfd90051
-                  signedFirstName: Jeff
-                  signedLastName: Otano
-                  signedEmail: otano.jeffrey@gmail.com
+                  signedFirstName: Alex
+                  signedLastName: Trainer
+                  signedEmail: alex.trainer@example.com
                   signedDate: "2025-09-03T20:35:04.655Z"
                   termsId: 044126c0-5a93-4036-bf36-ea9a6e967f64
                   subscribeToEmail: false
                   termsType: tonal-smart-view-1
                 - id: 4943e3a6-87ae-428c-ae7d-3e68ad976ff9
-                  signedFirstName: Jeff
-                  signedLastName: Otano
-                  signedEmail: otano.jeffrey@gmail.com
+                  signedFirstName: Alex
+                  signedLastName: Trainer
+                  signedEmail: alex.trainer@example.com
                   signedDate: "2025-09-03T20:35:04.655Z"
                   termsId: 4f04e7b8-c432-422b-a5f4-a5df04a5244e
                   subscribeToEmail: false
@@ -25834,7 +25834,7 @@ paths:
                       workoutId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       resourceId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       assetId: 27b1f756-be25-42df-8993-2a6334927f79
-                      title: Jeff's Daily Lift
+                      title: Alex's Daily Lift
                       duration: 3178
                       level: ADVANCED
                       targetArea: UPPER BODY
@@ -26523,7 +26523,7 @@ paths:
                       workoutId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       resourceId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       assetId: 27b1f756-be25-42df-8993-2a6334927f79
-                      title: Jeff's Daily Lift
+                      title: Alex's Daily Lift
                       duration: 3178
                       level: ADVANCED
                       targetArea: UPPER BODY
@@ -26861,7 +26861,7 @@ paths:
                       workoutId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       resourceId: 44ffce88-b220-4645-bdff-4a8c9529a253
                       assetId: 27b1f756-be25-42df-8993-2a6334927f79
-                      title: Jeff's Daily Lift
+                      title: Alex's Daily Lift
                       duration: 3178
                       level: ADVANCED
                       targetArea: UPPER BODY
@@ -28195,7 +28195,7 @@ paths:
                   hasSeenCoachingCuesVolumeTooltip:
                     type: boolean
               example:
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 overallVolume: 0.8666667
                 musicVolume: 1
                 coachVolume: 0.48
@@ -29068,7 +29068,7 @@ paths:
               shortDescription: ""
               description: ""
               coachId: 00000000-0000-0000-0000-000000000000
-              userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+              userId: 00000000-0000-4000-8000-000000000003
               duration: 758
               publishState: published
               level: ""
@@ -29222,7 +29222,7 @@ paths:
                   publishedAt: "2026-03-15T18:54:32.277855Z"
                   localPublishedAt: "0001-01-01T00:00:00Z"
                   type: Custom
-                  userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                  userId: 00000000-0000-4000-8000-000000000003
                   style: 2020-Branding
                   trainingType: Custom
                   trainingTypeIds: null
@@ -29712,7 +29712,7 @@ paths:
                 publishedAt: "2026-03-12T01:36:34.524855Z"
                 localPublishedAt: "0001-01-01T00:00:00Z"
                 type: Custom
-                userId: f12eafc8-b9b1-3146-b0cf-eb39a08203e2
+                userId: 00000000-0000-4000-8000-000000000003
                 style: 2020-Branding
                 trainingType: Custom
                 trainingTypeIds: null

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import bundleAnalyzer from "@next/bundle-analyzer";
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
+import { shouldUseSentryBuildPlugin } from "./src/lib/deployment";
 
 const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
@@ -46,40 +47,26 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withSentryConfig(withBundleAnalyzer(nextConfig), {
-  // For all available options, see:
-  // https://www.npmjs.com/package/@sentry/webpack-plugin#options
+const baseConfig = withBundleAnalyzer(nextConfig);
 
-  org: "techie-industries-f4",
-
-  project: "tonalcoach",
-
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
-
-  // For all available options, see:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
-
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: true,
-
-  // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
-  // This can increase your server load as well as your hosting bill.
-  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
-  // side errors will fail.
-  tunnelRoute: "/monitoring",
-
-  webpack: {
-    // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-    // See the following for more information:
-    // https://docs.sentry.io/product/crons/
-    // https://vercel.com/docs/cron-jobs
-    automaticVercelMonitors: true,
-
-    // Tree-shaking options for reducing bundle size
-    treeshake: {
-      // Automatically tree-shake Sentry logger statements to reduce bundle size
-      removeDebugLogging: true,
-    },
-  },
+const sentryBuildEnabled = shouldUseSentryBuildPlugin({
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
 });
+
+export default sentryBuildEnabled
+  ? withSentryConfig(baseConfig, {
+      org: process.env.SENTRY_ORG!,
+      project: process.env.SENTRY_PROJECT!,
+      silent: !process.env.CI,
+      widenClientFileUpload: true,
+      tunnelRoute: "/monitoring",
+      webpack: {
+        automaticVercelMonitors: true,
+        treeshake: {
+          removeDebugLogging: true,
+        },
+      },
+    })
+  : baseConfig;

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,29 +1,3 @@
-// This file configures the initialization of Sentry on the client.
-// The config you add here will be used whenever a user loads a page in their browser.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-import * as Sentry from "@sentry/nextjs";
-
-Sentry.init({
-  dsn: "https://26edc867bc124097762f80b3670d82db@o4511044550656000.ingest.us.sentry.io/4511044553998336",
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-
-  // Enable session replay to capture what users see when errors occur
-  replaysOnErrorSampleRate: 1.0,
-  replaysSessionSampleRate: 1.0,
-
-  integrations: [
-    Sentry.replayIntegration({
-      maskAllText: true,
-      blockAllMedia: true,
-    }),
-  ],
-});
+// Client-side Sentry initialization lives in src/instrumentation-client.ts so it can
+// share one startup path with PostHog and stay opt-in for self-hosted deployments.
+export {};

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,17 +4,17 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { getSentryRuntimeConfig } from "./src/lib/deployment";
 
-Sentry.init({
-  dsn: "https://26edc867bc124097762f80b3670d82db@o4511044550656000.ingest.us.sentry.io/4511044553998336",
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+const sentryConfig = getSentryRuntimeConfig({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
 });
+
+if (sentryConfig) {
+  Sentry.init({
+    ...sentryConfig,
+    enableLogs: false,
+    sendDefaultPii: false,
+  });
+}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,17 +3,17 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { getSentryRuntimeConfig } from "./src/lib/deployment";
 
-Sentry.init({
-  dsn: "https://26edc867bc124097762f80b3670d82db@o4511044550656000.ingest.us.sentry.io/4511044553998336",
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+const sentryConfig = getSentryRuntimeConfig({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
 });
+
+if (sentryConfig) {
+  Sentry.init({
+    ...sentryConfig,
+    enableLogs: false,
+    sendDefaultPii: false,
+  });
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,12 +5,15 @@ import Link from "next/link";
 import { useAction } from "convex/react";
 import { Check, MessageSquare } from "lucide-react";
 import { api } from "../../../convex/_generated/api";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { isContactFormEnabled } from "@/lib/deployment";
+import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { SiteNav } from "../_components/SiteNav";
 import { SiteFooter } from "../_components/SiteFooter";
 
 export default function ContactPage() {
+  const contactFormEnabled = isContactFormEnabled(process.env.NEXT_PUBLIC_CONTACT_FORM_ENABLED);
   const sendMessage = useAction(api.contact.send);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -72,7 +75,7 @@ export default function ContactPage() {
                 &larr; Back to home
               </Link>
             </div>
-          ) : (
+          ) : contactFormEnabled ? (
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="flex gap-3">
                 <div className="flex-1">
@@ -140,6 +143,34 @@ export default function ContactPage() {
                 {status === "submitting" ? "Sending..." : "Send Message"}
               </Button>
             </form>
+          ) : (
+            <div className="rounded-xl bg-card p-8 ring-1 ring-border">
+              <p className="text-base font-medium text-foreground">
+                This deployment does not accept contact form submissions.
+              </p>
+              <p className="mt-3 text-muted-foreground">
+                Use the support docs for self-hosting help, or open a GitHub issue for bugs and
+                feature requests.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <a
+                  href="https://github.com/JeffOtano/tonal-coach/blob/main/SUPPORT.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn(buttonVariants({ size: "lg" }))}
+                >
+                  Support docs
+                </a>
+                <a
+                  href="https://github.com/JeffOtano/tonal-coach/issues"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn(buttonVariants({ variant: "outline", size: "lg" }))}
+                >
+                  GitHub issues
+                </a>
+              </div>
+            </div>
           )}
         </div>
       </main>

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -4,6 +4,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import posthog from "posthog-js";
+import { getSentryRuntimeConfig } from "@/lib/deployment";
 
 if (process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
@@ -17,25 +18,28 @@ if (process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) {
   });
 }
 
-Sentry.init({
-  dsn: "https://26edc867bc124097762f80b3670d82db@o4511044550656000.ingest.us.sentry.io/4511044553998336",
-
-  // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration()],
-
-  tracesSampleRate: 1,
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-
-  // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
-
-  sendDefaultPii: false,
+const sentryConfig = getSentryRuntimeConfig({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+  replaysOnErrorSampleRate: process.env.NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE,
+  replaysSessionSampleRate: process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE,
 });
+
+if (sentryConfig) {
+  Sentry.init({
+    ...sentryConfig,
+    integrations:
+      sentryConfig.replaysOnErrorSampleRate > 0 || sentryConfig.replaysSessionSampleRate > 0
+        ? [
+            Sentry.replayIntegration({
+              maskAllText: true,
+              blockAllMedia: true,
+            }),
+          ]
+        : [],
+    enableLogs: false,
+    sendDefaultPii: false,
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/lib/deployment.test.ts
+++ b/src/lib/deployment.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSentryRuntimeConfig,
+  isContactFormEnabled,
+  shouldUseSentryBuildPlugin,
+} from "./deployment";
+
+describe("getSentryRuntimeConfig", () => {
+  it("returns null when no DSN is configured", () => {
+    expect(getSentryRuntimeConfig({ dsn: "" })).toBeNull();
+  });
+
+  it("uses conservative defaults when optional sample rates are missing", () => {
+    expect(
+      getSentryRuntimeConfig({
+        dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+      }),
+    ).toEqual({
+      dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+      tracesSampleRate: 0,
+      replaysOnErrorSampleRate: 0,
+      replaysSessionSampleRate: 0,
+    });
+  });
+
+  it("parses valid sample rates and ignores invalid values", () => {
+    expect(
+      getSentryRuntimeConfig({
+        dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+        tracesSampleRate: "0.25",
+        replaysOnErrorSampleRate: "1",
+        replaysSessionSampleRate: "2",
+      }),
+    ).toEqual({
+      dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+      tracesSampleRate: 0.25,
+      replaysOnErrorSampleRate: 1,
+      replaysSessionSampleRate: 0,
+    });
+  });
+});
+
+describe("isContactFormEnabled", () => {
+  it("only enables the contact form for an explicit true flag", () => {
+    expect(isContactFormEnabled("true")).toBe(true);
+    expect(isContactFormEnabled("false")).toBe(false);
+    expect(isContactFormEnabled(undefined)).toBe(false);
+  });
+});
+
+describe("shouldUseSentryBuildPlugin", () => {
+  it("requires auth token, org, and project", () => {
+    expect(
+      shouldUseSentryBuildPlugin({
+        authToken: "token",
+        org: "org",
+        project: "project",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseSentryBuildPlugin({
+        authToken: undefined,
+        org: "org",
+        project: "project",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -1,0 +1,51 @@
+type OptionalString = string | undefined;
+
+export type SentryRuntimeConfig = {
+  dsn: string;
+  tracesSampleRate: number;
+  replaysOnErrorSampleRate: number;
+  replaysSessionSampleRate: number;
+};
+
+function hasValue(value: OptionalString): value is string {
+  return value !== undefined && value.trim().length > 0;
+}
+
+function parseSampleRate(value: OptionalString, fallback: number): number {
+  if (!hasValue(value)) return fallback;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function getSentryRuntimeConfig(options: {
+  dsn: OptionalString;
+  tracesSampleRate?: OptionalString;
+  replaysOnErrorSampleRate?: OptionalString;
+  replaysSessionSampleRate?: OptionalString;
+}): SentryRuntimeConfig | null {
+  if (!hasValue(options.dsn)) return null;
+
+  return {
+    dsn: options.dsn,
+    tracesSampleRate: parseSampleRate(options.tracesSampleRate, 0),
+    replaysOnErrorSampleRate: parseSampleRate(options.replaysOnErrorSampleRate, 0),
+    replaysSessionSampleRate: parseSampleRate(options.replaysSessionSampleRate, 0),
+  };
+}
+
+export function isContactFormEnabled(value: OptionalString): boolean {
+  return value === "true";
+}
+
+export function shouldUseSentryBuildPlugin(options: {
+  authToken: OptionalString;
+  org: OptionalString;
+  project: OptionalString;
+}): boolean {
+  return hasValue(options.authToken) && hasValue(options.org) && hasValue(options.project);
+}


### PR DESCRIPTION
## Summary
- make Sentry opt-in for self-hosted deployments and gate the build plugin on explicit Sentry env vars
- disable the public contact form unless it is explicitly configured, and document the optional deployment env vars
- scrub checked-in API example personal data and add deployment config tests

## Testing
- npm run typecheck
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Contact form is now an optional feature that can be enabled/disabled via configuration
  * Analytics and error reporting are now opt-in integrations (disabled by default for self-hosted deployments)

* **Documentation**
  * Updated deployment guides with new environment variable options for configuring analytics, error reporting, and contact form features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->