### PR TITLE
chore: security hardening pass

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,26 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Picks up .gitleaks.toml from the repo root (false-positive allowlist
+      # for the BYOK test fixtures, the public Tonal Auth0 client ID, and
+      # the expired example JWT in docs/tonal-api.yaml).
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,7 +3,6 @@ name: Gitleaks
 on:
   pull_request:
   push:
-    branches: [main]
 
 permissions:
   contents: read

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -51,6 +51,7 @@ import type * as discord from "../discord.js";
 import type * as email from "../email.js";
 import type * as emailChange from "../emailChange.js";
 import type * as emailTemplates from "../emailTemplates.js";
+import type * as fileGc from "../fileGc.js";
 import type * as goals from "../goals.js";
 import type * as healthCheck from "../healthCheck.js";
 import type * as http from "../http.js";
@@ -167,6 +168,7 @@ declare const fullApi: ApiFromModules<{
   email: typeof email;
   emailChange: typeof emailChange;
   emailTemplates: typeof emailTemplates;
+  fileGc: typeof fileGc;
   goals: typeof goals;
   healthCheck: typeof healthCheck;
   http: typeof http;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,6 +1,7 @@
 import { convexAuth } from "@convex-dev/auth/server";
 import { Password } from "@convex-dev/auth/providers/Password";
 import { ResendOTP } from "./ResendOTP";
+import { rateLimiter } from "./rateLimits";
 
 export const { auth, signIn, signOut, store } = convexAuth({
   providers: [
@@ -10,9 +11,15 @@ export const { auth, signIn, signOut, store } = convexAuth({
   ],
   callbacks: {
     async createOrUpdateUser(ctx, args) {
-      // The 50-user beta capacity check was removed with the BYOK open-source
-      // release. New users bring their own Gemini key, so there is no cost
-      // ceiling to enforce at signup time.
+      // Blunt abuse deterrent. Only run on actual account creation, not on
+      // updates to an existing user. If the global bucket is empty, the
+      // caller sees a clear rate-limit error and the auth library rolls
+      // back the half-created auth account (which is why we throw before
+      // inserting the users row).
+      if (args.existingUserId === null) {
+        await rateLimiter.limit(ctx, "newSignup", { throws: true });
+      }
+
       const userId = await ctx.db.insert("users", {
         ...(args.profile.email ? { email: args.profile.email } : {}),
         ...(args.profile.name ? { name: args.profile.name as string } : {}),

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -41,6 +41,8 @@ crons.cron(
 
 crons.interval("health-check", { minutes: 15 }, internal.healthCheck.runHealthCheck);
 
+crons.interval("vacuum-unused-files", { hours: 6 }, internal.fileGc.vacuumUnusedFiles);
+
 crons.cron("data-retention", "0 2 * * 0", internal.dataRetention.runDataRetention, {});
 
 export default crons;

--- a/convex/fileGc.ts
+++ b/convex/fileGc.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { internalAction } from "./_generated/server";
 import { components } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
@@ -19,15 +20,16 @@ import type { Id } from "./_generated/dataModel";
 const PAGE_SIZE = 100;
 const MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
-// Convex storage IDs are opaque base32-ish tokens starting with "kg" and
-// have a bounded length. Validating the shape lets us drop the `as`
-// cast at the agent-component boundary (where storageId is typed `string`)
-// without a full Zod dependency for a single field.
-const STORAGE_ID_PATTERN = /^[a-z0-9]{20,}$/;
+// Zod-backed validation at the agent-component boundary where storageId
+// arrives as an untyped `string`. Convex storage IDs are opaque
+// lowercase-alphanumeric tokens with a bounded length.
+const storageIdSchema = z.custom<Id<"_storage">>(
+  (value) => typeof value === "string" && /^[a-z0-9]{20,}$/.test(value),
+);
 
 function asStorageId(value: string): Id<"_storage"> | null {
-  if (!STORAGE_ID_PATTERN.test(value)) return null;
-  return value as Id<"_storage">;
+  const parsed = storageIdSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
 }
 
 export const vacuumUnusedFiles = internalAction({

--- a/convex/fileGc.ts
+++ b/convex/fileGc.ts
@@ -19,6 +19,17 @@ import type { Id } from "./_generated/dataModel";
 const PAGE_SIZE = 100;
 const MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
+// Convex storage IDs are opaque base32-ish tokens starting with "kg" and
+// have a bounded length. Validating the shape lets us drop the `as`
+// cast at the agent-component boundary (where storageId is typed `string`)
+// without a full Zod dependency for a single field.
+const STORAGE_ID_PATTERN = /^[a-z0-9]{20,}$/;
+
+function asStorageId(value: string): Id<"_storage"> | null {
+  if (!STORAGE_ID_PATTERN.test(value)) return null;
+  return value as Id<"_storage">;
+}
+
 export const vacuumUnusedFiles = internalAction({
   args: {},
   handler: async (ctx) => {
@@ -32,24 +43,32 @@ export const vacuumUnusedFiles = internalAction({
       return { scanned: page.page.length, deleted: 0 };
     }
 
-    // Delete the underlying Convex storage objects first. If the deleteFiles
-    // mutation below succeeds but a storage delete failed, the file row is
-    // gone so we'd lose the reference - unrecoverable. Opposite order lets
-    // a stale file row get retried on the next run.
-    let storageDeleted = 0;
+    // Delete underlying Convex storage objects first, then remove the
+    // agent's tracking rows ONLY for files whose storage delete succeeded.
+    // If we deleted the tracking rows for failed storage deletes too, the
+    // orphaned bytes would become unreachable on the next run (no row
+    // means nothing to retry), stranding storage forever.
+    const succeededFileIds: string[] = [];
     for (const file of oldEnough) {
+      const storageId = asStorageId(file.storageId);
+      if (storageId === null) {
+        console.error(`fileGc: malformed storageId ${file.storageId}, skipping`);
+        continue;
+      }
       try {
-        await ctx.storage.delete(file.storageId as Id<"_storage">);
-        storageDeleted++;
+        await ctx.storage.delete(storageId);
+        succeededFileIds.push(file._id);
       } catch (err) {
         console.error(`fileGc: failed to delete storage ${file.storageId}:`, err);
       }
     }
 
-    await ctx.runMutation(components.agent.files.deleteFiles, {
-      fileIds: oldEnough.map((file) => file._id),
-    });
+    if (succeededFileIds.length > 0) {
+      await ctx.runMutation(components.agent.files.deleteFiles, {
+        fileIds: succeededFileIds,
+      });
+    }
 
-    return { scanned: page.page.length, deleted: storageDeleted };
+    return { scanned: page.page.length, deleted: succeededFileIds.length };
   },
 });

--- a/convex/fileGc.ts
+++ b/convex/fileGc.ts
@@ -1,0 +1,55 @@
+import { internalAction } from "./_generated/server";
+import { components } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+
+/**
+ * Drain the @convex-dev/agent component's zero-refcount file queue.
+ *
+ * The agent tracks chat-image files with a refcount. When a message that
+ * references a file is deleted (including via account deletion), the
+ * refcount drops. Files at refcount 0 land in `getFilesToDelete`, but the
+ * component only removes its own tracking row - the underlying Convex
+ * `_storage` object is the caller's responsibility to clean up. That means
+ * without this cron, deleted chat images leak storage forever.
+ *
+ * Runs every 6 hours, processes up to one page per run, ignores files
+ * touched within the last 24 hours (per the component's recommendation)
+ * to avoid racing uploads that haven't been linked to a message yet.
+ */
+const PAGE_SIZE = 100;
+const MIN_AGE_MS = 24 * 60 * 60 * 1000;
+
+export const vacuumUnusedFiles = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const page = await ctx.runQuery(components.agent.files.getFilesToDelete, {
+      paginationOpts: { cursor: null, numItems: PAGE_SIZE },
+    });
+
+    const cutoff = Date.now() - MIN_AGE_MS;
+    const oldEnough = page.page.filter((file) => file.lastTouchedAt < cutoff);
+    if (oldEnough.length === 0) {
+      return { scanned: page.page.length, deleted: 0 };
+    }
+
+    // Delete the underlying Convex storage objects first. If the deleteFiles
+    // mutation below succeeds but a storage delete failed, the file row is
+    // gone so we'd lose the reference - unrecoverable. Opposite order lets
+    // a stale file row get retried on the next run.
+    let storageDeleted = 0;
+    for (const file of oldEnough) {
+      try {
+        await ctx.storage.delete(file.storageId as Id<"_storage">);
+        storageDeleted++;
+      } catch (err) {
+        console.error(`fileGc: failed to delete storage ${file.storageId}:`, err);
+      }
+    }
+
+    await ctx.runMutation(components.agent.files.deleteFiles, {
+      fileIds: oldEnough.map((file) => file._id),
+    });
+
+    return { scanned: page.page.length, deleted: storageDeleted };
+  },
+});

--- a/convex/rateLimits.ts
+++ b/convex/rateLimits.ts
@@ -70,4 +70,15 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
     period: MINUTE,
     capacity: 3,
   },
+  /**
+   * Global cap on new account creation to blunt automated signup abuse.
+   * 20/hour is well above any realistic organic signup rate for a
+   * personal-scale hosted instance and still blocks bulk bot floods.
+   */
+  newSignup: {
+    kind: "token bucket",
+    rate: 20,
+    period: 60 * MINUTE,
+    capacity: 5,
+  },
 });

--- a/convex/rateLimits.ts
+++ b/convex/rateLimits.ts
@@ -4,6 +4,15 @@ import { components } from "./_generated/api";
 /** Daily message cap per user. Easy to adjust per tier later. */
 export const DAILY_MESSAGE_LIMIT = 30;
 
+/**
+ * Global cap on new account creation to blunt automated signup abuse. Well
+ * above any realistic organic signup rate for a personal-scale hosted
+ * instance and still blocks bulk bot floods.
+ */
+export const NEW_SIGNUP_RATE_PER_HOUR = 20;
+export const NEW_SIGNUP_BURST_CAPACITY = 5;
+const NEW_SIGNUP_PERIOD = 60 * MINUTE;
+
 export const rateLimiter = new RateLimiter(components.rateLimiter, {
   sendMessage: {
     kind: "token bucket",
@@ -70,15 +79,10 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
     period: MINUTE,
     capacity: 3,
   },
-  /**
-   * Global cap on new account creation to blunt automated signup abuse.
-   * 20/hour is well above any realistic organic signup rate for a
-   * personal-scale hosted instance and still blocks bulk bot floods.
-   */
   newSignup: {
     kind: "token bucket",
-    rate: 20,
-    period: 60 * MINUTE,
-    capacity: 5,
+    rate: NEW_SIGNUP_RATE_PER_HOUR,
+    period: NEW_SIGNUP_PERIOD,
+    capacity: NEW_SIGNUP_BURST_CAPACITY,
   },
 });

--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -1,6 +1,6 @@
 type OptionalString = string | undefined;
 
-export type SentryRuntimeConfig = {
+type SentryRuntimeConfig = {
   dsn: string;
   tracesSampleRate: number;
   replaysOnErrorSampleRate: number;


### PR DESCRIPTION
## Why

From the 8-item "what are we missing to safely open source" audit. Ships three of those items in code. Items that belong in the GitHub dashboard, and one that needs design discussion, are called out at the bottom.

## What's in this PR

### 1. Continuous secret scanning (item #4)

**New file:** \`.github/workflows/gitleaks.yml\`

Runs on every push and every PR. A future contributor (or a tired maintainer) can't sneak an API key past CI. The workflow uses the existing \`.gitleaks.toml\` allowlist that was set up during the history scrub - it ignores the BYOK test fixtures (which have to look like real Gemini keys to exercise the validator regex), the public Tonal Auth0 client ID, and the expired example JWT in \`docs/tonal-api.yaml\`.

The one-time scrub we did during the OSS release was good for cleaning history. This makes it continuous.

### 2. Signup abuse deterrent (item #6)

**Changes:** \`convex/rateLimits.ts\`, \`convex/auth.ts\`

Added a \`newSignup\` token bucket to the rate limiter (20/hour global, burst capacity 5) and wired it into the \`createOrUpdateUser\` callback:

\`\`\`ts
if (args.existingUserId === null) {
  await rateLimiter.limit(ctx, "newSignup", { throws: true });
}
\`\`\`

Only runs on actual new account creation, not on updates to existing users. 20/hour is well above any realistic organic signup rate for a personal-scale hosted instance and still blocks bulk bot floods.

**Known limitation:** this is global, not per-IP. A legitimate burst of signups after a launch post could briefly hit the limit. Adjust the rate in \`rateLimits.ts\` if it becomes an issue. A proper CAPTCHA would be the right long-term answer but that needs a client-facing component and a provider (hCaptcha / Turnstile / reCAPTCHA) - out of scope here.

### 3. Chat-image storage leak (item #5)

**New file:** \`convex/fileGc.ts\`
**Changes:** \`convex/crons.ts\`

The \`@convex-dev/agent\` component tracks chat-image files with a refcount and exposes \`getFilesToDelete\` / \`deleteFiles\` for zero-refcount cleanup. But - **the component only manages its own tracking rows**. The underlying Convex \`_storage\` objects are the caller's responsibility to delete. Without a sweeper, every image attached to a deleted chat message leaks storage forever, including images attached to messages deleted by account deletion (which PR #74 now does thoroughly).

The fix is a scheduled internalAction that:
1. Queries \`components.agent.files.getFilesToDelete\` for one page of up to 100 zero-refcount files
2. Filters out anything touched within the last 24 hours (per the component's own recommendation - avoids racing fresh uploads not yet linked to a message)
3. Calls \`ctx.storage.delete(file.storageId)\` on each eligible file first
4. Then calls \`components.agent.files.deleteFiles\` to clean up the agent's tracking rows

Ordering matters: delete underlying storage first, then remove the agent file row. The opposite order would lose the reference on a mid-run failure and strand the bytes permanently.

Scheduled via \`crons.ts\` every 6 hours. Over time it drains the queue at up to 400 files/day, which is vastly more than any realistic throughput for a personal-scale instance.

## Verification

- [x] \`npx convex codegen\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` - 731 passed / 13 skipped
- [x] \`npm run knip\` - one pre-existing unused \`SentryRuntimeConfig\` type warning from the recent Sentry hardening PR, not introduced by this change
- [ ] Smoke: after merge, the next cron run should log \`scanned: N, deleted: M\` for whatever's already orphaned. Watch Convex logs after deploy.

## Item #1 (Sentry PII) is already done

You (or a contributor) already shipped the Sentry hardening via \`src/lib/deployment.ts\` and the updated \`sentry.{client,edge,server}.config.ts\` files. \`sendDefaultPii\` is now \`false\` everywhere, the DSN is env-var-driven, and traces/replays default to 0 so self-hosters don't send telemetry unless they explicitly opt in. That's a better implementation than what I was going to write.

## Items that need your click (GitHub dashboard)

### #2 - Required status checks
Go to **Settings → Branches → main → Edit → Require status checks to pass before merging** and enable at least:
- \`CI / Lint & Format\`
- \`CI / Type Check\`
- \`CI / Test\`
- \`CI / Build\`
- \`Gitleaks / Secret Scan\` (after this PR merges and the workflow exists)

### #3 - Require at least 1 approving review
Same settings page, **Require pull request reviews before merging → Required approving reviews: 1**. With CODEOWNERS covering you as the owner, you can still self-merge via the owner path, but outside contributors can't.

### #7 - DCO signoff
Install the DCO GitHub App on the repo: https://github.com/apps/dco. Adds a check that requires \`Signed-off-by:\` on every commit. Small friction for contributors, meaningful IP-dispute protection down the road.

## Item still open (needs design discussion)

### #8 - House-key burn protection for grandfathered users

Grandfathered users (created before \`BYOK_REQUIRED_AFTER\`) still run on your shared house Gemini key. The existing \`sendMessage\` / \`dailyMessages\` rate limits prevent one user from burning everything in a day, but there's no aggregate cost cap - a grandfathered user running a script could sustainably cost you money.

**Proposed design (not implemented yet):**
- Add a \`houseKeyMonthly\` fixed-window limit: ~300 messages / 30 days per user
- Apply it only when \`resolveGeminiKey\` returns the house key (detectable via \`!isBYOKRequired(user._creationTime)\`)
- On limit hit, surface a clear error routing the user to the existing BYOK settings page with a \"you've hit your free house-key quota - paste your own Gemini key to continue\" message

Ship as a follow-up PR once you've decided:
1. What's the right monthly cap? (300 is a guess - could be 200, could be 500)
2. Soft cap (warning) or hard cap (block)?
3. Does it reset automatically or require operator intervention?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limiting for new account creation to deter abuse and smooth signup spikes.
  * Automatic periodic cleanup that removes unused files from storage every 6 hours, reducing storage usage.

* **Chores**
  * Enabled secret scanning in CI to detect potential credential leaks on pushes and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->