### PR TITLE
fix: address 5 Sentry issues across AI, cache, and proxy layers

### DIFF
--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -187,6 +187,11 @@ export const coachAgentConfig = {
 
   maxSteps: 25,
 
+  // Disable the AI SDK's built-in retry (default maxRetries: 2 = 3 attempts).
+  // streamWithRetry already handles retries with primary -> retry -> fallback.
+  // Without this, a terminal error like quota exhaustion triggers 9 API calls.
+  callSettings: { maxRetries: 0 },
+
   usageHandler: (async (ctx, { userId, threadId, agentName, usage, model, provider }) => {
     await ctx.runMutation(internal.aiUsage.record, {
       userId: userId as Id<"users"> | undefined,

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -123,6 +123,10 @@ const STREAM_OPTIONS = {
   saveStreamDeltas: { chunking: "word" as const, throttleMs: 100 },
 };
 
+// Convex actions have a 600s hard limit. Budget 180s per attempt so all three
+// attempts (primary + retry + fallback) fit within the action lifetime.
+const ATTEMPT_TIMEOUT_MS = 180_000;
+
 export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs): Promise<void> {
   const { primaryAgent, fallbackAgent, threadId, userId } = args;
   const promptArgs: PromptArgs =
@@ -169,9 +173,18 @@ async function attemptStream(
   userId: string,
   promptArgs: PromptArgs,
 ): Promise<void> {
-  const { thread } = await agent.continueThread(ctx, { threadId, userId });
-  const result = await thread.streamText(promptArgs, STREAM_OPTIONS);
-  await result.text;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort("Stream timeout"), ATTEMPT_TIMEOUT_MS);
+  try {
+    const { thread } = await agent.continueThread(ctx, { threadId, userId });
+    const result = await thread.streamText(
+      { ...promptArgs, abortSignal: controller.signal },
+      STREAM_OPTIONS,
+    );
+    await result.text;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function saveErrorAndNotify(

--- a/convex/ai/weekModificationTools.ts
+++ b/convex/ai/weekModificationTools.ts
@@ -61,12 +61,16 @@ export const swapExerciseTool = createTool({
         };
       }
 
-      await ctx.runMutation(internal.coach.weekModifications.swapExerciseInDraft, {
-        userId,
-        workoutPlanId: day.workoutPlanId,
-        oldMovementId: input.oldMovementId,
-        newMovementId: input.newMovementId,
-      });
+      try {
+        await ctx.runMutation(internal.coach.weekModifications.swapExerciseInDraft, {
+          userId,
+          workoutPlanId: day.workoutPlanId,
+          oldMovementId: input.oldMovementId,
+          newMovementId: input.newMovementId,
+        });
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) };
+      }
 
       return {
         success: true,
@@ -129,13 +133,17 @@ export const addExerciseTool = createTool({
       }
 
       const { dayIndex: _, movementId, sets, ...opts } = input;
-      await ctx.runMutation(internal.coach.weekModifications.addExerciseToDraft, {
-        userId,
-        workoutPlanId: day.workoutPlanId,
-        movementId,
-        sets,
-        ...opts,
-      });
+      try {
+        await ctx.runMutation(internal.coach.weekModifications.addExerciseToDraft, {
+          userId,
+          workoutPlanId: day.workoutPlanId,
+          movementId,
+          sets,
+          ...opts,
+        });
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) };
+      }
 
       return {
         success: true,

--- a/convex/ai/weekModificationTools.ts
+++ b/convex/ai/weekModificationTools.ts
@@ -14,6 +14,18 @@ import { DAY_NAMES } from "../coach/weekProgrammingHelpers";
 import { getWeekStartDateString } from "../weekPlanHelpers";
 import { requireUserId, withToolTracking } from "./helpers";
 
+const VALIDATION_PREFIXES = [
+  "Invalid movementId",
+  "Workout plan not found",
+  "Can only swap",
+  "Can only add",
+];
+
+function isValidationError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return VALIDATION_PREFIXES.some((p) => err.message.startsWith(p));
+}
+
 // ---------------------------------------------------------------------------
 // swapExerciseTool
 // ---------------------------------------------------------------------------
@@ -69,7 +81,10 @@ export const swapExerciseTool = createTool({
           newMovementId: input.newMovementId,
         });
       } catch (err) {
-        return { success: false, error: err instanceof Error ? err.message : String(err) };
+        if (isValidationError(err)) {
+          return { success: false, error: (err as Error).message };
+        }
+        throw err;
       }
 
       return {
@@ -142,7 +157,10 @@ export const addExerciseTool = createTool({
           ...opts,
         });
       } catch (err) {
-        return { success: false, error: err instanceof Error ? err.message : String(err) };
+        if (isValidationError(err)) {
+          return { success: false, error: (err as Error).message };
+        }
+        throw err;
       }
 
       return {

--- a/convex/tonal/cache.ts
+++ b/convex/tonal/cache.ts
@@ -77,10 +77,15 @@ export const setCacheEntry = internalMutation({
           expiresAt: args.expiresAt,
         });
       }
-    } catch {
-      // Silently skip if data exceeds Convex's 1 MiB document limit.
-      // The caller (cachedFetch) still returns fresh data to the user.
-      console.warn(`setCacheEntry(${args.dataType}): skipped, data too large`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("too large") || msg.includes("maximum size")) {
+        // Silently skip if data exceeds Convex's 1 MiB document limit.
+        // The caller (cachedFetch) still returns fresh data to the user.
+        console.warn(`setCacheEntry(${args.dataType}): skipped, data too large`);
+        return;
+      }
+      throw err;
     }
   },
 });

