### PR TITLE
[codex] use quality-first provider defaults

### DIFF
--- a/convex/ai/providers.test.ts
+++ b/convex/ai/providers.test.ts
@@ -68,6 +68,15 @@ describe("getProviderConfig", () => {
     expect(config.label).toBe("Google Gemini");
   });
 
+  it("uses the quality-first default models", () => {
+    expect(getProviderConfig("gemini").primaryModel).toBe("gemini-3-flash-preview");
+    expect(getProviderConfig("claude").primaryModel).toBe("claude-sonnet-4-6");
+    expect(getProviderConfig("claude").fallbackModel).toBe("claude-haiku-4-5");
+    expect(getProviderConfig("openai").primaryModel).toBe("gpt-5.4");
+    expect(getProviderConfig("openai").fallbackModel).toBe("gpt-5.4-mini");
+    expect(getProviderConfig("openrouter").primaryModel).toBe("openrouter/auto");
+  });
+
   it("throws for invalid provider", () => {
     expect(() => getProviderConfig("invalid" as ProviderId)).toThrow();
   });

--- a/convex/ai/providers.ts
+++ b/convex/ai/providers.ts
@@ -37,8 +37,8 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
   },
   claude: {
     label: "Anthropic Claude",
-    primaryModel: "claude-sonnet-4-5-20250514",
-    fallbackModel: "claude-haiku-4-5-20251001",
+    primaryModel: "claude-sonnet-4-6",
+    fallbackModel: "claude-haiku-4-5",
     keyRegex: /^sk-ant-/,
     keyFormatError: "Key format looks wrong. Claude keys start with 'sk-ant-'.",
     keySourceUrl: "https://console.anthropic.com/settings/keys",
@@ -52,8 +52,8 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
   },
   openai: {
     label: "OpenAI",
-    primaryModel: "gpt-4o",
-    fallbackModel: "gpt-4o-mini",
+    primaryModel: "gpt-5.4",
+    fallbackModel: "gpt-5.4-mini",
     keyRegex: /^sk-(?!ant-)(?!or-)/,
     keyFormatError:
       "Key format looks wrong. OpenAI keys start with 'sk-' (but not 'sk-ant-' or 'sk-or-').",
@@ -68,7 +68,7 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
   },
   openrouter: {
     label: "OpenRouter",
-    primaryModel: "",
+    primaryModel: "openrouter/auto",
     fallbackModel: null,
     keyRegex: /^sk-or-/,
     keyFormatError: "Key format looks wrong. OpenRouter keys start with 'sk-or-'.",

--- a/convex/byok-provider.test.ts
+++ b/convex/byok-provider.test.ts
@@ -217,27 +217,12 @@ describe("resolveProviderKey", () => {
     expect(result.apiKey).toBe(GEMINI_USER_KEY);
   });
 
-  it("throws byok_model_missing when OpenRouter is selected without a model override", async () => {
+  it("uses the OpenRouter default model when no override is set", async () => {
     process.env.TOKEN_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
     const ciphertext = await encrypt(OPENROUTER_USER_KEY, TEST_ENCRYPTION_KEY);
     const profile = makeProfile({
       selectedProvider: "openrouter",
       openrouterApiKeyEncrypted: ciphertext,
-    });
-    const byokCreationTime = BYOK_REQUIRED_AFTER + 1000;
-
-    await expect(resolveProviderKey(profile, byokCreationTime)).rejects.toThrow(
-      "byok_model_missing",
-    );
-  });
-
-  it("returns OpenRouter when the model override is present", async () => {
-    process.env.TOKEN_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
-    const ciphertext = await encrypt(OPENROUTER_USER_KEY, TEST_ENCRYPTION_KEY);
-    const profile = makeProfile({
-      selectedProvider: "openrouter",
-      openrouterApiKeyEncrypted: ciphertext,
-      modelOverride: "openai/gpt-4o-mini",
     });
     const byokCreationTime = BYOK_REQUIRED_AFTER + 1000;
 
@@ -246,7 +231,25 @@ describe("resolveProviderKey", () => {
     expect(result).toEqual({
       provider: "openrouter",
       apiKey: OPENROUTER_USER_KEY,
-      modelOverride: "openai/gpt-4o-mini",
+    });
+  });
+
+  it("returns OpenRouter when the model override is present", async () => {
+    process.env.TOKEN_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    const ciphertext = await encrypt(OPENROUTER_USER_KEY, TEST_ENCRYPTION_KEY);
+    const profile = makeProfile({
+      selectedProvider: "openrouter",
+      openrouterApiKeyEncrypted: ciphertext,
+      modelOverride: "openai/gpt-5.4-mini",
+    });
+    const byokCreationTime = BYOK_REQUIRED_AFTER + 1000;
+
+    const result = await resolveProviderKey(profile, byokCreationTime);
+
+    expect(result).toEqual({
+      provider: "openrouter",
+      apiKey: OPENROUTER_USER_KEY,
+      modelOverride: "openai/gpt-5.4-mini",
     });
   });
 });

--- a/convex/byok.ts
+++ b/convex/byok.ts
@@ -144,8 +144,7 @@ async function saveProviderKeyCore(
   const nextModelOverride = normalizeModelOverride(modelOverride);
   const effectiveModelOverride = nextModelOverride ?? normalizeModelOverride(profile.modelOverride);
 
-  // Avoid selecting OpenRouter until we have a usable model name.
-  const autoSwitch = provider !== "openrouter" || effectiveModelOverride !== undefined;
+  const autoSwitch = effectiveModelOverride !== undefined || config.primaryModel !== "";
 
   const patch: Partial<Doc<"userProfiles">> = {
     [config.keyFieldName]: encrypted,
@@ -183,8 +182,6 @@ async function removeProviderKeyCore(
     const fallback = (["gemini", "claude", "openai", "openrouter"] as const).find((p) => {
       if (p === provider) return false;
       if (!profile[KEY_FIELD_MAP[p]]) return false;
-      // Skip OpenRouter if no model override is set
-      if (p === "openrouter" && !profile.modelOverride?.trim()) return false;
       return true;
     });
     patch.selectedProvider = fallback ?? undefined;
@@ -276,11 +273,7 @@ export const setSelectedProvider = mutation({
       throw new Error(`No API key on file for ${provider}`);
     }
 
-    if (provider === "openrouter") {
-      if (!normalizeModelOverride(profile.modelOverride)) {
-        throw new Error("OpenRouter requires a model name. Set one in Advanced first.");
-      }
-    }
+    assertProviderHasRequiredModel(provider, normalizeModelOverride(profile.modelOverride));
 
     await ctx.db.patch(profile._id, { selectedProvider: provider });
   },
@@ -300,9 +293,11 @@ export const setModelOverride = mutation({
     if (!profile) throw new Error("User profile not found");
 
     const nextModelOverride = normalizeModelOverride(args.modelOverride);
-    if (profile.selectedProvider === "openrouter" && !nextModelOverride) {
-      throw new Error("OpenRouter requires a model name while it is selected.");
-    }
+    const selectedProvider =
+      profile.selectedProvider && isValidProvider(profile.selectedProvider)
+        ? profile.selectedProvider
+        : "gemini";
+    assertProviderHasRequiredModel(selectedProvider, nextModelOverride);
 
     await ctx.db.patch(profile._id, {
       modelOverride: nextModelOverride,

--- a/convex/byokShared.ts
+++ b/convex/byokShared.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
-import type { ProviderId } from "./ai/providers";
+import { getProviderConfig, type ProviderId } from "./ai/providers";
 
 export const providerIdValidator = v.union(
   v.literal("gemini"),
@@ -44,7 +44,7 @@ export function assertProviderHasRequiredModel(
   provider: ProviderId,
   modelOverride: string | undefined,
 ): void {
-  if (provider === "openrouter" && !modelOverride) {
+  if (!modelOverride && !getProviderConfig(provider).primaryModel) {
     throw new Error("byok_model_missing");
   }
 }

--- a/src/app/onboarding/ProviderKeyStep.tsx
+++ b/src/app/onboarding/ProviderKeyStep.tsx
@@ -31,8 +31,6 @@ export function ProviderKeyStep({ onComplete }: { readonly onComplete: () => voi
     onComplete();
   };
 
-  const openrouterMissingModel = provider === "openrouter" && !modelName.trim();
-
   return (
     <Card>
       <CardContent className="pt-6">
@@ -68,20 +66,23 @@ export function ProviderKeyStep({ onComplete }: { readonly onComplete: () => voi
         {provider === "openrouter" && (
           <div className="mb-4 space-y-1.5">
             <Label htmlFor="model-name" className="text-xs text-muted-foreground">
-              Model name (required)
+              Model name (optional)
             </Label>
             <Input
               id="model-name"
               type="text"
               value={modelName}
               onChange={(e) => setModelName(e.target.value)}
-              placeholder="e.g. anthropic/claude-sonnet-4-5 or openai/gpt-4o"
+              placeholder="e.g. openrouter/auto or anthropic/claude-sonnet-4-6"
               autoComplete="off"
             />
+            <p className="text-xs text-muted-foreground">
+              Leave blank to use the quality-first default: <code>openrouter/auto</code>.
+            </p>
           </div>
         )}
 
-        <ApiKeyForm provider={provider} onSave={handleSave} disabled={openrouterMissingModel} />
+        <ApiKeyForm provider={provider} onSave={handleSave} />
       </CardContent>
     </Card>
   );

--- a/src/features/byok/ModelOverrideSection.tsx
+++ b/src/features/byok/ModelOverrideSection.tsx
@@ -11,9 +11,9 @@ import { Label } from "@/components/ui/label";
 
 const DEFAULT_MODEL_BY_PROVIDER: Record<ProviderId, string> = {
   gemini: "gemini-3-flash-preview",
-  claude: "claude-sonnet-4-5-20250514",
-  openai: "gpt-4o",
-  openrouter: "",
+  claude: "claude-sonnet-4-6",
+  openai: "gpt-5.4",
+  openrouter: "openrouter/auto",
 };
 
 export function ModelOverrideSection({
@@ -87,9 +87,7 @@ export function ModelOverrideSection({
                 placeholder={defaultModel || "Enter model name"}
                 disabled={saving}
               />
-              <p className="text-xs text-muted-foreground">
-                Default: {defaultModel || "none (OpenRouter requires a model)"}
-              </p>
+              <p className="text-xs text-muted-foreground">Default: {defaultModel}</p>
             </div>
 
             <div className="flex items-center gap-2">
@@ -101,7 +99,7 @@ export function ModelOverrideSection({
                 {saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
                 Save
               </Button>
-              {modelOverride && provider !== "openrouter" && (
+              {modelOverride && (
                 <button
                   type="button"
                   onClick={handleReset}

--- a/src/features/byok/ProviderSection.tsx
+++ b/src/features/byok/ProviderSection.tsx
@@ -17,9 +17,9 @@ import { ProviderKeyDisplay } from "./ProviderKeyDisplay";
 // Client-side UI metadata only (no server-side createLanguageModel functions)
 const PROVIDER_UI_CONFIG: Record<ProviderId, { label: string; primaryModel: string }> = {
   gemini: { label: "Google Gemini", primaryModel: "gemini-3-flash-preview" },
-  claude: { label: "Anthropic Claude", primaryModel: "claude-sonnet-4-5-20250514" },
-  openai: { label: "OpenAI", primaryModel: "gpt-4o" },
-  openrouter: { label: "OpenRouter", primaryModel: "" },
+  claude: { label: "Anthropic Claude", primaryModel: "claude-sonnet-4-6" },
+  openai: { label: "OpenAI", primaryModel: "gpt-5.4" },
+  openrouter: { label: "OpenRouter", primaryModel: "openrouter/auto" },
 };
 
 const PROVIDER_OPTIONS: { id: ProviderId; label: string }[] = [
@@ -122,17 +122,10 @@ export function ProviderSection() {
   };
 
   const handleSave = async (apiKey: string) => {
-    const needsModelSetup = viewProvider === "openrouter" && !settings?.modelOverride?.trim();
     await saveKey({ provider: viewProvider, apiKey });
     await refreshSettings();
-    if (needsModelSetup) {
-      setViewProvider("openrouter");
-    }
     setIsOptingIn(false);
     toast.success(`${PROVIDER_UI_CONFIG[viewProvider].label} key saved`);
-    if (needsModelSetup) {
-      toast("Set a model name in Advanced below to activate OpenRouter", { duration: 6000 });
-    }
   };
 
   const handleRemove = async () => {


### PR DESCRIPTION
## Summary
- move the provider defaults to the current quality-first models
- update the BYOK flow so OpenRouter has a real default model instead of requiring manual setup first
- refresh the onboarding and settings copy to match the new defaults

## What Changed
- Gemini stays on `gemini-3-flash-preview` with `gemini-2.5-flash` fallback
- Claude moves to `claude-sonnet-4-6` with `claude-haiku-4-5` fallback
- OpenAI moves to `gpt-5.4` with `gpt-5.4-mini` fallback
- OpenRouter now defaults to `openrouter/auto`
- OpenRouter selection and key save paths now treat the model field as an optional override instead of a required prerequisite
- provider tests were updated to cover the new defaults and the OpenRouter default path

## Why
The merged multi-provider PR shipped with model defaults that were already behind the current provider lineups for Claude and OpenAI, and OpenRouter had no default at all. This follow-up aligns the app defaults with the current quality-first recommendations and removes unnecessary setup friction for OpenRouter.

## Impact
- users get stronger out-of-the-box defaults without needing to know current model IDs
- OpenRouter users can start with the provider's routing default and override it only when they want explicit control
- the backend and UI stay aligned on the same default-model policy

## Validation
- `npx vitest run convex/ai/providers.test.ts convex/byok-provider.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check convex/ai/providers.ts convex/ai/providers.test.ts convex/byok.ts convex/byokShared.ts convex/byok-provider.test.ts src/app/onboarding/ProviderKeyStep.tsx src/features/byok/ModelOverrideSection.tsx src/features/byok/ProviderSection.tsx`

## Research Basis
Checked against current official provider docs on April 13, 2026:
- Google Gemini models
- Anthropic Claude models overview
- OpenAI models overview
- OpenRouter auto router docs
