### PR TITLE
fix: batch account deletion to stay under 4096 read limit

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -102,6 +102,7 @@ import type * as tonal_types from "../tonal/types.js";
 import type * as tonal_validation from "../tonal/validation.js";
 import type * as tonal_workoutCatalogSync from "../tonal/workoutCatalogSync.js";
 import type * as tonal_workoutHistoryProxy from "../tonal/workoutHistoryProxy.js";
+import type * as userData from "../userData.js";
 import type * as userProfiles from "../userProfiles.js";
 import type * as users from "../users.js";
 import type * as validators from "../validators.js";
@@ -215,6 +216,7 @@ declare const fullApi: ApiFromModules<{
   "tonal/validation": typeof tonal_validation;
   "tonal/workoutCatalogSync": typeof tonal_workoutCatalogSync;
   "tonal/workoutHistoryProxy": typeof tonal_workoutHistoryProxy;
+  userData: typeof userData;
   userProfiles: typeof userProfiles;
   users: typeof users;
   validators: typeof validators;

--- a/convex/account.ts
+++ b/convex/account.ts
@@ -156,7 +156,10 @@ export const deleteAccount = action({
       }
     }
 
-    await ctx.runMutation(internal.accountDeletion.deleteAuthData, { userId });
+    let hasMoreAuthData = true;
+    while (hasMoreAuthData) {
+      hasMoreAuthData = await ctx.runMutation(internal.accountDeletion.deleteAuthData, { userId });
+    }
     await ctx.runMutation(internal.accountDeletion.deleteUserRecord, { userId });
   },
 });

--- a/convex/account.ts
+++ b/convex/account.ts
@@ -3,6 +3,7 @@ import { getAuthUserId, modifyAccountCredentials, retrieveAccount } from "@conve
 import { action, internalQuery, mutation, query } from "./_generated/server";
 import { components, internal } from "./_generated/api";
 import { getEffectiveUserId } from "./lib/auth";
