### PR TITLE
feat: visual confirmation banners for coach actions

### DIFF
--- a/src/features/chat/ActionConfirmationBanner.test.tsx
+++ b/src/features/chat/ActionConfirmationBanner.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ActionConfirmationBanner } from "./ActionConfirmationBanner";
+
+describe("ActionConfirmationBanner", () => {
+  it("renders success variant with checkmark and message", () => {
+    render(<ActionConfirmationBanner variant="success" message="5 workouts pushed to Tonal" />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("5 workouts pushed to Tonal")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status").querySelector("[data-testid='banner-icon-success']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders error variant with alert icon and message", () => {
+    render(<ActionConfirmationBanner variant="error" message="3 pushed, 2 failed" />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("3 pushed, 2 failed")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status").querySelector("[data-testid='banner-icon-error']"),
+    ).toBeInTheDocument();
+  });
+
+  it("applies green styling for success variant", () => {
+    render(<ActionConfirmationBanner variant="success" message="Done" />);
+
+    const banner = screen.getByRole("status");
+    expect(banner.className).toContain("border-green");
+  });
+
+  it("applies red styling for error variant", () => {
+    render(<ActionConfirmationBanner variant="error" message="Failed" />);
+
+    const banner = screen.getByRole("status");
+    expect(banner.className).toContain("border-red");
+  });
+});

--- a/src/features/chat/ActionConfirmationBanner.tsx
+++ b/src/features/chat/ActionConfirmationBanner.tsx
@@ -1,0 +1,34 @@
+import { Check, CircleAlert } from "lucide-react";
+
+interface ActionConfirmationBannerProps {
+  variant: "success" | "error";
+  message: string;
+}
+
+export function ActionConfirmationBanner({ variant, message }: ActionConfirmationBannerProps) {
+  const isSuccess = variant === "success";
+
+  return (
+    <div
+      role="status"
+      className={`my-2 flex items-center gap-2.5 rounded-lg border px-3.5 py-2.5 ${
+        isSuccess
+          ? "border-green-900/30 bg-gradient-to-br from-green-500/[0.08] to-green-500/[0.02]"
+          : "border-red-900/30 bg-gradient-to-br from-red-500/[0.08] to-red-500/[0.02]"
+      }`}
+    >
+      <div
+        className={`flex size-7 shrink-0 items-center justify-center rounded-full ${
+          isSuccess ? "bg-green-500/15" : "bg-red-500/15"
+        }`}
+      >
+        {isSuccess ? (
+          <Check data-testid="banner-icon-success" className="size-3.5 text-green-500" />
+        ) : (
+          <CircleAlert data-testid="banner-icon-error" className="size-3.5 text-red-500" />
+        )}
+      </div>
+      <span className="text-sm font-semibold text-foreground">{message}</span>
+    </div>
+  );
+}

--- a/src/features/chat/ChatMessage.tsx
+++ b/src/features/chat/ChatMessage.tsx
@@ -217,7 +217,6 @@ export function ChatMessage({ message, isGrouped, threadId }: ChatMessageProps) 
                   key={part.toolCallId}
                   toolName={part.toolName}
                   state={part.state}
-                  input={part.input}
                   output={"output" in part ? part.output : undefined}
                 />
               ))}

