### PR TITLE
fix: retry on Gemini 429 and high demand errors

### DIFF
--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -11,13 +11,24 @@ describe("isTransientError", () => {
     expect(isTransientError(new TypeError("fetch failed"))).toBe(true);
   });
 
-  it("returns false for 429 rate limit (treated as BYOK quota_exceeded, not transient)", () => {
-    // With BYOK, a 429 from Google AI means the user's per-key quota is
-    // exhausted. Retrying does not help, and it must surface as a typed
-    // BYOK error rather than be retried as a generic transient failure.
-    // See classifyByokError below for the routing.
+  it("returns true for 429 rate limit (retryable; BYOK routing handled upstream)", () => {
+    // For house-key users, 429 from Gemini "high demand" should be retried.
+    // BYOK users' 429s are caught by throwIfByokError before isTransientError
+    // is ever called, so this classification is safe for both paths.
     const error = Object.assign(new Error("Rate limited"), { status: 429 });
-    expect(isTransientError(error)).toBe(false);
+    expect(isTransientError(error)).toBe(true);
+  });
+
+  it("returns true for Gemini high demand message", () => {
+    const error = new Error(
+      "This model is currently experiencing high demand. Please try again later.",
+    );
+    expect(isTransientError(error)).toBe(true);
+  });
+
+  it("returns true for service unavailable message", () => {
+    const error = new Error("The service is currently unavailable.");
+    expect(isTransientError(error)).toBe(true);
   });
 
   it("returns true for 500 server error", () => {

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -10,21 +10,32 @@ const AI_ERROR_MESSAGE = "I'm having trouble right now. Please try again in a mo
 const BUDGET_EXCEEDED_MESSAGE =
   "I've hit my daily thinking limit -- let's pick this up tomorrow. Your limit resets at midnight UTC.";
 const MAX_OUTPUT_TOKENS = 4096;
-const RETRY_DELAY_MS = 1000;
+const RETRY_DELAY_MS = 3000;
 
 // ---------------------------------------------------------------------------
 // Error classification
 // ---------------------------------------------------------------------------
 
-const TRANSIENT_STATUS_CODES = new Set([500, 502, 503]);
+const TRANSIENT_STATUS_CODES = new Set([429, 500, 502, 503]);
+
+const TRANSIENT_MESSAGE_PATTERNS = [
+  "high demand",
+  "unavailable",
+  "overloaded",
+  "try again later",
+  "rate limit",
+  "resource_exhausted",
+];
 
 export function isTransientError(error: unknown): boolean {
   if (error instanceof TypeError && error.message.includes("fetch")) return true;
 
   if (error instanceof Error) {
     if (error.name === "TimeoutError" || error.name === "AbortError") return true;
-    if (error.message.toLowerCase().includes("timeout")) return true;
-    if (error.message.toLowerCase().includes("aborted")) return true;
+
+    const lower = error.message.toLowerCase();
+    if (lower.includes("timeout") || lower.includes("aborted")) return true;
+    if (TRANSIENT_MESSAGE_PATTERNS.some((p) => lower.includes(p))) return true;
 
     const status = (error as Error & { status?: number }).status;
     if (typeof status === "number" && TRANSIENT_STATUS_CODES.has(status)) return true;


### PR DESCRIPTION
## Summary

- Add 429 to transient status codes so rate limit errors trigger retry + fallback
- Add message-based detection for Gemini "high demand", "unavailable", "overloaded" errors (the AI SDK can strip status codes)
- Increase retry delay from 1s to 3s to give the API time to recover
- BYOK 429s are unaffected: `throwIfByokError` runs before `isTransientError` in `streamWithRetry`

Previously, when Gemini returned "This model is currently experiencing high demand", the system classified it as a non-transient error and immediately gave up, showing "I'm having trouble right now" to the user. Now it retries once with the primary model, then falls back to the secondary model before giving up.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (853 tests)
- [x] Resilience unit tests updated and passing (28 tests)
- [ ] Deploy and monitor Discord error notifications for reduced "high demand" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)