+import { BY_USER_ID_BATCH_TABLES } from "./userData";
 
 export const getFullProfile = query({
   args: {},
@@ -110,22 +111,6 @@ export const getUserEmail = internalQuery({
   },
 });
 
-/** Tables with a by_userId index, deleted via the typed deleteUserTableBatch mutation. */
-const USER_TABLES = [
-  "checkIns",
-  "workoutPlans",
-  "weekPlans",
-  "workoutFeedback",
-  "trainingBlocks",
-  "goals",
-  "injuries",
-  "emailChangeRequests",
-  "completedWorkouts",
-  "strengthScoreSnapshots",
-  "aiUsage",
-  "muscleReadiness",
-] as const;
-
 export const deleteAccount = action({
   args: {},
   handler: async (ctx): Promise<void> => {
@@ -135,7 +120,7 @@ export const deleteAccount = action({
     await ctx.runAction(components.agent.users.deleteAllForUserId, { userId });
 
     // Drain each table in batches of 500 to stay under the 4096 read limit
-    for (const table of USER_TABLES) {
+    for (const table of BY_USER_ID_BATCH_TABLES) {
       let hasMore = true;
       while (hasMore) {
         hasMore = await ctx.runMutation(internal.accountDeletion.deleteUserTableBatch, {

--- a/convex/account.ts
+++ b/convex/account.ts
@@ -79,7 +79,7 @@ export const changePassword = action({
     newPassword: v.string(),
   },
   handler: async (ctx, { oldPassword, newPassword }): Promise<void> => {
-    const userId = await getAuthUserId(ctx);
+    const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 
     const user = await ctx.runQuery(internal.account.getUserEmail, { userId });
@@ -117,34 +117,43 @@ export const deleteAccount = action({
     const userId = await getAuthUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
-    await ctx.runAction(components.agent.users.deleteAllForUserId, { userId });
+    await ctx.runMutation(internal.accountDeletion.markDeletionInProgress, { userId });
 
-    // Drain each table in batches of 500 to stay under the 4096 read limit
-    for (const table of BY_USER_ID_BATCH_TABLES) {
-      let hasMore = true;
-      while (hasMore) {
-        hasMore = await ctx.runMutation(internal.accountDeletion.deleteUserTableBatch, {
+    try {
+      await ctx.runAction(components.agent.users.deleteAllForUserId, { userId });
+
+      // Drain each table in batches of 500 to stay under the 4096 read limit
+      for (const table of BY_USER_ID_BATCH_TABLES) {
+        let hasMore = true;
+        while (hasMore) {
+          hasMore = await ctx.runMutation(internal.accountDeletion.deleteUserTableBatch, {
+            userId,
+            table,
+          });
+        }
+      }
+
+      for (const mutation of [
+        internal.accountDeletion.deleteExercisePerformanceBatch,
+        internal.accountDeletion.deleteTonalCacheBatch,
+        internal.accountDeletion.deleteExternalActivitiesBatch,
+      ] as const) {
+        let hasMore = true;
+        while (hasMore) {
+          hasMore = await ctx.runMutation(mutation, { userId });
+        }
+      }
+
+      let hasMoreAuthData = true;
+      while (hasMoreAuthData) {
+        hasMoreAuthData = await ctx.runMutation(internal.accountDeletion.deleteAuthData, {
           userId,
-          table,
         });
       }
+      await ctx.runMutation(internal.accountDeletion.deleteUserRecord, { userId });
+    } catch (error) {
+      await ctx.runMutation(internal.accountDeletion.clearDeletionInProgress, { userId });
+      throw error;
     }
-
-    for (const mutation of [
-      internal.accountDeletion.deleteExercisePerformanceBatch,
-      internal.accountDeletion.deleteTonalCacheBatch,
-      internal.accountDeletion.deleteExternalActivitiesBatch,
-    ] as const) {
-      let hasMore = true;
-      while (hasMore) {
-        hasMore = await ctx.runMutation(mutation, { userId });
-      }
-    }
-
-    let hasMoreAuthData = true;
-    while (hasMoreAuthData) {
-      hasMoreAuthData = await ctx.runMutation(internal.accountDeletion.deleteAuthData, { userId });
-    }
-    await ctx.runMutation(internal.accountDeletion.deleteUserRecord, { userId });
   },
 });

--- a/convex/account.ts
+++ b/convex/account.ts
@@ -110,24 +110,21 @@ export const getUserEmail = internalQuery({
   },
 });
 
-/** Tables to delete from, in order. Each entry is [table, indexName]. */
-const DELETION_TABLES: Array<[string, string?]> = [
-  ["checkIns"],
-  ["workoutPlans"],
-  ["weekPlans"],
-  ["workoutFeedback"],
-  ["trainingBlocks"],
-  ["goals"],
-  ["injuries"],
-  ["emailChangeRequests"],
-  ["completedWorkouts"],
-  ["strengthScoreSnapshots"],
-  ["aiUsage"],
-  ["exercisePerformance", "by_userId_date"],
-  ["tonalCache", "by_userId_dataType"],
-  ["muscleReadiness", "by_userId"],
-  ["externalActivities", "by_userId_beginTime"],
-];
+/** Tables with a by_userId index, deleted via the typed deleteUserTableBatch mutation. */
+const USER_TABLES = [
+  "checkIns",
+  "workoutPlans",
+  "weekPlans",
+  "workoutFeedback",
+  "trainingBlocks",
+  "goals",
+  "injuries",
+  "emailChangeRequests",
+  "completedWorkouts",
+  "strengthScoreSnapshots",
+  "aiUsage",
+  "muscleReadiness",
+] as const;
 
 export const deleteAccount = action({
   args: {},
@@ -137,15 +134,25 @@ export const deleteAccount = action({
 
     await ctx.runAction(components.agent.users.deleteAllForUserId, { userId });
 
-    // Delete each table in batches of 500 to stay under the 4096 read limit
-    for (const [table, indexName] of DELETION_TABLES) {
+    // Drain each table in batches of 500 to stay under the 4096 read limit
+    for (const table of USER_TABLES) {
       let hasMore = true;
       while (hasMore) {
-        hasMore = await ctx.runMutation(internal.accountDeletion.deleteTableBatch, {
+        hasMore = await ctx.runMutation(internal.accountDeletion.deleteUserTableBatch, {
           userId,
           table,
-          indexName,
         });
+      }
+    }
+
+    for (const mutation of [
+      internal.accountDeletion.deleteExercisePerformanceBatch,
+      internal.accountDeletion.deleteTonalCacheBatch,
+      internal.accountDeletion.deleteExternalActivitiesBatch,
+    ] as const) {
+      let hasMore = true;
+      while (hasMore) {
+        hasMore = await ctx.runMutation(mutation, { userId });
       }
     }
 

--- a/convex/account.ts
+++ b/convex/account.ts
@@ -110,19 +110,46 @@ export const getUserEmail = internalQuery({
   },
 });
 
+/** Tables to delete from, in order. Each entry is [table, indexName]. */
+const DELETION_TABLES: Array<[string, string?]> = [
+  ["checkIns"],
+  ["workoutPlans"],
+  ["weekPlans"],
+  ["workoutFeedback"],
+  ["trainingBlocks"],
+  ["goals"],
+  ["injuries"],
+  ["emailChangeRequests"],
+  ["completedWorkouts"],
+  ["strengthScoreSnapshots"],
+  ["aiUsage"],
+  ["exercisePerformance", "by_userId_date"],
+  ["tonalCache", "by_userId_dataType"],
+  ["muscleReadiness", "by_userId"],
+  ["externalActivities", "by_userId_beginTime"],
+];
+
 export const deleteAccount = action({
   args: {},
   handler: async (ctx): Promise<void> => {
     const userId = await getAuthUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
-    // Purge the @convex-dev/agent component's threads and messages first.
-    // Its tables live outside our schema, so deleteAllUserData can't touch
-    // them - we have to call the component's own purge action. Running it
-    // before the user row is deleted keeps the foreign-key target alive
-    // for any internal cascades the component performs.
     await ctx.runAction(components.agent.users.deleteAllForUserId, { userId });
 
-    await ctx.runMutation(internal.accountDeletion.deleteAllUserData, { userId });
+    // Delete each table in batches of 500 to stay under the 4096 read limit
+    for (const [table, indexName] of DELETION_TABLES) {
+      let hasMore = true;
+      while (hasMore) {
+        hasMore = await ctx.runMutation(internal.accountDeletion.deleteTableBatch, {
+          userId,
+          table,
+          indexName,
+        });
+      }
+    }
+
+    await ctx.runMutation(internal.accountDeletion.deleteAuthData, { userId });
+    await ctx.runMutation(internal.accountDeletion.deleteUserRecord, { userId });
   },
 });

--- a/convex/accountDeletion.test.ts
+++ b/convex/accountDeletion.test.ts
@@ -1,0 +1,177 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.*s");
+
+async function createUser(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => ctx.db.insert("users", {}));
+}
+
+async function createSession(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+  suffix: string,
+) {
+  return t.run(async (ctx) =>
+    ctx.db.insert("authSessions", {
+      userId,
+      expirationTime: Date.now() + Number(suffix),
+    }),
+  );
+}
+
+async function createAccount(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+  suffix: string,
+) {
+  return t.run(async (ctx) =>
+    ctx.db.insert("authAccounts", {
+      userId,
+      provider: `provider-${suffix}`,
+      providerAccountId: `account-${suffix}`,
+      secret: `secret-${suffix}`,
+    }),
+  );
+}
+
+async function countUserSessions(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
+  return t.run(async (ctx) => {
+    const sessions = await ctx.db.query("authSessions").collect();
+    return sessions.filter((session) => session.userId === userId);
+  });
+}
+
+async function countSessionTokens(t: ReturnType<typeof convexTest>, sessionId: Id<"authSessions">) {
+  return t.run(async (ctx) => {
+    const tokens = await ctx.db.query("authRefreshTokens").collect();
+    return tokens.filter((token) => token.sessionId === sessionId);
+  });
+}
+
+async function countUserAccounts(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
+  return t.run(async (ctx) => {
+    const accounts = await ctx.db.query("authAccounts").collect();
+    return accounts.filter((account) => account.userId === userId);
+  });
+}
+
+async function countAccountCodes(t: ReturnType<typeof convexTest>, accountId: Id<"authAccounts">) {
+  return t.run(async (ctx) => {
+    const codes = await ctx.db.query("authVerificationCodes").collect();
+    return codes.filter((code) => code.accountId === accountId);
+  });
+}
+
+async function drainAuthData(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
+  let iterations = 0;
+  while (await t.mutation(internal.accountDeletion.deleteAuthData, { userId })) {
+    iterations += 1;
+    if (iterations > 5_000) {
+      throw new Error("deleteAuthData did not converge");
+    }
+  }
+  return iterations;
+}
+
+describe("deleteAuthData", () => {
+  test("drains more than 500 auth sessions and accounts across repeated calls", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+    const otherUserId = await createUser(t);
+
+    for (let i = 0; i < 501; i += 1) {
+      await createSession(t, userId, `user-${i}`);
+      await createAccount(t, userId, `user-${i}`);
+    }
+
+    await createSession(t, otherUserId, "other");
+    await createAccount(t, otherUserId, "other");
+
+    const iterations = await drainAuthData(t, userId);
+
+    expect(iterations).toBeGreaterThan(1);
+    expect(await countUserSessions(t, userId)).toHaveLength(0);
+    expect(await countUserAccounts(t, userId)).toHaveLength(0);
+    expect(await countUserSessions(t, otherUserId)).toHaveLength(1);
+    expect(await countUserAccounts(t, otherUserId)).toHaveLength(1);
+  });
+
+  test("deletes refresh tokens in batches before deleting the session", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+    const sessionId = await createSession(t, userId, "batched-session");
+
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 501; i += 1) {
+        await ctx.db.insert("authRefreshTokens", {
+          sessionId,
+          expirationTime: Date.now() + i,
+        });
+      }
+    });
+
+    await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
+      true,
+    );
+    expect(await countSessionTokens(t, sessionId)).toHaveLength(1);
+    expect(await countUserSessions(t, userId)).toHaveLength(1);
+
+    await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
+      true,
+    );
+    expect(await countSessionTokens(t, sessionId)).toHaveLength(0);
+    expect(await countUserSessions(t, userId)).toHaveLength(1);
+
+    await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
+      true,
+    );
+    expect(await countUserSessions(t, userId)).toHaveLength(0);
+
+    await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
+      false,
+    );
+  });
+
+  test("deletes verification codes in batches before deleting the account", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+    const accountId = await createAccount(t, userId, "batched-account");
+
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 501; i += 1) {
+        await ctx.db.insert("authVerificationCodes", {
+          accountId,
+          provider: "password",
+          code: `code-${i}`,
+          expirationTime: Date.now() + i,
+        });
+      }
+    });
+
+    await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
+      true,
+    );
+    expect(await countAccountCodes(t, accountId)).toHaveLength(1);
+    expect(await countUserAccounts(t, userId)).toHaveLength(1);
+
+    await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
+      true,
+    );
+    expect(await countAccountCodes(t, accountId)).toHaveLength(0);
+    expect(await countUserAccounts(t, userId)).toHaveLength(1);
+
+    await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
+      true,
+    );
+    expect(await countUserAccounts(t, userId)).toHaveLength(0);
+
+    await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
+      false,
+    );
+  });
+});

--- a/convex/accountDeletion.test.ts
+++ b/convex/accountDeletion.test.ts
@@ -67,6 +67,13 @@ async function countAccountCodes(t: ReturnType<typeof convexTest>, accountId: Id
   });
 }
 
+async function countCurrentStrengthScores(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
+  return t.run(async (ctx) => {
+    const scores = await ctx.db.query("currentStrengthScores").collect();
+    return scores.filter((score) => score.userId === userId);
+  });
+}
+
 async function drainAuthData(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
   let iterations = 0;
   while (await t.mutation(internal.accountDeletion.deleteAuthData, { userId })) {
@@ -76,6 +83,20 @@ async function drainAuthData(t: ReturnType<typeof convexTest>, userId: Id<"users
     }
   }
   return iterations;
+}
+
+async function drainUserTableBatch(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+  table: "currentStrengthScores",
+) {
+  let iterations = 0;
+  while (await t.mutation(internal.accountDeletion.deleteUserTableBatch, { userId, table })) {
+    iterations += 1;
+    if (iterations > 5_000) {
+      throw new Error(`deleteUserTableBatch did not converge for ${table}`);
+    }
+  }
 }
 
 describe("deleteAuthData", () => {
@@ -173,5 +194,36 @@ describe("deleteAuthData", () => {
     await expect(t.mutation(internal.accountDeletion.deleteAuthData, { userId })).resolves.toBe(
       false,
     );
+  });
+});
+
+describe("deleteUserTableBatch", () => {
+  test("deletes current strength scores in batches via the shared registry", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+    const otherUserId = await createUser(t);
+
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 501; i += 1) {
+        await ctx.db.insert("currentStrengthScores", {
+          userId,
+          bodyRegion: `region-${i}`,
+          score: i,
+          fetchedAt: Date.now() + i,
+        });
+      }
+
+      await ctx.db.insert("currentStrengthScores", {
+        userId: otherUserId,
+        bodyRegion: "other-region",
+        score: 999,
+        fetchedAt: Date.now(),
+      });
+    });
+
+    await drainUserTableBatch(t, userId, "currentStrengthScores");
+
+    expect(await countCurrentStrengthScores(t, userId)).toHaveLength(0);
+    expect(await countCurrentStrengthScores(t, otherUserId)).toHaveLength(1);
   });
 });

