### PR TITLE
fix: use recent-only fetch for incremental sync

### DIFF
--- a/convex/tonal/client.ts
+++ b/convex/tonal/client.ts
@@ -107,17 +107,18 @@ export async function fetchRecentWorkoutActivities<T>(
   tonalUserId: string,
   count: number = PG_PAGE_SIZE,
 ): Promise<T[]> {
-  // First call with offset=0 just to get pgTotal from the response header
-  const { pgTotal } = await fetchWorkoutActivitiesPage<T>(token, tonalUserId, 0, 1);
+  // Fetch a full page from offset 0. If pgTotal fits in one page, we're done.
+  // Otherwise use pgTotal to jump to the end for the newest items.
+  const { items: firstPage, pgTotal } = await fetchWorkoutActivitiesPage<T>(
+    token,
+    tonalUserId,
+    0,
+    count,
+  );
 
-  if (pgTotal === 0) return [];
-  if (pgTotal <= count) {
-    // Small enough to fetch everything in one shot
-    const { items } = await fetchWorkoutActivitiesPage<T>(token, tonalUserId, 0, pgTotal);
-    return items.reverse();
-  }
+  if (pgTotal <= count) return firstPage.reverse();
 
-  // Fetch the last `count` items from the end
+  // User has more than `count` items - fetch the last page from the end
   const startOffset = Math.max(0, pgTotal - count);
   const { items } = await fetchWorkoutActivitiesPage<T>(token, tonalUserId, startOffset, count);
   return items.reverse();

--- a/convex/tonal/client.ts
+++ b/convex/tonal/client.ts
@@ -45,9 +45,40 @@ export async function tonalFetch<T = unknown>(
 const PG_PAGE_SIZE = 200;
 
 /**
- * Paginated fetch from /workout-activities.
- * The Tonal API uses request headers (not query params) for pagination:
- *   pg-offset: starting index, pg-limit: page size, pg-total: response header with count.
+ * Fetch a single page of /workout-activities using pg-offset/pg-limit headers.
+ * Returns { items, pgTotal } so callers can decide whether to continue.
+ */
+async function fetchWorkoutActivitiesPage<T>(
+  token: string,
+  tonalUserId: string,
+  offset: number,
+  limit: number = PG_PAGE_SIZE,
+): Promise<{ items: T[]; pgTotal: number }> {
+  const res = await fetch(`${TONAL_API_BASE}/v6/users/${tonalUserId}/workout-activities`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "pg-offset": String(offset),
+      "pg-limit": String(limit),
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (res.status === 401) {
+    throw new TonalApiError(401, await res.text().catch(() => "Unauthorized"));
+  }
+  if (!res.ok) {
+    throw new TonalApiError(res.status, await res.text().catch(() => res.statusText));
+  }
+
+  const items = (await res.json()) as T[];
+  const pgTotal = parseInt(res.headers.get("pg-total") ?? "0", 10);
+  return { items, pgTotal };
+}
+
+/**
+ * Paginated fetch of ALL /workout-activities (oldest to newest).
+ * Used by backfill to get complete history.
  */
 export async function fetchAllWorkoutActivities<T>(
   token: string,
@@ -57,31 +88,37 @@ export async function fetchAllWorkoutActivities<T>(
   let offset = 0;
 
   while (true) {
-    const res = await fetch(`${TONAL_API_BASE}/v6/users/${tonalUserId}/workout-activities`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        "pg-offset": String(offset),
-        "pg-limit": String(PG_PAGE_SIZE),
-      },
-      signal: AbortSignal.timeout(30_000),
-    });
-
-    if (res.status === 401) {
-      throw new TonalApiError(401, await res.text().catch(() => "Unauthorized"));
-    }
-    if (!res.ok) {
-      throw new TonalApiError(res.status, await res.text().catch(() => res.statusText));
-    }
-
-    const page = (await res.json()) as T[];
-    all.push(...page);
-
-    const pgTotal = parseInt(res.headers.get("pg-total") ?? "0", 10);
-    offset += page.length;
-
-    if (page.length < PG_PAGE_SIZE || offset >= pgTotal) break;
+    const { items, pgTotal } = await fetchWorkoutActivitiesPage<T>(token, tonalUserId, offset);
+    all.push(...items);
+    offset += items.length;
+    if (items.length < PG_PAGE_SIZE || offset >= pgTotal) break;
   }
 
   return all;
+}
+
+/**
+ * Fetch the most recent workout activities (newest first) by reading from the
+ * end of the paginated list. Returns up to `count` items, newest first.
+ * Used by incremental sync - typically 1 API call instead of 5+.
+ */
+export async function fetchRecentWorkoutActivities<T>(
+  token: string,
+  tonalUserId: string,
+  count: number = PG_PAGE_SIZE,
+): Promise<T[]> {
+  // First call with offset=0 just to get pgTotal from the response header
+  const { pgTotal } = await fetchWorkoutActivitiesPage<T>(token, tonalUserId, 0, 1);
+
+  if (pgTotal === 0) return [];
+  if (pgTotal <= count) {
+    // Small enough to fetch everything in one shot
+    const { items } = await fetchWorkoutActivitiesPage<T>(token, tonalUserId, 0, pgTotal);
+    return items.reverse();
+  }
+
+  // Fetch the last `count` items from the end
+  const startOffset = Math.max(0, pgTotal - count);
+  const { items } = await fetchWorkoutActivitiesPage<T>(token, tonalUserId, startOffset, count);
+  return items.reverse();
 }

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -278,6 +278,7 @@ export const backfillUserHistory = internalAction({
     try {
       const activities: Activity[] = await ctx.runAction(internal.tonal.proxy.fetchWorkoutHistory, {
         userId,
+        mode: "full",
       });
 
       let synced = 0;

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -4,7 +4,12 @@ import { internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { decrypt } from "./encryption";
-import { fetchAllWorkoutActivities, TonalApiError, tonalFetch } from "./client";
+import {
+  fetchAllWorkoutActivities,
+  fetchRecentWorkoutActivities,
+  TonalApiError,
+  tonalFetch,
+} from "./client";
 import { CACHE_TTLS } from "./cache";
 import { withTokenRetry } from "./tokenRetry";
 import type {
@@ -260,24 +265,33 @@ export const fetchWorkoutHistory = internalAction({
   args: {
     userId: v.id("users"),
     limit: v.optional(v.number()),
+    // "recent" (default): fetches newest page only (1-2 API calls). For cron sync.
+    // "full": paginates through all history (N API calls). For backfill.
+    mode: v.optional(v.union(v.literal("recent"), v.literal("full"))),
   },
-  handler: async (ctx, { userId, limit }): Promise<Activity[]> =>
+  handler: async (ctx, { userId, limit, mode = "recent" }): Promise<Activity[]> =>
     withTokenRetry(ctx, userId, async (token, tonalUserId) => {
-      // Cache the lightweight Activity[] (no per-set data) instead of the
-      // raw WorkoutActivityDetail[] which can exceed 16 MiB for heavy users.
+      const cacheKey = mode === "full" ? "workoutHistory_v3_full" : "workoutHistory_v3";
+
       const activities = await cachedFetch<Activity[]>(ctx, {
         userId,
-        dataType: "workoutHistory_v3",
+        dataType: cacheKey,
         ttl: CACHE_TTLS.workoutHistory,
         fetcher: async () => {
-          const items = await fetchAllWorkoutActivities<WorkoutActivityDetail>(token, tonalUserId);
+          const items =
+            mode === "full"
+              ? await fetchAllWorkoutActivities<WorkoutActivityDetail>(token, tonalUserId)
+              : await fetchRecentWorkoutActivities<WorkoutActivityDetail>(token, tonalUserId);
+
           if (items.length === 0) return [];
 
           const uniqueWorkoutIds = [...new Set(items.map((w) => w.workoutId))];
           const meta = await fetchWorkoutMetaBatch(ctx, token, uniqueWorkoutIds);
 
-          // API returns oldest-first; reverse so callers get newest-first
-          return items.map((wa) => toActivity(wa, meta.get(wa.workoutId))).reverse();
+          // fetchRecentWorkoutActivities already returns newest-first;
+          // fetchAllWorkoutActivities returns oldest-first, so reverse it
+          const mapped = items.map((wa) => toActivity(wa, meta.get(wa.workoutId)));
+          return mode === "full" ? mapped.reverse() : mapped;
         },
       });
 

--- a/convex/tonal/resync.ts
+++ b/convex/tonal/resync.ts
@@ -16,6 +16,7 @@ import type { Id } from "../_generated/dataModel";
 /** Cache keys to clear before a resync (old per-limit keys + current key). */
 const STALE_CACHE_KEYS = [
   "workoutHistory_v3",
+  "workoutHistory_v3_full",
   "workoutHistory_v2",
   "workoutHistory_v2:1",
   "workoutHistory_v2:5",


### PR DESCRIPTION
## Summary

- Incremental sync (cron every 30 min) was paginating through ALL workout activities for every user - 5+ API calls for users with 1000+ workouts just to find 0-1 new ones.
- Split `fetchWorkoutHistory` into two modes:
  - **"recent"** (default): reads `pg-total` from a 1-item probe, then fetches the last 200 items from offset `total-200`. 2 API calls max. Used by cron sync.
  - **"full"**: paginates all pages from the start. Used by backfill only.
- Each mode has its own cache key so they don't interfere.

## Test plan

- [x] Type-check passes
- [x] 862 tests pass
- [x] File sizes under 400 lines
- [ ] Verify incremental sync uses 2 API calls (check Convex logs after deploy)
- [ ] Verify backfill still fetches complete history

## Context

Follow-up to PR #130 which added full pagination via `pg-offset`/`pg-limit` request headers. That fix was correct for backfill but wasteful for the ongoing cron sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized workout history data fetching and caching with support for both recent and complete activity retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->