### PR TITLE
fix: pre-warm chat cache keys during Tonal backfill

### DIFF
--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -265,6 +265,15 @@ export const backfillUserHistory = internalAction({
       synced = await syncActivitiesAndStrength(ctx, userId, activities);
     }
 
+    // Pre-warm the cache keys that buildTrainingSnapshot reads on first
+    // chat so the user doesn't hit cold-cache Tonal API calls.
+    await Promise.all([
+      ctx.runAction(internal.tonal.proxy.fetchWorkoutHistory, { userId, limit: 20 }),
+      ctx.runAction(internal.tonal.proxy.fetchExternalActivities, { userId, limit: 20 }),
+      ctx.runAction(internal.tonal.proxy.fetchStrengthScores, { userId }),
+      ctx.runAction(internal.tonal.proxy.fetchMuscleReadiness, { userId }),
+    ]);
+
     // Always refresh profile, even for new users with no workouts
     await maybeRefreshProfile(ctx, userId);
 


### PR DESCRIPTION
## Summary

- Pre-warm the 4 cache keys that `buildTrainingSnapshot` reads immediately after the initial Tonal history backfill
- Eliminates cold-cache Tonal API calls on a new user's first chat message

## Changes

**`convex/tonal/historySync.ts`**

After `backfillUserHistory` fetches deep history (limit=100, cached as `workoutHistory:100`), it now also fetches in parallel with the exact params that `buildTrainingSnapshot` uses:

- `workoutHistory:20`
- `externalActivities:20`
- `strengthScores`
- `muscleReadiness`

These run in `Promise.all` so they add minimal wall-clock time to the backfill (one round of parallel Tonal API calls).

## Context

Phase 2 follow-up to #92. Phase 1 fixed the freeze by aligning cache keys and making the first message async. This closes the remaining gap: new users whose 30-minute cron hasn't run yet were still hitting cold cache on first chat.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] Backend tests pass (565 tests)
- [ ] Manual: new user connects Tonal, sends first message -- should see no cold-cache delay

Related: #87, #88, #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)