### PR TITLE
fix: unblock coach freeze for users with large Tonal history

### DIFF
--- a/convex/ai/context.ts
+++ b/convex/ai/context.ts
@@ -71,7 +71,7 @@ export async function buildTrainingSnapshot(
     ctx
       .runAction(internal.tonal.proxy.fetchWorkoutHistory, {
         userId: convexUserId,
-        limit: 10,
+        limit: 20,
       })
       .catch(() => [] as Activity[]),
     ctx

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -33,11 +33,7 @@ const MAX_IMAGES_PER_MESSAGE = 4;
  * fall back to the house key on failure: the entire BYOK release exists to
  * stop the cost bleed of users running on someone else's key.
  */
-/**
- * Validate that the user's Gemini key can be resolved without decrementing
- * quota. Use in createThreadWithMessage to surface BYOK errors early
- * without double-counting when processMessage resolves the key again.
- */
+// Like resolveUserGeminiKey but skips the quota check.
 async function validateUserGeminiKey(ctx: ActionCtx, userId: string): Promise<void> {
   const context = await ctx.runQuery(internal.byok._getKeyResolutionContext, {
     userId: userId as Id<"users">,
@@ -190,11 +186,8 @@ export const createThreadWithMessage = action({
     const staleHours = await ctx.runQuery(internal.userProfiles.getThreadStaleHours, { userId });
     const staleMs = staleHours * 60 * 60 * 1000;
 
-    // Validate the Gemini key BEFORE creating the thread. A BYOK error here
-    // throws out of the action and is surfaced to the frontend. This uses
-    // validateUserGeminiKey (not resolveUserGeminiKey) to avoid decrementing
-    // the house-key quota -- processMessage will call resolveUserGeminiKey
-    // which handles both key resolution and quota enforcement.
+    // Validate key early so BYOK errors surface before the thread is created.
+    // Quota is checked later in processMessage.
     await validateUserGeminiKey(ctx, userId);
 
     let targetThreadId: string;

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -33,6 +33,19 @@ const MAX_IMAGES_PER_MESSAGE = 4;
  * fall back to the house key on failure: the entire BYOK release exists to
  * stop the cost bleed of users running on someone else's key.
  */
+/**
+ * Validate that the user's Gemini key can be resolved without decrementing
+ * quota. Use in createThreadWithMessage to surface BYOK errors early
+ * without double-counting when processMessage resolves the key again.
+ */
+async function validateUserGeminiKey(ctx: ActionCtx, userId: string): Promise<void> {
+  const context = await ctx.runQuery(internal.byok._getKeyResolutionContext, {
+    userId: userId as Id<"users">,
+  });
+  if (!context) throw new Error("byok_user_not_found");
+  await resolveGeminiKey(context.profile, context.userCreationTime);
+}
+
 async function resolveUserGeminiKey(ctx: ActionCtx, userId: string): Promise<string> {
   const context = await ctx.runQuery(internal.byok._getKeyResolutionContext, {
     userId: userId as Id<"users">,
@@ -177,12 +190,12 @@ export const createThreadWithMessage = action({
     const staleHours = await ctx.runQuery(internal.userProfiles.getThreadStaleHours, { userId });
     const staleMs = staleHours * 60 * 60 * 1000;
 
-    // Resolve the user's Gemini key BEFORE doing anything expensive. A BYOK
-    // error here throws out of the action and is surfaced to the frontend,
-    // not silently ignored. The standalone agentCreateThread below does not
-    // invoke the LLM, but we still want the key error to block thread
-    // creation so the user gets a single clean failure.
-    await resolveUserGeminiKey(ctx, userId);
+    // Validate the Gemini key BEFORE creating the thread. A BYOK error here
+    // throws out of the action and is surfaced to the frontend. This uses
+    // validateUserGeminiKey (not resolveUserGeminiKey) to avoid decrementing
+    // the house-key quota -- processMessage will call resolveUserGeminiKey
+    // which handles both key resolution and quota enforcement.
+    await validateUserGeminiKey(ctx, userId);
 
     let targetThreadId: string;
     if (threadId) {

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -149,9 +149,10 @@ export const createThread = mutation({
 });
 
 /**
- * Creates a new thread and sends the first message. Invokes the LLM synchronously
- * so a BYOK key error surfaces before the thread is created. Use for the welcome
- * flow where no thread exists yet; use sendMessageToThread for all other messages.
+ * Creates a new thread and sends the first message. Validates the BYOK key
+ * synchronously so key errors surface before the thread is created. The LLM
+ * response is scheduled asynchronously (same as sendMessageToThread) so the
+ * frontend is never blocked on the full inference roundtrip.
  */
 export const createThreadWithMessage = action({
   args: {
@@ -181,7 +182,7 @@ export const createThreadWithMessage = action({
     // not silently ignored. The standalone agentCreateThread below does not
     // invoke the LLM, but we still want the key error to block thread
     // creation so the user gets a single clean failure.
-    const geminiKey = await resolveUserGeminiKey(ctx, userId);
+    await resolveUserGeminiKey(ctx, userId);
 
     let targetThreadId: string;
     if (threadId) {
@@ -206,28 +207,15 @@ export const createThreadWithMessage = action({
       }
     }
 
-    const budgetExceeded = await checkDailyBudget(ctx, userId, targetThreadId);
-    if (budgetExceeded) return { threadId: targetThreadId };
-
-    const resolvedPrompt = await buildPrompt(ctx, prompt, imageStorageIds ?? undefined);
-
-    const startTime = Date.now();
-    const { primary, fallback } = buildCoachAgents(geminiKey);
-    await withByokErrorSanitization(() =>
-      streamWithRetry(ctx, {
-        primaryAgent: primary,
-        fallbackAgent: fallback,
-        threadId: targetThreadId,
-        userId,
-        prompt: resolvedPrompt,
-      }),
-    );
-
-    analytics.capture(userId, "coach_response_received", {
-      response_time_ms: Date.now() - startTime,
-      has_images: (imageStorageIds?.length ?? 0) > 0,
+    // Schedule the LLM response asynchronously so the frontend gets the
+    // threadId back immediately. processMessage handles BYOK resolution,
+    // budget checks, streaming, retries, and analytics.
+    await ctx.scheduler.runAfter(0, internal.chat.processMessage, {
+      threadId: targetThreadId,
+      userId,
+      prompt,
+      imageStorageIds,
     });
-    await analytics.flush();
 
     return { threadId: targetThreadId };
   },

--- a/convex/tonal/movementSync.ts
+++ b/convex/tonal/movementSync.ts
@@ -132,20 +132,12 @@ export const updateMovement = internalMutation({
 /**
  * Return all movements from the dedicated table, mapped to the Movement
  * interface shape (tonalId -> id) for backward compatibility.
- * Resolves thumbnailStorageId to a serving URL when thumbnailMediaUrl is absent.
+ * URLs are resolved and persisted at write time by setThumbnailStorageId.
  */
 export const getAllMovements = internalQuery({
   handler: async (ctx): Promise<Movement[]> => {
     const docs = await ctx.db.query("movements").collect();
-    const results: Movement[] = [];
-    for (const doc of docs) {
-      const m = mapDocToMovement(doc);
-      if (!m.thumbnailMediaUrl && doc.thumbnailStorageId) {
-        m.thumbnailMediaUrl = (await ctx.storage.getUrl(doc.thumbnailStorageId)) ?? undefined;
-      }
-      results.push(m);
-    }
-    return results;
+    return docs.map(mapDocToMovement);
   },
 });
 
@@ -159,23 +151,21 @@ export const getByTonalIds = internalQuery({
         .query("movements")
         .withIndex("by_tonalId", (q) => q.eq("tonalId", tonalId))
         .unique();
-      if (doc) {
-        const m = mapDocToMovement(doc);
-        if (!m.thumbnailMediaUrl && doc.thumbnailStorageId) {
-          m.thumbnailMediaUrl = (await ctx.storage.getUrl(doc.thumbnailStorageId)) ?? undefined;
-        }
-        results.push(m);
-      }
+      if (doc) results.push(mapDocToMovement(doc));
     }
     return results;
   },
 });
 
-/** Save a thumbnail storageId to a movement document. */
+/** Save a thumbnail storageId and resolved URL to a movement document. */
 export const setThumbnailStorageId = internalMutation({
   args: { id: v.id("movements"), storageId: v.id("_storage") },
   handler: async (ctx, { id, storageId }) => {
-    await ctx.db.patch(id, { thumbnailStorageId: storageId });
+    const url = await ctx.storage.getUrl(storageId);
+    await ctx.db.patch(id, {
+      thumbnailStorageId: storageId,
+      ...(url ? { thumbnailMediaUrl: url } : {}),
+    });
   },
 });
 
@@ -240,6 +230,23 @@ export const backfillThumbnails = internalAction({
       });
       console.log("[movementSync] Scheduled next thumbnail backfill batch");
     }
+  },
+});
+
+/** One-time migration: resolve thumbnailStorageId to thumbnailMediaUrl for existing documents. */
+export const backfillThumbnailUrls = internalMutation({
+  handler: async (ctx) => {
+    const docs = await ctx.db.query("movements").collect();
+    const needsBackfill = docs.filter((m) => m.thumbnailStorageId && !m.thumbnailMediaUrl);
+    let patched = 0;
+    for (const doc of needsBackfill) {
+      const url = await ctx.storage.getUrl(doc.thumbnailStorageId!);
+      if (url) {
+        await ctx.db.patch(doc._id, { thumbnailMediaUrl: url });
+        patched++;
+      }
+    }
+    console.log(`[backfillThumbnailUrls] ${patched} of ${needsBackfill.length} documents patched`);
   },
 });
 


### PR DESCRIPTION
## Summary

- Fix coach freeze reported by users with 5M+ lbs lifted and extensive workout histories
- Eliminate 300+ sequential `ctx.storage.getUrl()` calls per chat message
- Make first-message flow non-blocking (async scheduling instead of synchronous LLM roundtrip)

## Changes

**Cache key alignment** (`convex/ai/context.ts`)
- Chat context now fetches `workoutHistory:20` instead of `:10`, matching the 30-minute cron's pre-warmed cache key. Returning users get a cache hit instead of a guaranteed miss.

**Thumbnail URL persistence** (`convex/tonal/movementSync.ts`)
- `setThumbnailStorageId` now resolves and persists `thumbnailMediaUrl` at write time
- `getAllMovements` and `getByTonalIds` no longer resolve URLs at read time -- just a pure `docs.map(mapDocToMovement)`
- Added `backfillThumbnailUrls` one-time migration for existing documents. Run with: `npx convex run tonal/movementSync:backfillThumbnailUrls`

**Async first message** (`convex/chat.ts`)
- `createThreadWithMessage` no longer blocks on the full LLM roundtrip
- BYOK key validation still runs synchronously (errors surface immediately)
- Thread creation still runs synchronously (reactive queries fire on commit)
- LLM inference is scheduled via `ctx.scheduler.runAfter(0, processMessage, ...)` and returns `threadId` immediately
- Matches the async pattern already used by `sendMessageToThread` for subsequent messages

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (718 tests, 0 failures)
- [x] Existing `movementSync.test.ts` passes (21 tests) -- covers the `mapDocToMovement` pure function that `getAllMovements` now uses directly
- [ ] Manual: deploy and run `npx convex run tonal/movementSync:backfillThumbnailUrls`
- [ ] Manual: test first-message flow as a new user (should see chat thread immediately, coach response streams in)
- [ ] Manual: test with a user that has large Tonal history (the original reporter)

Closes #88
Related: #87, #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * AI training now analyzes more workout history for better personalized coaching insights.
  * Optimized thumbnail image loading for improved performance.
  * Enhanced message processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->