### PR TITLE
fix: merge consecutive same-role messages for Gemini turn alternation

### DIFF
--- a/convex/ai/coach.test.ts
+++ b/convex/ai/coach.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { ModelMessage } from "ai";
+import { mergeConsecutiveSameRole } from "./coach";
+
+describe("mergeConsecutiveSameRole", () => {
+  it("returns empty array unchanged", () => {
+    expect(mergeConsecutiveSameRole([])).toEqual([]);
+  });
+
+  it("returns single message unchanged", () => {
+    const msgs: ModelMessage[] = [{ role: "user", content: "hi" }];
+    expect(mergeConsecutiveSameRole(msgs)).toEqual(msgs);
+  });
+
+  it("leaves alternating roles untouched", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "plan my week" },
+    ];
+    expect(mergeConsecutiveSameRole(msgs)).toEqual(msgs);
+  });
+
+  it("merges consecutive assistant messages (string + string)", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "search result text" },
+      { role: "assistant", content: "recent context text" },
+      { role: "user", content: "plan my week" },
+    ];
+    const result = mergeConsecutiveSameRole(msgs);
+    expect(result).toHaveLength(3);
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].content).toEqual([
+      { type: "text", text: "search result text" },
+      { type: "text", text: "recent context text" },
+    ]);
+  });
+
+  it("merges consecutive assistant messages (text + tool-call)", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "I can help with that" },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "tc1", toolName: "get_scores", input: {} }],
+      },
+    ];
+    const result = mergeConsecutiveSameRole(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].content).toEqual([
+      { type: "text", text: "I can help with that" },
+      { type: "tool-call", toolCallId: "tc1", toolName: "get_scores", input: {} },
+    ]);
+  });
+
+  it("merges more than two consecutive messages", () => {
+    const msgs: ModelMessage[] = [
+      { role: "assistant", content: "a" },
+      { role: "assistant", content: "b" },
+      { role: "assistant", content: "c" },
+    ];
+    const result = mergeConsecutiveSameRole(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toEqual([
+      { type: "text", text: "a" },
+      { type: "text", text: "b" },
+      { type: "text", text: "c" },
+    ]);
+  });
+
+  it("does not merge consecutive system messages", () => {
+    const msgs: ModelMessage[] = [
+      { role: "system", content: "instructions" },
+      { role: "system", content: "training data" },
+      { role: "user", content: "hello" },
+    ];
+    const result = mergeConsecutiveSameRole(msgs);
+    expect(result).toHaveLength(3);
+  });
+
+  it("merges consecutive user messages", () => {
+    const msgs: ModelMessage[] = [
+      { role: "assistant", content: "done" },
+      { role: "user", content: "first" },
+      { role: "user", content: "second" },
+    ];
+    const result = mergeConsecutiveSameRole(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[1].content).toEqual([
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+    ]);
+  });
+});

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -67,6 +67,31 @@ import {
   updateGoalProgressTool,
 } from "./coachingTools";
 