--- a/src/features/chat/ToolCallIndicator.test.tsx
+++ b/src/features/chat/ToolCallIndicator.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ToolCallIndicator } from "./ToolCallIndicator";
+
+vi.mock("./WeekPlanCard", () => ({
+  WeekPlanCard: ({ plan }: { plan: { summary: string } }) => (
+    <div data-testid="week-plan-card">{plan.summary}</div>
+  ),
+}));
+
+describe("ToolCallIndicator", () => {
+  it("renders running chip for a state-changing tool in progress", () => {
+    render(<ToolCallIndicator toolName="approve_week_plan" state="input-available" />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("Pushing workouts to your Tonal...")).toBeInTheDocument();
+  });
+
+  it("renders confirmation banner for approve_week_plan on success", () => {
+    render(
+      <ToolCallIndicator
+        toolName="approve_week_plan"
+        state="output-available"
+        output={{ success: true, pushed: 4, failed: 0, skipped: 3, results: [] }}
+      />,
+    );
+
+    expect(screen.getByText("4 workouts pushed to Tonal")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status").querySelector("[data-testid='banner-icon-success']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders error banner for approve_week_plan on failure", () => {
+    render(
+      <ToolCallIndicator
+        toolName="approve_week_plan"
+        state="output-available"
+        output={{ success: false, pushed: 2, failed: 1, skipped: 0, results: [] }}
+      />,
+    );
+
+    expect(screen.getByText("2 pushed, 1 failed")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status").querySelector("[data-testid='banner-icon-error']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders confirmation banner for swap_exercise on success", () => {
+    render(
+      <ToolCallIndicator
+        toolName="swap_exercise"
+        state="output-available"
+        output={{ success: true, message: "Swapped" }}
+      />,
+    );
+
+    expect(screen.getByText("Exercise swapped")).toBeInTheDocument();
+  });
+
+  it("falls back to chip when output shape is unexpected", () => {
+    render(
+      <ToolCallIndicator
+        toolName="approve_week_plan"
+        state="output-available"
+        output="unexpected string"
+      />,
+    );
+
+    expect(screen.getByText("Workouts pushed to Tonal")).toBeInTheDocument();
+  });
+
+  it("renders chip for read-only tools", () => {
+    render(<ToolCallIndicator toolName="search_exercises" state="output-available" />);
+
+    expect(screen.getByText("Searched exercises")).toBeInTheDocument();
+  });
+
+  it("still renders WeekPlanCard for program_week", () => {
+    const output = {
+      success: true,
+      summary: {
+        weekStartDate: "2026-04-14",
+        preferredSplit: "ppl",
+        days: [
+          {
+            dayName: "Monday",
+            sessionType: "Push",
+            estimatedDuration: 45,
+            exercises: [{ name: "Bench Press", muscleGroups: ["Chest"], sets: 3, reps: 10 }],
+          },
+        ],
+      },
+    };
+
+    render(<ToolCallIndicator toolName="program_week" state="output-available" output={output} />);
+
+    expect(screen.getByTestId("week-plan-card")).toBeInTheDocument();
+    expect(screen.getByText(/PPL split/)).toBeInTheDocument();
+  });
+
+  it("returns null for unknown state", () => {
+    const { container } = render(
+      <ToolCallIndicator toolName="search_exercises" state="unknown-state" />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/features/chat/ToolCallIndicator.tsx
+++ b/src/features/chat/ToolCallIndicator.tsx
@@ -83,7 +83,6 @@ const TOOL_MESSAGES: Record<string, { running: string; done: string }> = {
 interface ToolCallIndicatorProps {
   toolName: string;
   state: string;
-  input?: unknown;
   output?: unknown;
 }
 

--- a/src/features/chat/ToolCallIndicator.tsx
+++ b/src/features/chat/ToolCallIndicator.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { WorkoutCard } from "@/components/WorkoutCard";
 import { WeekPlanCard } from "./WeekPlanCard";
+import { ActionConfirmationBanner } from "./ActionConfirmationBanner";
+import { extractBannerProps } from "./bannerExtractors";
 import type { WeekPlanPresentation } from "../../../convex/ai/schemas";
 
 const TOOL_MESSAGES: Record<string, { running: string; done: string }> = {
@@ -86,7 +87,7 @@ interface ToolCallIndicatorProps {
   output?: unknown;
 }
 
-export function ToolCallIndicator({ toolName, state, input, output }: ToolCallIndicatorProps) {
+export function ToolCallIndicator({ toolName, state, output }: ToolCallIndicatorProps) {
   const messages = TOOL_MESSAGES[toolName] ?? {
     running: `Running ${toolName}...`,
     done: `Ran ${toolName}`,
@@ -94,20 +95,6 @@ export function ToolCallIndicator({ toolName, state, input, output }: ToolCallIn
 
   const isRunning = state === "input-streaming" || state === "input-available";
   const isDone = state === "output-available";
-
-  // Special case: create_workout shows WorkoutCard when done
-  if (toolName === "create_workout" && isDone && input) {
-    const data = input as {
-      name?: string;
-      exercises?: Array<{
-        exerciseName?: string;
-        name?: string;
-        sets?: number;
-        reps?: number;
-      }>;
-    };
-    return <WorkoutCard title={data.name} exercises={data.exercises} />;
-  }
 
   // Special case: program_week shows WeekPlanCard when done
   if (toolName === "program_week" && isDone && output) {
@@ -159,7 +146,15 @@ export function ToolCallIndicator({ toolName, state, input, output }: ToolCallIn
     }
   }
 
-  // Unified chip layout for both running and done (prevents layout shift during transitions)
+  // State-changing tools: show confirmation banner when done
+  if (isDone) {
+    const bannerProps = extractBannerProps(toolName, output);
+    if (bannerProps) {
+      return <ActionConfirmationBanner {...bannerProps} />;
+    }
+  }
+
+  // Unified chip layout for both running and done
   if (isRunning) {
     return (
       <span

--- a/src/features/chat/bannerExtractors.test.ts
+++ b/src/features/chat/bannerExtractors.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { extractBannerProps } from "./bannerExtractors";
+
+describe("extractBannerProps", () => {
+  describe("approve_week_plan", () => {
+    it("returns success when all workouts pushed", () => {
+      const output = { success: true, pushed: 5, failed: 0, skipped: 2, results: [] };
+      expect(extractBannerProps("approve_week_plan", output)).toEqual({
+        variant: "success",
+        message: "5 workouts pushed to Tonal",
+      });
+    });
+
+    it("returns error when some workouts failed", () => {
+      const output = { success: false, pushed: 3, failed: 2, skipped: 0, results: [] };
+      expect(extractBannerProps("approve_week_plan", output)).toEqual({
+        variant: "error",
+        message: "3 pushed, 2 failed",
+      });
+    });
+
+    it("returns error with message when output has error field", () => {
+      const output = { error: "No week plan found. Use program_week first." };
+      expect(extractBannerProps("approve_week_plan", output)).toEqual({
+        variant: "error",
+        message: "No week plan found. Use program_week first.",
+      });
+    });
+
+    it("returns null for unexpected output shape", () => {
+      expect(extractBannerProps("approve_week_plan", "string")).toBeNull();
+      expect(extractBannerProps("approve_week_plan", null)).toBeNull();
+      expect(extractBannerProps("approve_week_plan", { unrelated: true })).toBeNull();
+    });
+  });
+
+  describe("create_workout", () => {
+    it("returns success for successful creation", () => {
+      const output = { success: true, workoutId: "w1", title: "Upper Body" };
+      expect(extractBannerProps("create_workout", output)).toEqual({
+        variant: "success",
+        message: "Workout created",
+      });
+    });
+
+    it("returns error for failed creation", () => {
+      const output = { success: false, error: "Invalid movement IDs" };
+      expect(extractBannerProps("create_workout", output)).toEqual({
+        variant: "error",
+        message: "Failed to create workout",
+      });
+    });
+  });
+
+  describe("delete_workout", () => {
+    it("returns success when deleted", () => {
+      const output = { deleted: true };
+      expect(extractBannerProps("delete_workout", output)).toEqual({
+        variant: "success",
+        message: "Workout deleted",
+      });
+    });
+
+    it("returns null for unexpected shape", () => {
+      expect(extractBannerProps("delete_workout", {})).toBeNull();
+    });
+  });
+
+  describe("delete_week_plan", () => {
+    it("returns success when deleted", () => {
+      const output = { deleted: true };
+      expect(extractBannerProps("delete_week_plan", output)).toEqual({
+        variant: "success",
+        message: "Week plan deleted",
+      });
+    });
+
+    it("returns error when not deleted", () => {
+      const output = { deleted: false, message: "No week plan found for the current week." };
+      expect(extractBannerProps("delete_week_plan", output)).toEqual({
+        variant: "error",
+        message: "Failed to delete week plan",
+      });
+    });
+  });
+
+  describe("swap_exercise", () => {
+    it("returns success", () => {
+      const output = { success: true, message: "Swapped Bench Press for Incline Press" };
+      expect(extractBannerProps("swap_exercise", output)).toEqual({
+        variant: "success",
+        message: "Exercise swapped",
+      });
+    });
+
+    it("returns error", () => {
+      const output = { success: false, error: "No workout linked to Monday." };
+      expect(extractBannerProps("swap_exercise", output)).toEqual({
+        variant: "error",
+        message: "Failed to swap exercise",
+      });
+    });
+  });
+
+  describe("move_session", () => {
+    it("returns success", () => {
+      const output = { success: true, message: "Moved Push from Monday to Wednesday" };
+      expect(extractBannerProps("move_session", output)).toEqual({
+        variant: "success",
+        message: "Session moved",
+      });
+    });
+
+    it("returns error", () => {
+      const output = { success: false, error: "Source and destination days are the same." };
+      expect(extractBannerProps("move_session", output)).toEqual({
+        variant: "error",
+        message: "Failed to move session",
+      });
+    });
+  });
+
+  describe("adjust_session_duration", () => {
+    it("returns success", () => {
+      const output = { success: true, message: "Adjusted Monday to 30 minutes" };
+      expect(extractBannerProps("adjust_session_duration", output)).toEqual({
+        variant: "success",
+        message: "Session adjusted",
+      });
+    });
+
+    it("returns error", () => {
+      const output = { success: false, error: "Monday is a rest day." };
+      expect(extractBannerProps("adjust_session_duration", output)).toEqual({
+        variant: "error",
+        message: "Failed to adjust session",
+      });
+    });
+  });
+
+  describe("unknown tools", () => {
+    it("returns null for read-only tools", () => {
+      expect(extractBannerProps("search_exercises", { results: [] })).toBeNull();
+    });
+
+    it("returns null for unknown tool names", () => {
+      expect(extractBannerProps("made_up_tool", {})).toBeNull();
+    });
+  });
+});

--- a/src/features/chat/bannerExtractors.ts
+++ b/src/features/chat/bannerExtractors.ts
@@ -1,0 +1,54 @@
+type BannerProps = { variant: "success" | "error"; message: string };
+type Extractor = (output: unknown) => BannerProps | null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+const approveWeekPlan: Extractor = (output) => {
+  if (!isRecord(output)) return null;
+  if (typeof output.error === "string") {
+    return { variant: "error", message: output.error };
+  }
+  if (typeof output.pushed === "number" && typeof output.failed === "number") {
+    if (output.failed > 0) {
+      return { variant: "error", message: `${output.pushed} pushed, ${output.failed} failed` };
+    }
+    return { variant: "success", message: `${output.pushed} workouts pushed to Tonal` };
+  }
+  return null;
+};
+
+function successBoolean(successMsg: string, errorMsg: string): Extractor {
+  return (output) => {
+    if (!isRecord(output)) return null;
+    if (output.success === true) return { variant: "success", message: successMsg };
+    if (output.success === false) return { variant: "error", message: errorMsg };
+    return null;
+  };
+}
+
+function deletedBoolean(successMsg: string, errorMsg: string): Extractor {
+  return (output) => {
+    if (!isRecord(output)) return null;
+    if (output.deleted === true) return { variant: "success", message: successMsg };
+    if (output.deleted === false) return { variant: "error", message: errorMsg };
+    return null;
+  };
+}
+
+const ACTION_EXTRACTORS: Record<string, Extractor> = {
+  approve_week_plan: approveWeekPlan,
+  create_workout: successBoolean("Workout created", "Failed to create workout"),
+  delete_workout: deletedBoolean("Workout deleted", "Failed to delete workout"),
+  delete_week_plan: deletedBoolean("Week plan deleted", "Failed to delete week plan"),
+  swap_exercise: successBoolean("Exercise swapped", "Failed to swap exercise"),
+  move_session: successBoolean("Session moved", "Failed to move session"),
+  adjust_session_duration: successBoolean("Session adjusted", "Failed to adjust session"),
+};
+
+export function extractBannerProps(toolName: string, output: unknown): BannerProps | null {
+  const extractor = ACTION_EXTRACTORS[toolName];
+  if (!extractor) return null;
+  return extractor(output);
+}


### PR DESCRIPTION
## Summary

- Adds tinted confirmation banners (green/red) when the AI coach performs state-changing actions (push workouts, swap exercises, move sessions, etc.)
- Replaces the plain "done" chip with a more visually distinct element so users get clear feedback that something actually happened
- Covers 7 state-changing tools with success/error variants; read-only tools keep the existing chip
- Gracefully falls back to the existing chip if the tool output shape is unexpected

Closes #109

## Test plan

- [ ] 30 new tests across 3 files (ActionConfirmationBanner, bannerExtractors, ToolCallIndicator) - all passing
- [ ] Full test suite: 816 tests pass, 0 failures
- [ ] Type check clean (`npx tsc --noEmit`)
- [ ] No dead code (`npm run knip`)
- [ ] Visual verification: start dev server, trigger coach actions, confirm banners render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)