### PR TITLE
fix: surface failed async messages in chat UI

### DIFF
--- a/src/features/chat/ChatMessage.tsx
+++ b/src/features/chat/ChatMessage.tsx
@@ -2,7 +2,7 @@
 
 import type { UIMessage } from "@convex-dev/agent/react";
 import { useSmoothText } from "@convex-dev/agent/react";
-import { Sparkles } from "lucide-react";
+import { AlertTriangle, Sparkles } from "lucide-react";
 import Image from "next/image";
 import { MarkdownContent } from "./MarkdownContent";
 import { ToolApprovalCard } from "./ToolApprovalCard";
@@ -142,6 +142,15 @@ export function ChatMessage({ message, isGrouped, threadId }: ChatMessageProps) 
       )}
 
       <div className="sm:pl-8">
+        {message.status === "failed" && !message.text.trim() && (
+          <div className="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <span>
+              Something went wrong generating a response. Check your AI provider&apos;s usage and
+              limits, or try again.
+            </span>
+          </div>
+        )}
         {message.parts.map((part, i) => {
           if (part.type === "text") {
             const text = part.text;

--- a/src/features/chat/ChatMessage.tsx
+++ b/src/features/chat/ChatMessage.tsx
@@ -143,7 +143,10 @@ export function ChatMessage({ message, isGrouped, threadId }: ChatMessageProps) 
 
       <div className="sm:pl-8">
         {message.status === "failed" && !message.text.trim() && (
-          <div className="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
+          >
             <AlertTriangle className="mt-0.5 size-4 shrink-0" />
             <span>
               Something went wrong generating a response. Check your AI provider&apos;s usage and

--- a/src/features/chat/ChatThread.tsx
+++ b/src/features/chat/ChatThread.tsx
@@ -81,7 +81,8 @@ export function ChatThread({ userInitial, threadId }: ChatThreadProps) {
   const lastIsRecentUser =
     lastMessage?.role === "user" && lastMessage._creationTime > mountTime - STALE_MS;
   const lastIsAssistantWithoutText = lastMessage?.role === "assistant" && !lastMessage.text.trim();
-  const isThinking = lastIsRecentUser || lastIsAssistantWithoutText;
+  const lastIsFailed = lastMessage?.status === "failed";
+  const isThinking = !lastIsFailed && (lastIsRecentUser || lastIsAssistantWithoutText);
 
   // Track whether the user has scrolled away from the bottom.
   const [showScrollButton, setShowScrollButton] = useState(false);

--- a/src/features/chat/MessageList.tsx
+++ b/src/features/chat/MessageList.tsx
@@ -27,9 +27,15 @@ export function MessageList({
   return (
     <>
       {messages.map((message, i) => {
-        // Hide empty assistant messages (no text, no tool calls) — ThinkingIndicator covers this state
+        // Hide empty assistant messages (no text, no tool calls) unless failed
         const hasToolParts = message.parts.some((p) => p.type === "dynamic-tool");
-        if (message.role === "assistant" && !message.text.trim() && !hasToolParts) return null;
+        if (
+          message.role === "assistant" &&
+          !message.text.trim() &&
+          !hasToolParts &&
+          message.status !== "failed"
+        )
+          return null;
 
         const prev = i > 0 ? messages[i - 1] : null;
         const showDateDivider = isDifferentDay(message._creationTime, prev?._creationTime ?? null);


### PR DESCRIPTION
## Summary
- When `processMessage` fails asynchronously (e.g. BYOK quota exceeded, provider rate limit), the assistant message gets `status: "failed"` but the UI was hiding it and leaving the thinking indicator spinning forever
- Now failed messages render an error alert: "Something went wrong generating a response. Check your AI provider's usage and limits, or try again."
- Three small changes to frontend components, no backend changes

## Changes
- `MessageList.tsx` - Stop filtering out failed empty assistant messages
- `ChatThread.tsx` - Stop showing `ThinkingIndicator` when the last message has failed
- `ChatMessage.tsx` - Render a destructive-styled error alert for failed assistant messages

## Context
Discovered while investigating a user (Chris Mansfield) whose free-tier Gemini API key was hitting Google's 20 req/day limit. The `byok_quota_exceeded` error was thrown in the async `processMessage` action but the UI had no way to surface it - the thinking indicator just spun indefinitely.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 222 frontend tests pass
- [ ] Manually verify: trigger a failed message (e.g. invalid API key) and confirm the error alert renders
- [ ] Verify normal messages still render correctly
- [ ] Verify thinking indicator still shows during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error visibility: Failed chat messages now display an error alert instead of being silently hidden.
  * Fixed the "thinking" indicator to properly clear when a message fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->