--- a/convex/accountDeletion.test.ts
+++ b/convex/accountDeletion.test.ts
@@ -39,6 +39,17 @@ async function createAccount(
   );
 }
 
+async function createUserProfile(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
+  return t.run(async (ctx) =>
+    ctx.db.insert("userProfiles", {
+      userId,
+      tonalUserId: `tonal-${userId}`,
+      tonalToken: "token",
+      lastActiveAt: Date.now(),
+    }),
+  );
+}
+
 async function countUserSessions(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
   return t.run(async (ctx) => {
     const sessions = await ctx.db.query("authSessions").collect();
@@ -71,6 +82,13 @@ async function countCurrentStrengthScores(t: ReturnType<typeof convexTest>, user
   return t.run(async (ctx) => {
     const scores = await ctx.db.query("currentStrengthScores").collect();
     return scores.filter((score) => score.userId === userId);
+  });
+}
+
+async function countUserCacheEntries(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
+  return t.run(async (ctx) => {
+    const entries = await ctx.db.query("tonalCache").collect();
+    return entries.filter((entry) => entry.userId === userId);
   });
 }
 
@@ -225,5 +243,31 @@ describe("deleteUserTableBatch", () => {
 
     expect(await countCurrentStrengthScores(t, userId)).toHaveLength(0);
     expect(await countCurrentStrengthScores(t, otherUserId)).toHaveLength(1);
+  });
+});
+
+describe("deletionInProgress", () => {
+  test("blocks history sync writes and user cache writes while deletion is running", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+    await createUserProfile(t, userId);
+
+    await t.mutation(internal.accountDeletion.markDeletionInProgress, { userId });
+
+    await t.mutation(internal.tonal.historySyncMutations.persistCurrentStrengthScores, {
+      userId,
+      scores: [{ bodyRegion: "upper", score: 123 }],
+    });
+    await t.mutation(internal.tonal.cache.setCacheEntry, {
+      userId,
+      dataType: "strengthScores",
+      data: { score: 123 },
+      fetchedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    });
+
+    expect(await t.query(internal.tonal.cache.getUserProfile, { userId })).toBeNull();
+    expect(await countCurrentStrengthScores(t, userId)).toHaveLength(0);
+    expect(await countUserCacheEntries(t, userId)).toHaveLength(0);
   });
 });