--- a/convex/tonal/cache.ts
+++ b/convex/tonal/cache.ts
@@ -58,23 +58,29 @@ export const setCacheEntry = internalMutation({
       )
       .unique();
 
-    if (existing) {
-      // Freshness guard: skip write if existing data is already newer.
-      // This makes concurrent cache writers harmless instead of conflicting.
-      if (args.fetchedAt <= existing.fetchedAt) return;
-      await ctx.db.patch(existing._id, {
-        data: args.data,
-        fetchedAt: args.fetchedAt,
-        expiresAt: args.expiresAt,
-      });
-    } else {
-      await ctx.db.insert("tonalCache", {
-        userId: args.userId,
-        dataType: args.dataType,
-        data: args.data,
-        fetchedAt: args.fetchedAt,
-        expiresAt: args.expiresAt,
-      });
+    try {
+      if (existing) {
+        // Freshness guard: skip write if existing data is already newer.
+        // This makes concurrent cache writers harmless instead of conflicting.
+        if (args.fetchedAt <= existing.fetchedAt) return;
+        await ctx.db.patch(existing._id, {
+          data: args.data,
+          fetchedAt: args.fetchedAt,
+          expiresAt: args.expiresAt,
+        });
+      } else {
+        await ctx.db.insert("tonalCache", {
+          userId: args.userId,
+          dataType: args.dataType,
+          data: args.data,
+          fetchedAt: args.fetchedAt,
+          expiresAt: args.expiresAt,
+        });
+      }
+    } catch {
+      // Silently skip if data exceeds Convex's 1 MiB document limit.
+      // The caller (cachedFetch) still returns fresh data to the user.
+      console.warn(`setCacheEntry(${args.dataType}): skipped, data too large`);
     }
   },
 });

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -210,13 +210,22 @@ export const fetchWorkoutHistory = internalAction({
     ),
 });
 
+// Convex caps array fields at 8192 elements. Tonal can return thousands of
+// set entries for some activities. Apply after every return path (fresh + cached).
+const MAX_SETS_RETURN = 4000;
+function truncateWorkoutDetail(detail: WorkoutActivityDetail | null): WorkoutActivityDetail | null {
+  if (!detail?.workoutSetActivity || detail.workoutSetActivity.length <= MAX_SETS_RETURN)
+    return detail;
+  return { ...detail, workoutSetActivity: detail.workoutSetActivity.slice(0, MAX_SETS_RETURN) };
+}
+
 export const fetchWorkoutDetail = internalAction({
   args: {
     userId: v.id("users"),
     activityId: v.string(),
   },
-  handler: async (ctx, { userId, activityId }): Promise<WorkoutActivityDetail | null> =>
-    withTokenRetry(ctx, userId, (token, tonalUserId) =>
+  handler: async (ctx, { userId, activityId }): Promise<WorkoutActivityDetail | null> => {
+    const result = await withTokenRetry(ctx, userId, (token, tonalUserId) =>
       cachedFetch<WorkoutActivityDetail | null>(ctx, {
         userId,
         dataType: `workoutDetail:${activityId}`,
@@ -227,17 +236,7 @@ export const fetchWorkoutDetail = internalAction({
               token,
               `/v6/users/${tonalUserId}/workout-activities/${activityId}`,
             );
-            // Tonal can return thousands of set entries for some activities,
-            // exceeding Convex's 8192 array element limit. Truncate to a safe
-            // ceiling -- no realistic single workout has more than 500 sets.
-            const MAX_SETS = 4000;
-            if (detail.workoutSetActivity && detail.workoutSetActivity.length > MAX_SETS) {
-              console.warn(
-                `fetchWorkoutDetail(${activityId}): truncating workoutSetActivity from ${detail.workoutSetActivity.length} to ${MAX_SETS}`,
-              );
-              detail.workoutSetActivity = detail.workoutSetActivity.slice(0, MAX_SETS);
-            }
-            return detail;
+            return truncateWorkoutDetail(detail);
           } catch (error) {
             if (error instanceof TonalApiError && error.status === 404) {
               return null;
@@ -246,7 +245,10 @@ export const fetchWorkoutDetail = internalAction({
           }
         },
       }),
-    ),
+    );
+    // Truncate after cachedFetch too: stale cache may predate the truncation.
+    return truncateWorkoutDetail(result);
+  },
 });
 
 export const fetchFormattedSummary = internalAction({


### PR DESCRIPTION
## Summary

Batch fix for 5 active Sentry issues:

- **TONALCOACH-1C** (240 events): Disable AI SDK internal retries (`maxRetries: 0`) since `streamWithRetry` already handles retries. Prevents 9 useless API calls on terminal errors like quota exhaustion
- **TONALCOACH-29** (22 events): Wrap `setCacheEntry` db ops in try-catch so oversized documents (>1 MiB) are silently skipped instead of throwing
- **TONALCOACH-10** (72 events): Catch mutation errors in `swap_exercise` and `add_exercise` tool handlers, returning structured `{ success: false }` so the AI can retry with valid IDs
- **TONALCOACH-1R** (147 events): Apply `workoutSetActivity` truncation after `cachedFetch` returns, not just in the fetcher -- stale cache predating the truncation bypassed it
- **TONALCOACH-17** (6 events): Add 180s per-attempt `AbortController` timeout so a single stalled stream can't consume the 600s Convex action budget

Also ignored TONALCOACH-24 in Sentry (stale client calling removed `canSignUp` function, no code references remain).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] All 786 tests pass
- [ ] Monitor Sentry after deploy for reduction in these 5 issue groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added streaming timeout protection to prevent AI responses from running indefinitely
  * Improved error handling in exercise modification tools for more graceful failures
  * Enhanced cache stability when handling large data entries
  * Optimized workout data retrieval to efficiently handle large exercise sets
  * Refined AI retry behavior for consistent performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->