### PR TITLE
fix: strip orphaned tool calls from thread history

### DIFF
--- a/convex/ai/coach.test.ts
+++ b/convex/ai/coach.test.ts
@@ -164,6 +164,22 @@ describe("stripOrphanedToolCalls", () => {
     expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
   });
 
+  it("keeps tool-calls that have a pending approval request", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Approve this push?" },
+          { type: "tool-call", toolCallId: "tc1", toolName: "approve_week_plan", input: {} },
+          { type: "tool-approval-request", approvalId: "ap1", toolCallId: "tc1" },
+        ],
+      },
+      { role: "user", content: "What does this change?" },
+    ];
+
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
   it("removes orphaned tool-call with no matching tool-result", () => {
     const msgs: ModelMessage[] = [
       { role: "user", content: "check scores" },
@@ -221,6 +237,22 @@ describe("stripOrphanedToolCalls", () => {
 });
 
 describe("coachAgentConfig.contextHandler", () => {
+  it("preserves pending approval-requested tool calls", async () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Approve this push?" },
+          { type: "tool-call", toolCallId: "tc1", toolName: "approve_week_plan", input: {} },
+          { type: "tool-approval-request", approvalId: "ap1", toolCallId: "tc1" },
+        ],
+      },
+      { role: "user", content: "What does this change?" },
+    ];
+
+    await expect(runContextHandler(messages)).resolves.toEqual(messages);
+  });
+
   it("normalizes orphaned tool calls before stripping old images and merging messages", async () => {
     const latestImage = new URL("https://example.com/latest.jpg");
 

--- a/convex/ai/coach.test.ts
+++ b/convex/ai/coach.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from "vitest";
 import type { ModelMessage } from "ai";
-import { mergeConsecutiveSameRole, stripOrphanedToolCalls } from "./coach";
+import { coachAgentConfig, mergeConsecutiveSameRole, stripOrphanedToolCalls } from "./coach";
+
+type ContextHandlerArgs = Parameters<typeof coachAgentConfig.contextHandler>[1];
+
+async function runContextHandler(allMessages: ModelMessage[]): Promise<ModelMessage[]> {
+  const args: ContextHandlerArgs = {
+    allMessages,
+    search: [],
+    recent: [],
+    inputMessages: [],
+    inputPrompt: [],
+    existingResponses: [],
+    userId: undefined,
+    threadId: undefined,
+  };
+
+  return coachAgentConfig.contextHandler(undefined as never, args);
+}
 
 describe("mergeConsecutiveSameRole", () => {
   it("returns empty array unchanged", () => {
@@ -127,6 +144,26 @@ describe("stripOrphanedToolCalls", () => {
     expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
   });
 
+  it("keeps tool-calls that were resolved by an approval response", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Approve this push?" },
+          { type: "tool-call", toolCallId: "tc1", toolName: "approve_week_plan", input: {} },
+          { type: "tool-approval-request", approvalId: "ap1", toolCallId: "tc1" },
+        ],
+      },
+      {
+        role: "tool",
+        content: [{ type: "tool-approval-response", approvalId: "ap1", approved: true }],
+      },
+      { role: "user", content: "Looks good" },
+    ];
+
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
   it("removes orphaned tool-call with no matching tool-result", () => {
     const msgs: ModelMessage[] = [
       { role: "user", content: "check scores" },
@@ -180,5 +217,51 @@ describe("stripOrphanedToolCalls", () => {
   it("handles string content on assistant messages", () => {
     const msgs: ModelMessage[] = [{ role: "assistant", content: "just text" }];
     expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+});
+
+describe("coachAgentConfig.contextHandler", () => {
+  it("normalizes orphaned tool calls before stripping old images and merging messages", async () => {
+    const latestImage = new URL("https://example.com/latest.jpg");
+
+    const result = await runContextHandler([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "older image note" },
+          {
+            type: "image",
+            image: new URL("https://example.com/older.jpg"),
+            mediaType: "image/jpeg",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "tc-orphan", toolName: "search_exercises", input: {} },
+        ],
+      },
+      { role: "user", content: "retry after failure" },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "latest image note" },
+          { type: "image", image: latestImage, mediaType: "image/jpeg" },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "older image note" },
+          { type: "text", text: "retry after failure" },
+          { type: "text", text: "latest image note" },
+          { type: "image", image: latestImage, mediaType: "image/jpeg" },
+        ],
+      },
+    ]);
   });
 });

--- a/convex/ai/coach.test.ts
+++ b/convex/ai/coach.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ModelMessage } from "ai";
-import { mergeConsecutiveSameRole } from "./coach";
+import { mergeConsecutiveSameRole, stripOrphanedToolCalls } from "./coach";
 
 describe("mergeConsecutiveSameRole", () => {
   it("returns empty array unchanged", () => {
@@ -92,5 +92,93 @@ describe("mergeConsecutiveSameRole", () => {
       { type: "text", text: "first" },
       { type: "text", text: "second" },
     ]);
+  });
+});
+
+describe("stripOrphanedToolCalls", () => {
+  it("passes through messages with no tool calls", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ];
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("keeps paired tool-call and tool-result", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "check scores" },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "tc1", toolName: "get_scores", input: {} }],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "get_scores",
+            output: { type: "text", value: "done" },
+          },
+        ],
+      },
+      { role: "assistant", content: "Your scores are great." },
+    ];
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("removes orphaned tool-call with no matching tool-result", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "check scores" },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "tc-orphan", toolName: "get_scores", input: {} },
+        ],
+      },
+      { role: "user", content: "try again" },
+    ];
+    const result = stripOrphanedToolCalls(msgs);
+    // The assistant message with only the orphaned tool-call is removed entirely
+    expect(result).toEqual([
+      { role: "user", content: "check scores" },
+      { role: "user", content: "try again" },
+    ]);
+  });
+
+  it("keeps text parts when only some tool-calls are orphaned", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "tool-call", toolCallId: "tc-good", toolName: "get_scores", input: {} },
+          { type: "tool-call", toolCallId: "tc-orphan", toolName: "search", input: {} },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-good",
+            toolName: "get_scores",
+            output: { type: "text", value: "ok" },
+          },
+        ],
+      },
+    ];
+    const result = stripOrphanedToolCalls(msgs);
+    expect(result).toHaveLength(3);
+    const assistantContent = result[1].content as Array<{ type: string; toolCallId?: string }>;
+    expect(assistantContent).toHaveLength(2);
+    expect(assistantContent[0]).toEqual({ type: "text", text: "Let me check." });
+    expect(assistantContent[1].toolCallId).toBe("tc-good");
+  });
+
+  it("handles string content on assistant messages", () => {
+    const msgs: ModelMessage[] = [{ role: "assistant", content: "just text" }];
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
   });
 });

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -94,6 +94,7 @@ export function mergeConsecutiveSameRole(messages: ModelMessage[]): ModelMessage
 
 export function stripOrphanedToolCalls(messages: ModelMessage[]): ModelMessage[] {
   const approvalIdToToolCallId = new Map<string, string>();
+  const toolCallIdsWithApprovalRequests = new Set<string>();
   const resolvedToolCallIds = new Set<string>();
   for (const msg of messages) {
     if (typeof msg.content === "string" || !Array.isArray(msg.content)) continue;
@@ -104,6 +105,7 @@ export function stripOrphanedToolCalls(messages: ModelMessage[]): ModelMessage[]
     }>) {
       if (part.type === "tool-approval-request" && part.approvalId && part.toolCallId) {
         approvalIdToToolCallId.set(part.approvalId, part.toolCallId);
+        toolCallIdsWithApprovalRequests.add(part.toolCallId);
       }
       if (part.type === "tool-result" && part.toolCallId) {
         resolvedToolCallIds.add(part.toolCallId);
@@ -133,7 +135,11 @@ export function stripOrphanedToolCalls(messages: ModelMessage[]): ModelMessage[]
       if (!hasToolCalls) return msg;
 
       const filtered = parts.filter(
-        (p) => p.type !== "tool-call" || (p.toolCallId && resolvedToolCallIds.has(p.toolCallId)),
+        (p) =>
+          p.type !== "tool-call" ||
+          (p.toolCallId &&
+            (resolvedToolCallIds.has(p.toolCallId) ||
+              toolCallIdsWithApprovalRequests.has(p.toolCallId))),
       );
 
       if (filtered.length === 0) return null;

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -92,6 +92,36 @@ export function mergeConsecutiveSameRole(messages: ModelMessage[]): ModelMessage
   return result;
 }
 
+export function stripOrphanedToolCalls(messages: ModelMessage[]): ModelMessage[] {
+  const answeredToolCallIds = new Set<string>();
+  for (const msg of messages) {
+    if (typeof msg.content === "string" || !Array.isArray(msg.content)) continue;
+    for (const part of msg.content as Array<{ type: string; toolCallId?: string }>) {
+      if (part.type === "tool-result" && part.toolCallId) {
+        answeredToolCallIds.add(part.toolCallId);
+      }
+    }
+  }
+
+  return messages
+    .map((msg) => {
+      if (msg.role !== "assistant") return msg;
+      if (typeof msg.content === "string" || !Array.isArray(msg.content)) return msg;
+
+      const parts = msg.content as Array<{ type: string; toolCallId?: string }>;
+      const hasToolCalls = parts.some((p) => p.type === "tool-call");
+      if (!hasToolCalls) return msg;
+
+      const filtered = parts.filter(
+        (p) => p.type !== "tool-call" || answeredToolCallIds.has(p.toolCallId!),
+      );
+
+      if (filtered.length === 0) return null;
+      return { ...msg, content: filtered } as ModelMessage;
+    })
+    .filter((msg): msg is ModelMessage => msg !== null);
+}
+
 /**
  * Remove image parts from all messages except the most recent user message.
  * Images stored in older messages cause unbounded memory growth when loaded
@@ -219,9 +249,9 @@ export const coachAgentConfig = {
   }) satisfies UsageHandler,
 
   contextHandler: (async (ctx, args) => {
-    // Normalize regardless of auth: strip stale images, merge consecutive
-    // same-role messages that arise from search + recent concatenation.
-    const messages = mergeConsecutiveSameRole(stripImagesFromOlderMessages(args.allMessages));
+    const messages = mergeConsecutiveSameRole(
+      stripImagesFromOlderMessages(stripOrphanedToolCalls(args.allMessages)),
+    );
 
     if (!args.userId) return messages;
 

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -93,12 +93,32 @@ export function mergeConsecutiveSameRole(messages: ModelMessage[]): ModelMessage
 }
 
 export function stripOrphanedToolCalls(messages: ModelMessage[]): ModelMessage[] {
-  const answeredToolCallIds = new Set<string>();
+  const approvalIdToToolCallId = new Map<string, string>();
+  const resolvedToolCallIds = new Set<string>();
   for (const msg of messages) {
     if (typeof msg.content === "string" || !Array.isArray(msg.content)) continue;
-    for (const part of msg.content as Array<{ type: string; toolCallId?: string }>) {
+    for (const part of msg.content as Array<{
+      type: string;
+      approvalId?: string;
+      toolCallId?: string;
+    }>) {
+      if (part.type === "tool-approval-request" && part.approvalId && part.toolCallId) {
+        approvalIdToToolCallId.set(part.approvalId, part.toolCallId);
+      }
       if (part.type === "tool-result" && part.toolCallId) {
-        answeredToolCallIds.add(part.toolCallId);
+        resolvedToolCallIds.add(part.toolCallId);
+      }
+    }
+  }
+
+  for (const msg of messages) {
+    if (typeof msg.content === "string" || !Array.isArray(msg.content)) continue;
+    for (const part of msg.content as Array<{ type: string; approvalId?: string }>) {
+      if (part.type === "tool-approval-response" && part.approvalId) {
+        const toolCallId = approvalIdToToolCallId.get(part.approvalId);
+        if (toolCallId) {
+          resolvedToolCallIds.add(toolCallId);
+        }
       }
     }
   }
@@ -113,7 +133,7 @@ export function stripOrphanedToolCalls(messages: ModelMessage[]): ModelMessage[]
       if (!hasToolCalls) return msg;
 
       const filtered = parts.filter(
-        (p) => p.type !== "tool-call" || answeredToolCallIds.has(p.toolCallId!),
+        (p) => p.type !== "tool-call" || (p.toolCallId && resolvedToolCallIds.has(p.toolCallId)),
       );
 
       if (filtered.length === 0) return null;


### PR DESCRIPTION
## Summary

- Adds `stripOrphanedToolCalls()` to the contextHandler pipeline that removes tool-call parts from assistant messages when no matching tool-result exists in the conversation
- Fixes a permanent failure loop where threads become unusable after a stream fails mid-tool-call (quota exceeded, timeout, abort)

## Root cause

When a stream fails mid-tool-call, the assistant message with the `tool-call` is persisted but the corresponding `tool-result` is never saved. Every subsequent message in that thread loads the corrupted history, and all providers reject it:

- **Gemini**: "Please ensure that function call turn comes immediately after a user turn or after a function response turn"
- **OpenAI**: Fails immediately (strict tool-call/result pairing validation)
- **Claude**: Hangs trying to process malformed conversation

PostHog error tracking shows **118 occurrences across 43 users** in the past 7 days (issue `019d510a-43f2-7b32-b574-9fc28c3d0fd4`).

## Test plan

- [ ] Verify `npx vitest run convex/ai/coach.test.ts` passes (5 new test cases)
- [ ] Deploy to production and confirm affected users can chat again
- [ ] Monitor PostHog error tracking issue for resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI coach message handling to remove orphaned tool calls that lack matching results, ensuring cleaner conversation contexts.

* **Tests**
  * Added comprehensive test suite covering tool call cleanup scenarios, including pass-through behavior, orphaned removal, and partial retention edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->