### PR TITLE
fix: native-button errors

### DIFF
--- a/src/app/(app)/chat/page.tsx
+++ b/src/app/(app)/chat/page.tsx
@@ -13,6 +13,7 @@ import { useAnalytics } from "@/lib/analytics";
 import {
   Activity,
   Dumbbell,
+  Flame,
   ImagePlus,
   Loader2,
   SendHorizontal,
@@ -26,6 +27,7 @@ const suggestions = [
   { icon: TrendingUp, text: "How are my strength scores trending?" },
   { icon: Zap, text: "Which muscles are freshest right now?" },
   { icon: Activity, text: "Analyze my training this month" },
+  { icon: Flame, text: "Add eccentrics and chains to my next workout" },
 ];
 
 // Wrap in Suspense because useSearchParams requires it in Next.js 14+

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -159,6 +159,20 @@ const FAQ_CATEGORIES: FaqCategory[] = [
         ),
       },
       {
+        q: "Can the coach program dynamic weight modes (eccentric, chains, burnout)?",
+        aText:
+          'Yes. Just ask. The coach can add Tonal\'s dynamic modes — eccentric (slow negatives), chains (progressive resistance), spotter, burnout (AMRAP), and drop sets — to any exercise it programs. Try something like "add eccentrics to my next leg day" or "put chains on bench this week." SmartFlex is handled automatically by the Tonal hardware and can\'t be toggled via the API.',
+        a: (
+          <>
+            Yes. Just ask. The coach can add Tonal&apos;s dynamic modes — eccentric (slow
+            negatives), chains (progressive resistance), spotter, burnout (AMRAP), and drop sets —
+            to any exercise it programs. Try something like &ldquo;add eccentrics to my next leg
+            day&rdquo; or &ldquo;put chains on bench this week.&rdquo; SmartFlex is handled
+            automatically by the Tonal hardware and can&apos;t be toggled via the API.
+          </>
+        ),
+      },
+      {
         q: "Does it handle injuries?",
         aText:
           "Yes. Flag any injuries or physical limitations during onboarding and the AI will avoid contraindicated movements and substitute safe alternatives. You can update your injury list at any time from settings, and the coach will adjust immediately.",

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -37,11 +37,17 @@ export default function NotFound() {
           <Button
             size="lg"
             className="shadow-lg shadow-primary/25 transition-all duration-300 hover:shadow-xl hover:shadow-primary/40"
+            nativeButton={false}
             render={<Link href="/chat" />}
           >
             Go to Chat
           </Button>
-          <Button variant="outline" size="lg" render={<Link href="/dashboard" />}>
+          <Button
+            variant="outline"
+            size="lg"
+            nativeButton={false}
+            render={<Link href="/dashboard" />}
+          >
             Dashboard
           </Button>
         </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -64,7 +64,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               <RefreshCw className="size-4" />
               Try again
             </Button>
-            <Button render={<Link href="/chat" />}>Go home</Button>
+            <Button nativeButton={false} render={<Link href="/chat" />}>
+              Go home
+            </Button>
           </div>
         </div>
       </div>

--- a/src/features/schedule/ScheduleDayCard.tsx
+++ b/src/features/schedule/ScheduleDayCard.tsx
@@ -187,6 +187,7 @@ function TrainingDayCard({
             variant="ghost"
             size="xs"
             className="h-7 gap-1.5"
+            nativeButton={false}
             render={<Link href={`/activity/${day.tonalWorkoutId}`} />}
           >
             <Eye className="size-3" aria-hidden="true" />
@@ -197,6 +198,7 @@ function TrainingDayCard({
             variant="outline"
             size="xs"
             className="h-7 gap-1.5"
+            nativeButton={false}
             render={
               <Link
                 href={`/chat?prompt=${encodeURIComponent(`Tell me about my ${sessionLabel} workout on ${day.dayName}`)}`}


### PR DESCRIPTION
fix for native-button ui errors

## Summary

Fixed native-button ui errors, setting nativeButton={false} where appropriate 

## Changes

Added FAQ for dynamic modes, allowing user to know they can ask for those when generating workouts.

## Checklist

- [X] `npx tsc --noEmit` passes
- [X] `npm run lint` passes
- [X] `npm test` passes (existing + new tests)
- [X] New logic has tests (happy path + at least one error/edge case)
- [X] No new or materially expanded file exceeds the 300-line soft cap
- [X] No file exceeds the 400-line hard cap (enforced by CI)
- [X] Functions stay near the 60-line convention
- [X] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [X] Tested in browser (if UI changes)
- [X] Commits follow conventional format (`type: description`)
- [X] No unused exports or dead code introduced

## Test Plan

Tested via UI as well as npm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workout suggestion prompt: "Add eccentrics and chains to my next workout."

* **Documentation**
  * Added FAQ entry explaining support for Tonal dynamic weight modes (eccentric, chains, spotter, burnout/AMRAP, and drop sets) in training programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->