### PR TITLE
fix: eliminate OCC contention on systemHealth table

### DIFF
--- a/convex/systemHealth.ts
+++ b/convex/systemHealth.ts
@@ -22,8 +22,8 @@ export const isCircuitOpen = internalQuery({
   },
 });
 
-/** Record a successful API call. Only writes when state changes (circuit was
- *  open or no record exists) to avoid OCC contention under concurrent load. */
+/** Record a successful API call. Skips the write in steady state (circuit
+ *  closed, no failures) to avoid OCC contention under concurrent load. */
 export const recordSuccess = internalMutation({
   args: { service: v.string() },
   handler: async (ctx, { service }) => {

--- a/convex/systemHealth.ts
+++ b/convex/systemHealth.ts
@@ -22,7 +22,8 @@ export const isCircuitOpen = internalQuery({
   },
 });
 
-/** Record a successful API call. Resets failure count and closes circuit. */
+/** Record a successful API call. Only writes when state changes (circuit was
+ *  open or no record exists) to avoid OCC contention under concurrent load. */
 export const recordSuccess = internalMutation({
   args: { service: v.string() },
   handler: async (ctx, { service }) => {
@@ -31,29 +32,28 @@ export const recordSuccess = internalMutation({
       .withIndex("by_service", (q) => q.eq("service", service))
       .unique();
 
-    const now = Date.now();
-
     if (!health) {
       await ctx.db.insert("systemHealth", {
         service,
         consecutiveFailures: 0,
         circuitOpen: false,
-        lastSuccessAt: now,
+        lastSuccessAt: Date.now(),
       });
       return;
     }
 
-    const updates: Record<string, unknown> = {
+    // Skip write when circuit is already closed and healthy
+    if (!health.circuitOpen && health.consecutiveFailures === 0) return;
+
+    await ctx.db.patch(health._id, {
       consecutiveFailures: 0,
-      lastSuccessAt: now,
-    };
+      circuitOpen: false,
+      lastSuccessAt: Date.now(),
+    });
 
     if (health.circuitOpen) {
-      updates.circuitOpen = false;
       console.log(`[circuitBreaker] Circuit CLOSED for ${service} - API recovered`);
     }
-
-    await ctx.db.patch(health._id, updates);
   },
 });
 

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -97,14 +97,12 @@ export async function cachedFetch<T>(
         expiresAt: now + ttl,
       });
     } catch (cacheErr) {
-      // If caching fails (e.g., data still too large), log and continue.
-      // The caller still gets fresh data; it just won't be cached.
       console.warn(`cachedFetch(${dataType}): cache write failed, returning fresh data`, cacheErr);
     }
 
     await ctx
       .runMutation(internal.systemHealth.recordSuccess, { service: "tonal" })
-      .catch(() => {});
+      .catch((err: unknown) => console.warn("[circuitBreaker] recordSuccess failed", err));
 
     return data;
   } catch (error) {
@@ -114,7 +112,7 @@ export async function cachedFetch<T>(
 
     await ctx
       .runMutation(internal.systemHealth.recordFailure, { service: "tonal" })
-      .catch(() => {});
+      .catch((err: unknown) => console.warn("[circuitBreaker] recordFailure failed", err));
 
     // For non-auth errors, fall back to stale data if available
     if (cached) {

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -102,8 +102,9 @@ export async function cachedFetch<T>(
       console.warn(`cachedFetch(${dataType}): cache write failed, returning fresh data`, cacheErr);
     }
 
-    // Record success for circuit breaker
-    await ctx.runMutation(internal.systemHealth.recordSuccess, { service: "tonal" });
+    await ctx
+      .runMutation(internal.systemHealth.recordSuccess, { service: "tonal" })
+      .catch(() => {});
 
     return data;
   } catch (error) {
@@ -111,8 +112,9 @@ export async function cachedFetch<T>(
     if (error instanceof TonalApiError && error.status === 401) throw error;
     if (error instanceof Error && error.message.includes("session expired")) throw error;
 
-    // Record failure for circuit breaker (non-auth errors only)
-    await ctx.runMutation(internal.systemHealth.recordFailure, { service: "tonal" });
+    await ctx
+      .runMutation(internal.systemHealth.recordFailure, { service: "tonal" })
+      .catch(() => {});
 
     // For non-auth errors, fall back to stale data if available
     if (cached) {


### PR DESCRIPTION
## Summary

Closes #143

- `recordSuccess` now skips the write when the circuit is already closed and healthy (`consecutiveFailures === 0`). During normal operation this means **zero writes** per `cachedFetch` call - only state transitions trigger writes.
- `cachedFetch` swallows errors from health tracking mutations. An OCC conflict on `systemHealth` should never cascade into a failed data fetch.

This was the root cause of the 3 persistently failing users during the mass resync - concurrent `cachedFetch` calls all patched the same document.

## Test plan

- [x] Type-check passes
- [x] 863 tests pass
- [ ] Retry the 3 failed users after deploy - should complete without OCC errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Stability**
  * System health monitoring is now more efficient, making selective updates only when system state changes to reduce overhead and improve overall responsiveness.
  * Data retrieval operations are now more resilient with improved error handling that ensures internal monitoring functions do not disrupt normal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->