--- a/convex/accountDeletion.ts
+++ b/convex/accountDeletion.ts
@@ -5,82 +5,45 @@ import type { DataModel, Id } from "./_generated/dataModel";
 
 type MutationCtx = GenericMutationCtx<DataModel>;
 
-/**
- * Tables keyed by userId with a plain `by_userId` index. Everything here
- * can be wiped in a single prefix query.
- */
-type UserIndexedTable =
-  | "checkIns"
-  | "workoutPlans"
-  | "weekPlans"
-  | "workoutFeedback"
-  | "trainingBlocks"
-  | "goals"
-  | "injuries"
-  | "emailChangeRequests"
-  | "completedWorkouts"
-  | "strengthScoreSnapshots"
-  | "aiUsage";
+const BATCH_SIZE = 500;
 
-async function deleteByUserIndex(
+/**
+ * Delete up to BATCH_SIZE rows from a table for a given userId.
+ * Returns the number of rows deleted so the caller knows whether to continue.
+ */
+async function deleteBatch(
   ctx: MutationCtx,
-  table: UserIndexedTable,
+  table: string,
+  indexName: string,
   userId: Id<"users">,
-): Promise<void> {
-  const docs = await ctx.db
-    .query(table)
-    .withIndex("by_userId", (q) => q.eq("userId", userId))
-    .collect();
+): Promise<number> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const docs = await (ctx.db.query(table as any) as any)
+    .withIndex(indexName, (q: { eq: (f: string, v: string) => unknown }) => q.eq("userId", userId))
+    .take(BATCH_SIZE);
   for (const doc of docs) {
     await ctx.db.delete(doc._id);
   }
+  return docs.length;
 }
 
