### PR TITLE
fix: filter ghost workout entries from recent workouts list

### DIFF
--- a/convex/dashboard.ts
+++ b/convex/dashboard.ts
@@ -104,18 +104,21 @@ export const getWorkoutHistory = query({
       .query("completedWorkouts")
       .withIndex("by_userId_date", (q) => q.eq("userId", userId))
       .order("desc")
-      .take(5);
+      .take(20);
 
-    return rows.map((r) => ({
-      activityId: r.activityId,
-      date: r.date,
-      title: r.title,
-      targetArea: r.targetArea,
-      totalVolume: r.totalVolume,
-      totalDuration: r.totalDuration,
-      totalWork: r.totalWork,
-      workoutType: r.workoutType,
-    }));
+    return rows
+      .filter((r) => r.title !== "")
+      .slice(0, 5)
+      .map((r) => ({
+        activityId: r.activityId,
+        date: r.date,
+        title: r.title,
+        targetArea: r.targetArea,
+        totalVolume: r.totalVolume,
+        totalDuration: r.totalDuration,
+        totalWork: r.totalWork,
+        workoutType: r.workoutType,
+      }));
   },
 });
 

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -265,8 +265,6 @@ export const fetchWorkoutHistory = internalAction({
   args: {
     userId: v.id("users"),
     limit: v.optional(v.number()),
-    // "recent" (default): fetches newest page only (1-2 API calls). For cron sync.
-    // "full": paginates through all history (N API calls). For backfill.
     mode: v.optional(v.union(v.literal("recent"), v.literal("full"))),
   },
   handler: async (ctx, { userId, limit, mode = "recent" }): Promise<Activity[]> =>
@@ -283,14 +281,21 @@ export const fetchWorkoutHistory = internalAction({
               ? await fetchAllWorkoutActivities<WorkoutActivityDetail>(token, tonalUserId)
               : await fetchRecentWorkoutActivities<WorkoutActivityDetail>(token, tonalUserId);
 
-          if (items.length === 0) return [];
+          // Filter ghost entries (null-UUID workoutId + zero volume/work)
+          const realItems = items.filter(
+            (wa) =>
+              wa.workoutId !== "00000000-0000-0000-0000-000000000000" ||
+              wa.totalVolume > 0 ||
+              wa.totalConcentricWork > 0,
+          );
+          if (realItems.length === 0) return [];
 
-          const uniqueWorkoutIds = [...new Set(items.map((w) => w.workoutId))];
+          const uniqueWorkoutIds = [...new Set(realItems.map((w) => w.workoutId))];
           const meta = await fetchWorkoutMetaBatch(ctx, token, uniqueWorkoutIds);
 
           // fetchRecentWorkoutActivities already returns newest-first;
           // fetchAllWorkoutActivities returns oldest-first, so reverse it
-          const mapped = items.map((wa) => toActivity(wa, meta.get(wa.workoutId)));
+          const mapped = realItems.map((wa) => toActivity(wa, meta.get(wa.workoutId)));
           return mode === "full" ? mapped.reverse() : mapped;
         },
       });

--- a/convex/tonal/syncQueries.test.ts
+++ b/convex/tonal/syncQueries.test.ts
@@ -205,6 +205,46 @@ describe("getRecentCompletedWorkouts", () => {
     });
     expect(result).toHaveLength(2);
   });
+
+  test("filters out ghost entries with empty title", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("completedWorkouts", {
+        userId,
+        ...baseWorkout,
+        activityId: "real-1",
+        date: "2024-01-15",
+        title: "Push Day",
+      });
+      await ctx.db.insert("completedWorkouts", {
+        userId,
+        ...baseWorkout,
+        activityId: "ghost-1",
+        date: "2024-01-14",
+        title: "",
+        workoutType: "",
+        totalVolume: 0,
+        totalWork: 0,
+      });
+      await ctx.db.insert("completedWorkouts", {
+        userId,
+        ...baseWorkout,
+        activityId: "real-2",
+        date: "2024-01-13",
+        title: "Pull Day",
+      });
+    });
+
+    const result = await t.query(internal.tonal.syncQueries.getRecentCompletedWorkouts, {
+      userId,
+      limit: 10,
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].activityId).toBe("real-1");
+    expect(result[1].activityId).toBe("real-2");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/convex/tonal/syncQueries.ts
+++ b/convex/tonal/syncQueries.ts
@@ -27,15 +27,18 @@ export const getMuscleReadiness = internalQuery({
   },
 });
 
-/** Get recent completed workouts, ordered by date descending. */
+/** Get recent completed workouts, ordered by date descending.
+ *  Filters out ghost entries (empty title) from non-workout Tonal activities. */
 export const getRecentCompletedWorkouts = internalQuery({
   args: userIdWithLimitArgsValidator,
   handler: async (ctx, { userId, limit }) => {
-    return await ctx.db
+    const rows = await ctx.db
       .query("completedWorkouts")
       .withIndex("by_userId_date", (q) => q.eq("userId", userId))
       .order("desc")
-      .take(limit);
+      .take(limit * 3);
+
+    return rows.filter((r) => r.title !== "").slice(0, limit);
   },
 });
 


### PR DESCRIPTION
## Summary

- Tonal's `/workout-activities` API returns non-workout activities (free lifts, movement tracking) with null-UUID workoutId, empty title, and zero volume. These "ghost entries" were being persisted to `completedWorkouts` and displayed in the dashboard's recent workouts list.
- Adds filtering at both ingestion (proxy) and display (queries) layers to eliminate ghost entries
- Handles existing dirty data in the DB via display-level filtering

## Changes

**`convex/tonal/proxy.ts`** - Filter ghost entries (`workoutId === "0000..."` + zero volume/work) in `fetchWorkoutHistory` before mapping to Activity objects. Prevents new ghost data from entering the sync pipeline.

**`convex/dashboard.ts`** - Over-fetch from `completedWorkouts` and filter out empty-title rows before returning the top 5. Handles existing dirty data.

**`convex/tonal/syncQueries.ts`** - Same empty-title filter in `getRecentCompletedWorkouts` (used by AI context builder).

**`convex/tonal/syncQueries.test.ts`** - New test verifying ghost entries are excluded from results.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run convex/tonal/syncQueries.test.ts` - 12/12 tests pass (including new ghost filter test)
- [ ] Verify dashboard no longer shows empty-title rows for affected users
- [ ] Verify new syncs don't persist ghost entries

Closes #148