+export function mergeConsecutiveSameRole(messages: ModelMessage[]): ModelMessage[] {
+  if (messages.length <= 1) return messages;
+
+  const result: ModelMessage[] = [messages[0]];
+
+  for (let i = 1; i < messages.length; i++) {
+    const prev = result[result.length - 1];
+    const curr = messages[i];
+
+    // Never merge system messages; the provider extracts them separately.
+    if (prev.role !== curr.role || prev.role === "system") {
+      result.push(curr);
+      continue;
+    }
+
+    const toParts = (c: ModelMessage["content"]): Array<Record<string, unknown>> =>
+      typeof c === "string" ? [{ type: "text", text: c }] : (c as Array<Record<string, unknown>>);
+
+    const merged = [...toParts(prev.content), ...toParts(curr.content)];
+    result[result.length - 1] = { ...prev, content: merged } as ModelMessage;
+  }
+
+  return result;
+}
+
 /**
  * Remove image parts from all messages except the most recent user message.
  * Images stored in older messages cause unbounded memory growth when loaded
@@ -199,7 +224,9 @@ export const coachAgentConfig = {
     // Strip image parts from all messages except the most recent user message
     // to prevent OOM from large image data accumulating in context.
     const messages = stripImagesFromOlderMessages(args.allMessages);
-    return [snapshotMessage, ...messages];
+    // Merge consecutive same-role messages that arise from search + recent
+    // concatenation to satisfy Gemini's turn-alternation requirement.
+    return [snapshotMessage, ...mergeConsecutiveSameRole(messages)];
   }) satisfies ContextHandler,
 };
 

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -214,19 +214,18 @@ export const coachAgentConfig = {
   }) satisfies UsageHandler,
 
   contextHandler: (async (ctx, args) => {
-    if (!args.userId) return [...args.allMessages];
+    // Normalize regardless of auth: strip stale images, merge consecutive
+    // same-role messages that arise from search + recent concatenation.
+    const messages = mergeConsecutiveSameRole(stripImagesFromOlderMessages(args.allMessages));
+
+    if (!args.userId) return messages;
 
     const snapshot = await buildTrainingSnapshot(ctx, args.userId);
     const snapshotMessage = {
       role: "system" as const,
       content: `<training-data>\n${snapshot}\n</training-data>`,
     };
-    // Strip image parts from all messages except the most recent user message
-    // to prevent OOM from large image data accumulating in context.
-    const messages = stripImagesFromOlderMessages(args.allMessages);
-    // Merge consecutive same-role messages that arise from search + recent
-    // concatenation to satisfy Gemini's turn-alternation requirement.
-    return [snapshotMessage, ...mergeConsecutiveSameRole(messages)];
+    return [snapshotMessage, ...messages];
   }) satisfies ContextHandler,
 };
 

--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -56,6 +56,16 @@ describe("isTransientError", () => {
     expect(isTransientError(error)).toBe(false);
   });
 
+  it("returns true for AbortError by name", () => {
+    const error = new Error("The operation was aborted");
+    error.name = "AbortError";
+    expect(isTransientError(error)).toBe(true);
+  });
+
+  it("returns true for errors containing 'aborted' in message", () => {
+    expect(isTransientError(new Error("This operation was aborted"))).toBe(true);
+  });
+
   it("returns false for generic errors without status", () => {
     expect(isTransientError(new Error("Something broke"))).toBe(false);
   });

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -22,8 +22,9 @@ export function isTransientError(error: unknown): boolean {
   if (error instanceof TypeError && error.message.includes("fetch")) return true;
 
   if (error instanceof Error) {
-    if (error.name === "TimeoutError") return true;
+    if (error.name === "TimeoutError" || error.name === "AbortError") return true;
     if (error.message.toLowerCase().includes("timeout")) return true;
+    if (error.message.toLowerCase().includes("aborted")) return true;
 
     const status = (error as Error & { status?: number }).status;
     if (typeof status === "number" && TRANSIENT_STATUS_CODES.has(status)) return true;


### PR DESCRIPTION
## Summary

- Adds `mergeConsecutiveSameRole()` in the contextHandler that coalesces adjacent same-role messages by merging their content arrays, fixing Gemini's "function call turn comes immediately after a user turn or after a function response turn" rejection
- Treats `AbortError` / `"aborted"` as transient in `isTransientError()` so aborted streams get retried instead of immediately saving an error message

## Context

The `@convex-dev/agent` framework concatenates search context (from other threads) with recent messages: `[...search, ...recent, ...inputPrompt]`. When the search snippet ends with an `assistant(text)` message and the 30-message recent window starts with an `assistant(tool-call)` (because the user message that preceded it fell outside the window), the `@ai-sdk/google` provider sends two consecutive `Content(role: "model")` objects. Gemini rejects this when the second carries `FunctionCall` parts.

The abort at 9:16 PM added ~4 messages to the thread, pushing it past 30 messages and shifting the window boundary to start on an assistant message, triggering the issue on the user's next message at 9:17 PM.

## Test plan

- [x] New unit tests for `mergeConsecutiveSameRole` (7 cases: empty, single, alternating, string+string, text+tool-call, 3+ consecutive, system messages preserved)
- [x] New unit tests for abort detection in `isTransientError`
- [x] All existing tests pass
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for aborted operations—errors with "AbortError" or containing "aborted" messages are now properly classified as transient.
  * Enhanced conversation flow through automatic message consolidation.

* **Tests**
  * Added comprehensive test coverage for error resilience and message consolidation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->