-export const deleteAllUserData = internalMutation({
+/** Delete one batch of user data from a specific table. Returns true if more rows remain. */
+export const deleteTableBatch = internalMutation({
+  args: {
+    userId: v.id("users"),
+    table: v.string(),
+    indexName: v.optional(v.string()),
+  },
+  handler: async (ctx, { userId, table, indexName = "by_userId" }): Promise<boolean> => {
+    const deleted = await deleteBatch(ctx, table, indexName, userId);
+    return deleted === BATCH_SIZE;
+  },
+});
+
+/** Delete auth sessions, refresh tokens, accounts, and verification codes. */
+export const deleteAuthData = internalMutation({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
-    // userProfiles: encrypted Tonal tokens, BYOK Gemini key, preferences
-    const profiles = await ctx.db
-      .query("userProfiles")
-      .withIndex("by_userId", (q) => q.eq("userId", userId))
-      .collect();
-    for (const doc of profiles) {
-      await ctx.db.delete(doc._id);
-    }
-
-    // App tables that share the `by_userId` index
-    await deleteByUserIndex(ctx, "checkIns", userId);
-    await deleteByUserIndex(ctx, "workoutPlans", userId);
-    await deleteByUserIndex(ctx, "weekPlans", userId);
-    await deleteByUserIndex(ctx, "workoutFeedback", userId);
-    await deleteByUserIndex(ctx, "trainingBlocks", userId);
-    await deleteByUserIndex(ctx, "goals", userId);
-    await deleteByUserIndex(ctx, "injuries", userId);
-    await deleteByUserIndex(ctx, "emailChangeRequests", userId);
-    await deleteByUserIndex(ctx, "completedWorkouts", userId);
-    await deleteByUserIndex(ctx, "strengthScoreSnapshots", userId);
-    await deleteByUserIndex(ctx, "aiUsage", userId);
-
-    // exercisePerformance has no plain by_userId index; the compound
-    // by_userId_date is a valid prefix query for all rows for this user.
-    const perfRows = await ctx.db
-      .query("exercisePerformance")
-      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
-      .collect();
-    for (const doc of perfRows) {
-      await ctx.db.delete(doc._id);
-    }
-
-    // tonalCache uses a compound by_userId_dataType index
-    const tonalCache = await ctx.db
-      .query("tonalCache")
-      .withIndex("by_userId_dataType", (q) => q.eq("userId", userId))
-      .collect();
-    for (const doc of tonalCache) {
-      await ctx.db.delete(doc._id);
-    }
-
-    // Auth sessions + their refresh tokens
     const sessions = await ctx.db
       .query("authSessions")
       .withIndex("userId", (q) => q.eq("userId", userId))
@@ -89,14 +52,13 @@ export const deleteAllUserData = internalMutation({
       const tokens = await ctx.db
         .query("authRefreshTokens")
         .withIndex("sessionId", (q) => q.eq("sessionId", session._id))
-        .collect();
+        .take(BATCH_SIZE);
       for (const token of tokens) {
         await ctx.db.delete(token._id);
       }
       await ctx.db.delete(session._id);
     }
 
-    // Auth accounts + their verification codes
     const accounts = await ctx.db
       .query("authAccounts")
       .withIndex("userIdAndProvider", (q) => q.eq("userId", userId))
@@ -105,15 +67,27 @@ export const deleteAllUserData = internalMutation({
       const codes = await ctx.db
         .query("authVerificationCodes")
         .withIndex("accountId", (q) => q.eq("accountId", account._id))
-        .collect();
+        .take(BATCH_SIZE);
       for (const code of codes) {
         await ctx.db.delete(code._id);
       }
       await ctx.db.delete(account._id);
     }
+  },
+});
 
-    // Delete the user document last so auth-component cascades don't lose
-    // their foreign-key target mid-run.
+/** Delete the user profile and user document. Run last. */
+export const deleteUserRecord = internalMutation({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    const profiles = await ctx.db
+      .query("userProfiles")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    for (const doc of profiles) {
+      await ctx.db.delete(doc._id);
+    }
+
     const user = await ctx.db.get(userId);
     if (user) {
       await ctx.db.delete(userId);

--- a/convex/accountDeletion.ts
+++ b/convex/accountDeletion.ts
@@ -81,36 +81,48 @@ export const deleteExternalActivitiesBatch = internalMutation({
 /** Delete auth sessions, refresh tokens, accounts, and verification codes. */
 export const deleteAuthData = internalMutation({
   args: { userId: v.id("users") },
-  handler: async (ctx, { userId }) => {
-    const sessions = await ctx.db
+  handler: async (ctx, { userId }): Promise<boolean> => {
+    const session = await ctx.db
       .query("authSessions")
       .withIndex("userId", (q) => q.eq("userId", userId))
-      .take(BATCH_SIZE);
-    for (const session of sessions) {
+      .first();
+    if (session) {
       const tokens = await ctx.db
         .query("authRefreshTokens")
         .withIndex("sessionId", (q) => q.eq("sessionId", session._id))
         .take(BATCH_SIZE);
-      for (const token of tokens) {
-        await ctx.db.delete(token._id);
+      if (tokens.length > 0) {
+        for (const token of tokens) {
+          await ctx.db.delete(token._id);
+        }
+        return true;
       }
+
       await ctx.db.delete(session._id);
+      return true;
     }
 
-    const accounts = await ctx.db
+    const account = await ctx.db
       .query("authAccounts")
       .withIndex("userIdAndProvider", (q) => q.eq("userId", userId))
-      .take(BATCH_SIZE);
-    for (const account of accounts) {
+      .first();
+    if (account) {
       const codes = await ctx.db
         .query("authVerificationCodes")
         .withIndex("accountId", (q) => q.eq("accountId", account._id))
         .take(BATCH_SIZE);
-      for (const code of codes) {
-        await ctx.db.delete(code._id);
+      if (codes.length > 0) {
+        for (const code of codes) {
+          await ctx.db.delete(code._id);
+        }
+        return true;
       }
+
       await ctx.db.delete(account._id);
+      return true;
     }
+
+    return false;
   },
 });
 

--- a/convex/accountDeletion.ts
+++ b/convex/accountDeletion.ts
@@ -1,21 +1,15 @@
 import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
+import { BY_USER_ID_BATCH_TABLES, type ByUserIdBatchTable } from "./userData";
 
 const BATCH_SIZE = 500;
 
 const userTableValidator = v.union(
-  v.literal("checkIns"),
-  v.literal("workoutPlans"),
-  v.literal("weekPlans"),
-  v.literal("workoutFeedback"),
-  v.literal("trainingBlocks"),
-  v.literal("goals"),
-  v.literal("injuries"),
-  v.literal("emailChangeRequests"),
-  v.literal("completedWorkouts"),
-  v.literal("strengthScoreSnapshots"),
-  v.literal("aiUsage"),
-  v.literal("muscleReadiness"),
+  ...(BY_USER_ID_BATCH_TABLES.map((table) => v.literal(table)) as [
+    ReturnType<typeof v.literal<ByUserIdBatchTable>>,
+    ReturnType<typeof v.literal<ByUserIdBatchTable>>,
+    ...Array<ReturnType<typeof v.literal<ByUserIdBatchTable>>>,
+  ]),
 );
 
 /** Delete one batch from a table with a by_userId index. Returns true if more remain. */

--- a/convex/accountDeletion.ts
+++ b/convex/accountDeletion.ts
@@ -72,6 +72,24 @@ export const deleteExternalActivitiesBatch = internalMutation({
   },
 });
 
+export const markDeletionInProgress = internalMutation({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    const user = await ctx.db.get(userId);
+    if (!user) throw new Error("User not found");
+    if (user.deletionInProgress) throw new Error("Account deletion already in progress");
+    await ctx.db.patch(userId, { deletionInProgress: true });
+  },
+});
+
+export const clearDeletionInProgress = internalMutation({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    const user = await ctx.db.get(userId);
+    if (user) await ctx.db.patch(userId, { deletionInProgress: false });
+  },
+});
+
 /** Delete auth sessions, refresh tokens, accounts, and verification codes. */
 export const deleteAuthData = internalMutation({
   args: { userId: v.id("users") },

--- a/convex/accountDeletion.ts
+++ b/convex/accountDeletion.ts
@@ -1,42 +1,80 @@
 import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
-import type { GenericMutationCtx } from "convex/server";
-import type { DataModel, Id } from "./_generated/dataModel";
-
-type MutationCtx = GenericMutationCtx<DataModel>;
 
 const BATCH_SIZE = 500;
 
-/**
- * Delete up to BATCH_SIZE rows from a table for a given userId.
- * Returns the number of rows deleted so the caller knows whether to continue.
- */
-async function deleteBatch(
-  ctx: MutationCtx,
-  table: string,
-  indexName: string,
-  userId: Id<"users">,
-): Promise<number> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const docs = await (ctx.db.query(table as any) as any)
-    .withIndex(indexName, (q: { eq: (f: string, v: string) => unknown }) => q.eq("userId", userId))
-    .take(BATCH_SIZE);
-  for (const doc of docs) {
-    await ctx.db.delete(doc._id);
-  }
-  return docs.length;
-}
+const userTableValidator = v.union(
+  v.literal("checkIns"),
+  v.literal("workoutPlans"),
+  v.literal("weekPlans"),
+  v.literal("workoutFeedback"),
+  v.literal("trainingBlocks"),
+  v.literal("goals"),
+  v.literal("injuries"),
+  v.literal("emailChangeRequests"),
+  v.literal("completedWorkouts"),
+  v.literal("strengthScoreSnapshots"),
+  v.literal("aiUsage"),
+  v.literal("muscleReadiness"),
+);
 
-/** Delete one batch of user data from a specific table. Returns true if more rows remain. */
-export const deleteTableBatch = internalMutation({
-  args: {
-    userId: v.id("users"),
-    table: v.string(),
-    indexName: v.optional(v.string()),
+/** Delete one batch from a table with a by_userId index. Returns true if more remain. */
+export const deleteUserTableBatch = internalMutation({
+  args: { userId: v.id("users"), table: userTableValidator },
+  handler: async (ctx, { userId, table }): Promise<boolean> => {
+    const docs = await ctx.db
+      .query(table)
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .take(BATCH_SIZE);
+    for (const doc of docs) {
+      await ctx.db.delete(doc._id);
+    }
+    return docs.length === BATCH_SIZE;
   },
-  handler: async (ctx, { userId, table, indexName = "by_userId" }): Promise<boolean> => {
-    const deleted = await deleteBatch(ctx, table, indexName, userId);
-    return deleted === BATCH_SIZE;
+});
+
+/** Delete one batch of exercisePerformance rows. */
+export const deleteExercisePerformanceBatch = internalMutation({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }): Promise<boolean> => {
+    const docs = await ctx.db
+      .query("exercisePerformance")
+      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+      .take(BATCH_SIZE);
+    for (const doc of docs) {
+      await ctx.db.delete(doc._id);
+    }
+    return docs.length === BATCH_SIZE;
+  },
+});
+
+/** Delete one batch of tonalCache rows. */
+export const deleteTonalCacheBatch = internalMutation({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }): Promise<boolean> => {
+    const docs = await ctx.db
+      .query("tonalCache")
+      .withIndex("by_userId_dataType", (q) => q.eq("userId", userId))
+      .take(BATCH_SIZE);
+    for (const doc of docs) {
+      await ctx.db.delete(doc._id);
+    }
+    return docs.length === BATCH_SIZE;
+  },
+});
+
+/** Delete one batch of externalActivities rows. */
+export const deleteExternalActivitiesBatch = internalMutation({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }): Promise<boolean> => {
+    const docs = await ctx.db
+      .query("externalActivities")
+      .withIndex("by_userId_beginTime", (q) => q.eq("userId", userId))
+      .take(BATCH_SIZE);
+    for (const doc of docs) {
+      await ctx.db.delete(doc._id);
+    }
+    return docs.length === BATCH_SIZE;
   },
 });
 
@@ -47,7 +85,7 @@ export const deleteAuthData = internalMutation({
     const sessions = await ctx.db
       .query("authSessions")
       .withIndex("userId", (q) => q.eq("userId", userId))
-      .collect();
+      .take(BATCH_SIZE);
     for (const session of sessions) {
       const tokens = await ctx.db
         .query("authRefreshTokens")
@@ -62,7 +100,7 @@ export const deleteAuthData = internalMutation({
     const accounts = await ctx.db
       .query("authAccounts")
       .withIndex("userIdAndProvider", (q) => q.eq("userId", userId))
-      .collect();
+      .take(BATCH_SIZE);
     for (const account of accounts) {
       const codes = await ctx.db
         .query("authVerificationCodes")

--- a/convex/dataExport.ts
+++ b/convex/dataExport.ts
@@ -3,8 +3,9 @@ import { action, internalQuery } from "./_generated/server";
 import { internal } from "./_generated/api";
 import * as analytics from "./lib/posthog";
 import type { Activity } from "./tonal/types";
+import type { JsonExportSectionKey } from "./userData";
 
-interface ExportedData {
+interface ExportedData extends Record<JsonExportSectionKey | "exportedAt" | "user", unknown> {
   exportedAt: string;
   user: { email: string | null; name: string | null };
   profile: {

--- a/convex/lib/auth.test.ts
+++ b/convex/lib/auth.test.ts
@@ -18,6 +18,7 @@ type FakeUser = {
   _id: string;
   isAdmin?: boolean;
   impersonatingUserId?: string;
+  deletionInProgress?: boolean;
 };
 
 function makeCtx(user: FakeUser | null) {
@@ -80,5 +81,14 @@ describe("getEffectiveUserId", () => {
     const result = await getEffectiveUserId(ctx);
 
     expect(result).toBe("user-admin");
+  });
+
+  it("returns null when account deletion is in progress", async () => {
+    getAuthUserIdMock.mockResolvedValue("user-deleting");
+    const ctx = makeCtx({ _id: "user-deleting", deletionInProgress: true });
+
+    const result = await getEffectiveUserId(ctx);
+
+    expect(result).toBeNull();
   });
 });

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,15 +1,34 @@
+import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { internalQuery } from "../_generated/server";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 
+export async function isDeletionInProgress(
+  ctx: QueryCtx | MutationCtx,
+  userId: Id<"users">,
+): Promise<boolean> {
+  const user = await ctx.db.get(userId);
+  return !user || user.deletionInProgress === true;
+}
+
 export async function getEffectiveUserId(ctx: QueryCtx | MutationCtx): Promise<Id<"users"> | null> {
-  return await getAuthUserId(ctx);
+  const userId = await getAuthUserId(ctx);
+  if (!userId) return null;
+  if (await isDeletionInProgress(ctx, userId)) return null;
+  return userId;
 }
 
 export const resolveEffectiveUserId = internalQuery({
   args: {},
   handler: async (ctx): Promise<Id<"users"> | null> => {
     return getEffectiveUserId(ctx);
+  },
+});
+
+export const getDeletionInProgress = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    return await isDeletionInProgress(ctx, userId);
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -19,6 +19,7 @@ export default defineSchema({
     phone: v.optional(v.string()),
     phoneVerificationTime: v.optional(v.number()),
     isAnonymous: v.optional(v.boolean()),
+    deletionInProgress: v.optional(v.boolean()),
   })
     .index("email", ["email"])
     .index("phone", ["phone"]),

--- a/convex/tonal/cache.ts
+++ b/convex/tonal/cache.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { internalMutation, internalQuery } from "../_generated/server";
+import { isDeletionInProgress } from "../lib/auth";
 
 // Cache TTLs in milliseconds
 export const CACHE_TTLS: Record<string, number> = {
@@ -15,6 +16,7 @@ export const CACHE_TTLS: Record<string, number> = {
 export const getUserProfile = internalQuery({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
+    if (await isDeletionInProgress(ctx, userId)) return null;
     return ctx.db
       .query("userProfiles")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
@@ -51,6 +53,7 @@ export const setCacheEntry = internalMutation({
     expiresAt: v.number(),
   },
   handler: async (ctx, args) => {
+    if (args.userId && (await isDeletionInProgress(ctx, args.userId))) return;
     const existing = await ctx.db
       .query("tonalCache")
       .withIndex("by_userId_dataType", (q) =>
@@ -96,6 +99,7 @@ export const deleteUserCacheEntries = internalMutation({
     dataTypes: v.array(v.string()),
   },
   handler: async (ctx, { userId, dataTypes }) => {
+    if (await isDeletionInProgress(ctx, userId)) return 0;
     let deleted = 0;
 
     for (const dataType of dataTypes) {

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -233,6 +233,7 @@ async function maybeRefreshProfile(ctx: ActionCtx, userId: Id<"users">): Promise
 export const syncUserHistory = internalAction({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
+    if (await ctx.runQuery(internal.lib.auth.getDeletionInProgress, { userId })) return;
     const activities: Activity[] = await ctx.runAction(
       internal.tonal.workoutHistoryProxy.fetchWorkoutHistory,
       {
@@ -279,6 +280,9 @@ export const backfillUserHistory = internalAction({
     ctx,
     { userId, retryCount = 0, pgOffset = 0, newestActivityDate },
   ): Promise<{ newWorkouts: number; totalActivities: number }> => {
+    if (await ctx.runQuery(internal.lib.auth.getDeletionInProgress, { userId })) {
+      return { newWorkouts: 0, totalActivities: 0 };
+    }
     if (retryCount === 0 && pgOffset === 0) {
       await ctx.runMutation(internal.userProfiles.updateSyncStatus, {
         userId,

--- a/convex/tonal/historySyncMutations.ts
+++ b/convex/tonal/historySyncMutations.ts
@@ -8,6 +8,7 @@
 
 import { v } from "convex/values";
 import { internalMutation, internalQuery } from "../_generated/server";
+import { isDeletionInProgress } from "../lib/auth";
 
 // ---------------------------------------------------------------------------
 // Shared validators (exported for action payload typing)
@@ -74,6 +75,7 @@ export const getExistingActivityIds = internalQuery({
 export const persistCompletedWorkouts = internalMutation({
   args: { userId: v.id("users"), workouts: v.array(workoutValidator) },
   handler: async (ctx, { userId, workouts }) => {
+    if (await isDeletionInProgress(ctx, userId)) return 0;
     let inserted = 0;
     for (const w of workouts) {
       const exists = await ctx.db
@@ -94,6 +96,7 @@ export const persistCompletedWorkouts = internalMutation({
 export const persistExercisePerformance = internalMutation({
   args: { userId: v.id("users"), performances: v.array(performanceValidator) },
   handler: async (ctx, { userId, performances }) => {
+    if (await isDeletionInProgress(ctx, userId)) return;
     for (const p of performances) {
       const existing = await ctx.db
         .query("exercisePerformance")
@@ -112,6 +115,7 @@ export const persistExercisePerformance = internalMutation({
 export const persistStrengthSnapshots = internalMutation({
   args: { userId: v.id("users"), snapshots: v.array(snapshotValidator) },
   handler: async (ctx, { userId, snapshots }) => {
+    if (await isDeletionInProgress(ctx, userId)) return;
     for (const s of snapshots) {
       const exists = await ctx.db
         .query("strengthScoreSnapshots")
@@ -162,6 +166,7 @@ export const externalActivityValidator = v.object({
 export const persistCurrentStrengthScores = internalMutation({
   args: { userId: v.id("users"), scores: v.array(strengthScoreValidator) },
   handler: async (ctx, { userId, scores }) => {
+    if (await isDeletionInProgress(ctx, userId)) return;
     const existing = await ctx.db
       .query("currentStrengthScores")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
@@ -180,6 +185,7 @@ export const persistCurrentStrengthScores = internalMutation({
 export const persistMuscleReadiness = internalMutation({
   args: { userId: v.id("users"), readiness: muscleReadinessValidator },
   handler: async (ctx, { userId, readiness }) => {
+    if (await isDeletionInProgress(ctx, userId)) return;
     const existing = await ctx.db
       .query("muscleReadiness")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
@@ -195,6 +201,7 @@ export const persistMuscleReadiness = internalMutation({
 export const clearMuscleReadiness = internalMutation({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
+    if (await isDeletionInProgress(ctx, userId)) return;
     const existing = await ctx.db
       .query("muscleReadiness")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
@@ -209,6 +216,7 @@ export const clearMuscleReadiness = internalMutation({
 export const persistExternalActivities = internalMutation({
   args: { userId: v.id("users"), activities: v.array(externalActivityValidator) },
   handler: async (ctx, { userId, activities }) => {
+    if (await isDeletionInProgress(ctx, userId)) return;
     const now = Date.now();
     for (const a of activities) {
       const existing = await ctx.db

--- a/convex/tonal/tokenRefresh.ts
+++ b/convex/tonal/tokenRefresh.ts
@@ -19,6 +19,11 @@ export const refreshExpiringTokens = internalAction({
 
     for (const profile of expiring) {
       try {
+        if (
+          await ctx.runQuery(internal.lib.auth.getDeletionInProgress, { userId: profile.userId })
+        ) {
+          continue;
+        }
         if (!profile.tonalRefreshToken) {
           console.warn(`No refresh token for user ${profile.userId} - skipping`);
           continue;

--- a/convex/userData.test.ts
+++ b/convex/userData.test.ts
@@ -1,0 +1,59 @@
+/// <reference types="vite/client" />
+import { readFileSync } from "node:fs";
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import { JSON_EXPORT_SECTION_KEYS, USER_DATA_TABLES } from "./userData";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.*s");
+
+function getLocalUserScopedTables() {
+  const schemaSource = readFileSync(new URL("./schema.ts", import.meta.url), "utf8");
+  const lines = schemaSource.split("\n");
+  const tableBlocks = new Map<string, string[]>();
+  let currentTable: string | null = null;
+
+  for (const line of lines) {
+    const tableMatch = line.match(/^  ([a-zA-Z][a-zA-Z0-9]*): defineTable\(/);
+    if (tableMatch) {
+      currentTable = tableMatch[1];
+      tableBlocks.set(currentTable, [line]);
+      continue;
+    }
+
+    if (currentTable) {
+      tableBlocks.get(currentTable)?.push(line);
+    }
+  }
+
+  return [...tableBlocks.entries()]
+    .filter(([, blockLines]) => {
+      const block = blockLines.join("\n");
+      return (
+        block.includes('userId: v.id("users")') ||
+        block.includes('userId: v.optional(v.id("users"))')
+      );
+    })
+    .map(([table]) => table)
+    .sort();
+}
+
+describe("USER_DATA_TABLES", () => {
+  test("classifies every local schema table with a typed userId", () => {
+    const registeredTables = USER_DATA_TABLES.map((entry) => entry.table).sort();
+
+    expect(registeredTables).toEqual(expect.arrayContaining(getLocalUserScopedTables()));
+  });
+
+  test("collectUserData returns every registered JSON export section", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+
+    const data = await t.query(internal.dataExport.collectUserData, { userId });
+
+    expect(Object.keys(data)).toEqual(
+      expect.arrayContaining(["exportedAt", "user", ...JSON_EXPORT_SECTION_KEYS]),
+    );
+  });
+});

--- a/convex/userData.ts
+++ b/convex/userData.ts
@@ -1,0 +1,52 @@
+/** Central classification for user-scoped data. Update this when adding new user data tables. */
+export const USER_DATA_TABLES = [
+  { table: "userProfiles", delete: "deleteUserRecord", jsonExportKey: "profile" },
+  { table: "checkIns", delete: "byUserIdBatch", jsonExportKey: "checkIns" },
+  { table: "tonalCache", delete: "tonalCacheBatch", jsonExportKey: null },
+  { table: "workoutPlans", delete: "byUserIdBatch", jsonExportKey: "workoutPlans" },
+  { table: "weekPlans", delete: "byUserIdBatch", jsonExportKey: "weekPlans" },
+  { table: "workoutFeedback", delete: "byUserIdBatch", jsonExportKey: null },
+  { table: "trainingBlocks", delete: "byUserIdBatch", jsonExportKey: null },
+  { table: "goals", delete: "byUserIdBatch", jsonExportKey: null },
+  { table: "injuries", delete: "byUserIdBatch", jsonExportKey: null },
+  { table: "emailChangeRequests", delete: "byUserIdBatch", jsonExportKey: null },
+  { table: "aiUsage", delete: "byUserIdBatch", jsonExportKey: null },
+  { table: "completedWorkouts", delete: "byUserIdBatch", jsonExportKey: "completedWorkouts" },
+  {
+    table: "exercisePerformance",
+    delete: "exercisePerformanceBatch",
+    jsonExportKey: "exercisePerformance",
+  },
+  {
+    table: "strengthScoreSnapshots",
+    delete: "byUserIdBatch",
+    jsonExportKey: "strengthScoreSnapshots",
+  },
+  {
+    table: "currentStrengthScores",
+    delete: "byUserIdBatch",
+    jsonExportKey: "currentStrengthScores",
+  },
+  { table: "muscleReadiness", delete: "byUserIdBatch", jsonExportKey: "muscleReadiness" },
+  {
+    table: "externalActivities",
+    delete: "externalActivitiesBatch",
+    jsonExportKey: "externalActivities",
+  },
+  { table: "authSessions", delete: "authData", jsonExportKey: null },
+  { table: "authAccounts", delete: "authData", jsonExportKey: null },
+] as const;
+
+type UserDataEntry = (typeof USER_DATA_TABLES)[number];
+
+export type ByUserIdBatchTable = Extract<UserDataEntry, { delete: "byUserIdBatch" }>["table"];
+export type JsonExportSectionKey = Exclude<UserDataEntry["jsonExportKey"], null>;
+
+export const BY_USER_ID_BATCH_TABLES = USER_DATA_TABLES.filter(
+  (entry): entry is Extract<UserDataEntry, { delete: "byUserIdBatch" }> =>
+    entry.delete === "byUserIdBatch",
+).map((entry) => entry.table);
+
+export const JSON_EXPORT_SECTION_KEYS = USER_DATA_TABLES.flatMap((entry) =>
+  entry.jsonExportKey ? [entry.jsonExportKey] : [],
+);


### PR DESCRIPTION
## Summary

Closes #136

The single `deleteAllUserData` mutation read every row across 15+ tables in one execution. For users with 926+ workouts, this exceeded Convex's 4096 read limit.

**Before**: One mutation reads + deletes all rows across all tables. OOM for large accounts.

**After**: The `deleteAccount` action orchestrates deletion table-by-table. Each table is processed in batches of 500 via `deleteTableBatch`. Each mutation stays well under the read limit. Auth data and user record deleted last.

## Test plan

- [x] Type-check passes
- [x] 863 tests pass
- [ ] Test account deletion for a user with large history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved account deletion workflow to handle large datasets more efficiently through a batched deletion process, reducing timeout risks.

* **Tests**
  * Added comprehensive test coverage for account deletion functionality across multiple data types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->