### PR TITLE
fix: pre-save user message to prevent triple Gemini API calls on retry

### DIFF
--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyByokError,
+  isByokQuotaError,
   isTransientError,
   throwIfByokError,
   withByokErrorSanitization,
@@ -131,6 +132,42 @@ describe("classifyByokError", () => {
     expect(classifyByokError("oops")).toBeNull();
     expect(classifyByokError(null)).toBeNull();
     expect(classifyByokError(undefined)).toBeNull();
+  });
+});
+
+describe("isByokQuotaError", () => {
+  it("returns true for 429 status code", () => {
+    const error = Object.assign(new Error("Too Many Requests"), { status: 429 });
+    expect(isByokQuotaError(error)).toBe(true);
+  });
+
+  it("returns true for resource_exhausted message", () => {
+    const error = new Error("RESOURCE_EXHAUSTED: Quota exceeded");
+    expect(isByokQuotaError(error)).toBe(true);
+  });
+
+  it("returns true for quota message", () => {
+    const error = new Error("You have exceeded your quota for this model");
+    expect(isByokQuotaError(error)).toBe(true);
+  });
+
+  it("returns true for rate_limit message", () => {
+    const error = new Error("rate_limit_exceeded: try again later");
+    expect(isByokQuotaError(error)).toBe(true);
+  });
+
+  it("returns false for 500 server error", () => {
+    const error = Object.assign(new Error("Internal"), { status: 500 });
+    expect(isByokQuotaError(error)).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isByokQuotaError("string error")).toBe(false);
+    expect(isByokQuotaError(null)).toBe(false);
+  });
+
+  it("returns false for generic errors", () => {
+    expect(isByokQuotaError(new Error("Something broke"))).toBe(false);
   });
 });
 

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -136,11 +136,14 @@ interface StreamWithRetryArgs {
   /** Text prompt or multimodal message array (text + images). */
   prompt?: string | Array<ModelMessage>;
   promptMessageId?: string;
+  /** True when the user is on their own API key (not the house key). */
+  isByok: boolean;
 }
 
 type PromptArgs =
   | { prompt: string | Array<ModelMessage>; maxOutputTokens: number }
-  | { promptMessageId: string; maxOutputTokens: number };
+  | { promptMessageId: string; maxOutputTokens: number }
+  | { promptMessageId: string; prompt: Array<ModelMessage>; maxOutputTokens: number };
 
 const STREAM_OPTIONS = {
   saveStreamDeltas: { chunking: "word" as const, throttleMs: 100 },
@@ -152,10 +155,15 @@ const ATTEMPT_TIMEOUT_MS = 180_000;
 
 export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs): Promise<void> {
   const { primaryAgent, fallbackAgent, threadId, userId } = args;
-  const promptArgs: PromptArgs =
-    args.prompt !== undefined
-      ? { prompt: args.prompt, maxOutputTokens: MAX_OUTPUT_TOKENS }
-      : { promptMessageId: args.promptMessageId!, maxOutputTokens: MAX_OUTPUT_TOKENS };
+  const promptArgs: PromptArgs = args.promptMessageId
+    ? args.prompt !== undefined
+      ? {
+          promptMessageId: args.promptMessageId,
+          prompt: args.prompt as Array<ModelMessage>,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+        }
+      : { promptMessageId: args.promptMessageId, maxOutputTokens: MAX_OUTPUT_TOKENS }
+    : { prompt: args.prompt!, maxOutputTokens: MAX_OUTPUT_TOKENS };
 
   try {
     await attemptStream(ctx, primaryAgent, threadId, userId, promptArgs);
@@ -163,6 +171,7 @@ export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs)
   } catch (error) {
     // BYOK errors are terminal under BYOK: never silently fall back to the house key.
     throwIfByokError(error);
+    if (args.isByok && isByokQuotaError(error)) throw new Error("byok_quota_exceeded");
     if (!isTransientError(error)) {
       await saveErrorAndNotify(ctx, threadId, userId, error);
       return;
@@ -175,6 +184,7 @@ export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs)
     return;
   } catch (error) {
     throwIfByokError(error);
+    if (args.isByok && isByokQuotaError(error)) throw new Error("byok_quota_exceeded");
     if (!isTransientError(error)) {
       await saveErrorAndNotify(ctx, threadId, userId, error);
       return;

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -101,6 +101,16 @@ export function throwIfByokError(error: unknown): void {
   if (code !== null) throw new Error(code);
 }
 
+export function isByokQuotaError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const status = (error as Error & { status?: number }).status;
+  if (status === 429) return true;
+  const lower = error.message.toLowerCase();
+  return (
+    lower.includes("resource_exhausted") || lower.includes("quota") || lower.includes("rate_limit")
+  );
+}
+
 // Sanitization is mandatory: Google AI error bodies can echo the decrypted key.
 export async function withByokErrorSanitization<T>(fn: () => Promise<T>): Promise<T> {
   try {

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -3,6 +3,7 @@ import { paginationOptsValidator } from "convex/server";
 import {
   createThread as agentCreateThread,
   listUIMessages,
+  saveMessage,
   syncStreams,
   vStreamArgs,
 } from "@convex-dev/agent";
@@ -291,6 +292,7 @@ export const continueAfterApproval = action({
         threadId,
         userId,
         promptMessageId: messageId,
+        isByok: !providerConfig.isHouseKey,
       }),
     );
 
@@ -351,6 +353,14 @@ export const processMessage = internalAction({
 
     const resolvedPrompt = await buildPrompt(ctx, prompt, imageStorageIds ?? undefined);
 
+    // Pre-save the user message once so retries use promptMessageId
+    // instead of re-saving, re-embedding, and duplicating the message.
+    const { messageId } = await saveMessage(ctx, components.agent, {
+      threadId,
+      userId,
+      message: { role: "user" as const, content: prompt },
+    });
+
     const startTime = Date.now();
     const { primary, fallback } = buildCoachAgentsForProvider(providerConfig);
     await withByokErrorSanitization(() =>
@@ -359,7 +369,9 @@ export const processMessage = internalAction({
         fallbackAgent: fallback,
         threadId,
         userId,
-        prompt: resolvedPrompt,
+        promptMessageId: messageId,
+        prompt: typeof resolvedPrompt === "string" ? undefined : resolvedPrompt,
+        isByok: !providerConfig.isHouseKey,
       }),
     );
 


### PR DESCRIPTION
## Summary

- Pre-save user message once before the retry loop in `processMessage`, then pass `promptMessageId` to all retry attempts so `@convex-dev/agent` skips re-saving, re-embedding, and duplicating messages
- Add `isByok` flag to `streamWithRetry` to short-circuit retries immediately on BYOK quota errors (429, resource_exhausted, quota, rate_limit patterns)
- Add `isByokQuotaError` helper with broader pattern matching than `classifyByokError` to catch AI SDK-wrapped error formats

Closes #140
Related: #137, #138

## Behavior changes

| Scenario | Before | After |
|----------|--------|-------|
| Text message, no errors | 1 Gemini call + 1 embedding | Same |
| Text message, 1 transient error | 2 Gemini calls + 2 embeddings + 2 prompt saves | 2 Gemini calls + 1 embedding + 1 prompt save |
| Text message, 2 transient errors | 3 Gemini calls + 3 embeddings + 3 prompt saves | 3 Gemini calls + 1 embedding + 1 prompt save |
| BYOK 429 quota error | 3 Gemini calls + 3 embeddings + 3 prompt saves | 1 Gemini call + 1 embedding + 1 prompt save, immediate throw |

## Test plan

- [x] 7 new unit tests for `isByokQuotaError` (429 status, resource_exhausted, quota, rate_limit, negative cases)
- [x] All 862 existing tests pass
- [x] Typecheck clean
- [x] Lint + format clean
- [ ] Manual: send a chat message, verify only 1 user message saved to thread in Convex dashboard
- [ ] Manual: test with BYOK key on free tier to confirm no triple calls on 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)