### PR TITLE
fix: timezone and validations

### DIFF
--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -189,24 +189,6 @@ const serverProvider = createGoogleGenerativeAI({
 });
 const sharedEmbeddingModel = serverProvider.textEmbeddingModel("gemini-embedding-001");
 
-/** Build per-request agent config with timezone-aware context handler. */
-export function makeCoachAgentConfig(userTimezone?: string) {
-  return {
-    ...coachAgentConfig,
-    contextHandler: (async (ctx, args) => {
-      const messages = mergeConsecutiveSameRole(
-        stripImagesFromOlderMessages(stripOrphanedToolCalls(args.allMessages)),
-      );
-      if (!args.userId) return messages;
-      const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
-      return [
-        { role: "system" as const, content: `<training-data>\n${snapshot}\n</training-data>` },
-        ...messages,
-      ];
-    }) satisfies ContextHandler,
-  };
-}
-
 export const coachAgentConfig = {
   embeddingModel: sharedEmbeddingModel,
 
@@ -292,6 +274,24 @@ export const coachAgentConfig = {
     });
   }) satisfies UsageHandler,
 };
+
+/** Build per-request agent config with timezone-aware context handler. */
+export function makeCoachAgentConfig(userTimezone?: string) {
+  return {
+    ...coachAgentConfig,
+    contextHandler: (async (ctx, args) => {
+      const messages = mergeConsecutiveSameRole(
+        stripImagesFromOlderMessages(stripOrphanedToolCalls(args.allMessages)),
+      );
+      if (!args.userId) return messages;
+      const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
+      return [
+        { role: "system" as const, content: `<training-data>\n${snapshot}\n</training-data>` },
+        ...messages,
+      ];
+    }) satisfies ContextHandler,
+  };
+}
 
 export interface CoachAgentPair {
   primary: Agent;

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -133,6 +133,27 @@ const serverProvider = createGoogleGenerativeAI({
 });
 const sharedEmbeddingModel = serverProvider.textEmbeddingModel("gemini-embedding-001");
 
+/**
+ * Build the agent config for a single request. The caller passes the user's
+ * browser-reported IANA timezone so `buildTrainingSnapshot` (invoked inside
+ * `contextHandler`) can label recent workouts as "today"/"yesterday" using
+ * the user's local wall clock instead of the server's UTC day boundary.
+ */
+export function makeCoachAgentConfig(userTimezone?: string) {
+  return {
+    ...coachAgentConfig,
+    contextHandler: (async (ctx, args) => {
+      const messages = mergeConsecutiveSameRole(stripImagesFromOlderMessages(args.allMessages));
+      if (!args.userId) return messages;
+      const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
+      return [
+        { role: "system" as const, content: `<training-data>\n${snapshot}\n</training-data>` },
+        ...messages,
+      ];
+    }) satisfies ContextHandler,
+  };
+}
+
 export const coachAgentConfig = {
   embeddingModel: sharedEmbeddingModel,
 
@@ -217,21 +238,6 @@ export const coachAgentConfig = {
       cacheWriteTokens: usage.inputTokenDetails?.cacheWriteTokens ?? undefined,
     });
   }) satisfies UsageHandler,
-
-  contextHandler: (async (ctx, args) => {
-    // Normalize regardless of auth: strip stale images, merge consecutive
-    // same-role messages that arise from search + recent concatenation.
-    const messages = mergeConsecutiveSameRole(stripImagesFromOlderMessages(args.allMessages));
-
-    if (!args.userId) return messages;
-
-    const snapshot = await buildTrainingSnapshot(ctx, args.userId);
-    const snapshotMessage = {
-      role: "system" as const,
-      content: `<training-data>\n${snapshot}\n</training-data>`,
-    };
-    return [snapshotMessage, ...messages];
-  }) satisfies ContextHandler,
 };
 
 export interface CoachAgentPair {
@@ -239,19 +245,20 @@ export interface CoachAgentPair {
   fallback: Agent;
 }
 
-export function buildCoachAgents(apiKey: string): CoachAgentPair {
+export function buildCoachAgents(apiKey: string, userTimezone?: string): CoachAgentPair {
   const provider = createGoogleGenerativeAI({ apiKey });
+  const config = makeCoachAgentConfig(userTimezone);
 
   const primary = new Agent(components.agent, {
     name: "Tonal Coach",
     languageModel: provider("gemini-3-flash-preview"),
-    ...coachAgentConfig,
+    ...config,
   });
 
   const fallback = new Agent(components.agent, {
     name: "Tonal Coach (Fallback)",
     languageModel: provider("gemini-2.5-flash"),
-    ...coachAgentConfig,
+    ...config,
   });
 
   return { primary, fallback };
@@ -261,11 +268,13 @@ export interface ProviderAgentArgs {
   provider: ProviderId;
   apiKey: string;
   modelOverride?: string;
+  userTimezone?: string;
 }
 
 export function buildCoachAgentsForProvider(args: ProviderAgentArgs): CoachAgentPair {
-  const { provider, apiKey, modelOverride } = args;
+  const { provider, apiKey, modelOverride, userTimezone } = args;
   const config = getProviderConfig(provider);
+  const agentConfig = makeCoachAgentConfig(userTimezone);
 
   const primaryModelName = modelOverride || config.primaryModel;
   if (!primaryModelName) {
@@ -276,7 +285,7 @@ export function buildCoachAgentsForProvider(args: ProviderAgentArgs): CoachAgent
   const primary = new Agent(components.agent, {
     name: "Tonal Coach",
     languageModel: primaryModel,
-    ...coachAgentConfig,
+    ...agentConfig,
   });
 
   let fallback: Agent;
@@ -285,7 +294,7 @@ export function buildCoachAgentsForProvider(args: ProviderAgentArgs): CoachAgent
     fallback = new Agent(components.agent, {
       name: "Tonal Coach (Fallback)",
       languageModel: fallbackModel,
-      ...coachAgentConfig,
+      ...agentConfig,
     });
   } else {
     // No fallback (OpenRouter) -- reuse primary so streamWithRetry still works
@@ -300,6 +309,6 @@ export function buildCoachAgentForStorageOnly(): Agent {
   return new Agent(components.agent, {
     name: "Tonal Coach (Storage Only)",
     languageModel: serverProvider("gemini-2.5-flash"),
-    ...coachAgentConfig,
+    ...makeCoachAgentConfig(),
   });
 }

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -189,12 +189,7 @@ const serverProvider = createGoogleGenerativeAI({
 });
 const sharedEmbeddingModel = serverProvider.textEmbeddingModel("gemini-embedding-001");
 
-/**
- * Build the agent config for a single request. The caller passes the user's
- * browser-reported IANA timezone so `buildTrainingSnapshot` (invoked inside
- * `contextHandler`) can label recent workouts as "today"/"yesterday" using
- * the user's local wall clock instead of the server's UTC day boundary.
- */
+/** Build per-request agent config with timezone-aware context handler. */
 export function makeCoachAgentConfig(userTimezone?: string) {
   return {
     ...coachAgentConfig,

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -357,11 +357,12 @@ export function buildCoachAgentsForProvider(args: ProviderAgentArgs): CoachAgent
   return { primary, fallback };
 }
 
-// Never pass to streamText/generateText; storage-only.
+// Never pass to streamText/generateText; storage-only (tool approvals).
+// Uses coachAgentConfig directly -- no contextHandler needed since no LLM call runs.
 export function buildCoachAgentForStorageOnly(): Agent {
   return new Agent(components.agent, {
     name: "Tonal Coach (Storage Only)",
     languageModel: serverProvider("gemini-2.5-flash"),
-    ...makeCoachAgentConfig(),
+    ...coachAgentConfig,
   });
 }

--- a/convex/ai/context.test.ts
+++ b/convex/ai/context.test.ts
@@ -3,11 +3,9 @@ import {
   buildExerciseCatalogSection,
   formatExternalActivityLine,
   getHrIntensityLabel,
-  getRecencyLabel,
   type SnapshotSection,
   trimSnapshot,
 } from "./context";
-import { computeAge } from "./snapshotHelpers";
 import type { ExternalActivity, Movement } from "../tonal/types";
 import type { OwnedAccessories } from "../tonal/accessories";
 
@@ -143,35 +141,6 @@ describe("formatExternalActivityLine", () => {
       makeExternal({ workoutType: "traditionalStrengthTraining" }),
     );
     expect(line).toContain("Traditional Strength Training");
-  });
-});
-
-// Recency labels
-
-describe("getRecencyLabel", () => {
-  it("returns 'today' for same-day timestamps", () => {
-    const now = new Date("2026-03-16T15:00:00Z");
-    expect(getRecencyLabel("2026-03-16T08:00:00Z", now)).toBe("today");
-  });
-
-  it("returns 'yesterday' for previous day", () => {
-    const now = new Date("2026-03-16T15:00:00Z");
-    expect(getRecencyLabel("2026-03-15T20:00:00Z", now)).toBe("yesterday");
-  });
-
-  it("returns 'this week' for 3 days ago", () => {
-    const now = new Date("2026-03-16T15:00:00Z");
-    expect(getRecencyLabel("2026-03-13T10:00:00Z", now)).toBe("this week");
-  });
-
-  it("returns 'last week' for 10 days ago", () => {
-    const now = new Date("2026-03-16T15:00:00Z");
-    expect(getRecencyLabel("2026-03-06T10:00:00Z", now)).toBe("last week");
-  });
-
-  it("returns 'older' for 20+ days ago", () => {
-    const now = new Date("2026-03-16T15:00:00Z");
-    expect(getRecencyLabel("2026-02-20T10:00:00Z", now)).toBe("older");
   });
 });
 
@@ -373,27 +342,5 @@ describe("buildExerciseCatalogSection", () => {
     const movements = [makeMovement()];
     const section = buildExerciseCatalogSection(movements, allOwned);
     expect(section!.priority).toBe(6.5);
-  });
-});
-
-// computeAge
-
-describe("computeAge", () => {
-  it("computes age correctly before birthday this year", () => {
-    const now = new Date("2026-03-28");
-    expect(computeAge("1993-12-15", now)).toBe(32);
-  });
-
-  it("computes age correctly after birthday this year", () => {
-    const now = new Date("2026-03-28");
-    expect(computeAge("1993-01-10", now)).toBe(33);
-  });
-
-  it("returns null for undefined dateOfBirth", () => {
-    expect(computeAge(undefined, new Date())).toBeNull();
-  });
-
-  it("returns null for invalid date string", () => {
-    expect(computeAge("not-a-date", new Date())).toBeNull();
   });
 });

--- a/convex/ai/context.ts
+++ b/convex/ai/context.ts
@@ -247,7 +247,7 @@ export async function buildTrainingSnapshot(
     const now = new Date();
     const wl = [`Recent Workouts:`];
     for (const a of activities) {
-      const r = getRecencyLabel(a.date + "T00:00:00Z", now, userTimezone);
+      const r = getRecencyLabel(a.date + "T12:00:00Z", now, userTimezone);
       const recent = r === "today" || r === "yesterday";
       const tag = recent ? `[${r.toUpperCase()}] ` : "";
       const vol = r !== "last week" && r !== "older" ? ` | ${a.totalVolume}lbs vol` : "";

--- a/convex/ai/context.ts
+++ b/convex/ai/context.ts
@@ -29,6 +29,7 @@ export {
 export async function buildTrainingSnapshot(
   ctx: Pick<ActionCtx, "runQuery">,
   userId: string,
+  userTimezone?: string,
 ): Promise<string> {
   const convexUserId = userId as Id<"users">;
 
@@ -246,7 +247,7 @@ export async function buildTrainingSnapshot(
     const now = new Date();
     const wl = [`Recent Workouts:`];
     for (const a of activities) {
-      const r = getRecencyLabel(a.date + "T00:00:00Z", now);
+      const r = getRecencyLabel(a.date + "T00:00:00Z", now, userTimezone);
       const recent = r === "today" || r === "yesterday";
       const tag = recent ? `[${r.toUpperCase()}] ` : "";
       const vol = r !== "last week" && r !== "older" ? ` | ${a.totalVolume}lbs vol` : "";
@@ -262,7 +263,7 @@ export async function buildTrainingSnapshot(
     const el: string[] = [`External Activities (non-Tonal):`];
     let vigorousThisWeek = 0;
     for (const ext of externalActivities) {
-      const r = getRecencyLabel(ext.beginTime, now);
+      const r = getRecencyLabel(ext.beginTime, now, userTimezone);
       const tag = r === "today" || r === "yesterday" ? `  [${r.toUpperCase()}] ` : "  ";
       const type = ext.workoutType
         .replace(/([A-Z])/g, " $1")

--- a/convex/ai/helpers.test.ts
+++ b/convex/ai/helpers.test.ts
@@ -1,4 +1,25 @@
 import { describe, expect, it } from "vitest";
+import { toSessionDuration } from "./helpers";
+
+describe("toSessionDuration", () => {
+  it("accepts valid numeric values", () => {
+    expect(toSessionDuration(30)).toBe(30);
+    expect(toSessionDuration(45)).toBe(45);
+    expect(toSessionDuration(60)).toBe(60);
+  });
+
+  it("accepts valid string values", () => {
+    expect(toSessionDuration("30")).toBe(30);
+    expect(toSessionDuration("45")).toBe(45);
+    expect(toSessionDuration("60")).toBe(60);
+  });
+
+  it("rejects invalid values", () => {
+    expect(() => toSessionDuration(15)).toThrow("Invalid session duration");
+    expect(() => toSessionDuration("90")).toThrow("Invalid session duration");
+    expect(() => toSessionDuration("abc")).toThrow("Invalid session duration");
+  });
+});
 
 describe("withToolTracking", () => {
   it("re-throws the original error from the inner function", async () => {

--- a/convex/ai/helpers.ts
+++ b/convex/ai/helpers.ts
@@ -8,13 +8,7 @@ export function requireUserId(ctx: ToolCtx): Id<"users"> {
   return ctx.userId as Id<"users">;
 }
 
-/**
- * Coerce an arbitrary input (string or number) into the allowed
- * session-duration literals. Throws on anything else. Used at the seam
- * between AI-tool inputs (strings like "30") and stored preferences
- * (numbers), so downstream code gets a typed value instead of a blind
- * `as 30 | 45 | 60` cast.
- */
+/** Validate and coerce to a session-duration literal (30, 45, or 60). */
 export function toSessionDuration(value: string | number): 30 | 45 | 60 {
   const n = typeof value === "number" ? value : Number(value);
   if (n === 30 || n === 45 || n === 60) return n;

--- a/convex/ai/helpers.ts
+++ b/convex/ai/helpers.ts
@@ -8,6 +8,19 @@ export function requireUserId(ctx: ToolCtx): Id<"users"> {
   return ctx.userId as Id<"users">;
 }
 
+/**
+ * Coerce an arbitrary input (string or number) into the allowed
+ * session-duration literals. Throws on anything else. Used at the seam
+ * between AI-tool inputs (strings like "30") and stored preferences
+ * (numbers), so downstream code gets a typed value instead of a blind
+ * `as 30 | 45 | 60` cast.
+ */
+export function toSessionDuration(value: string | number): 30 | 45 | 60 {
+  const n = typeof value === "number" ? value : Number(value);
+  if (n === 30 || n === 45 || n === 60) return n;
+  throw new Error(`Invalid session duration: ${String(value)} (must be 30, 45, or 60)`);
+}
+
 /** ToolCtx.userId is `string | undefined`; recordToolCall accepts `v.optional(v.string())` to avoid forbidden `as` casts. */
 
 export function withToolTracking<TInput, TOutput>(

--- a/convex/ai/snapshotHelpers.test.ts
+++ b/convex/ai/snapshotHelpers.test.ts
@@ -326,31 +326,34 @@ describe("buildExerciseCatalogSection", () => {
 // ---------------------------------------------------------------------------
 
 describe("computeAge", () => {
+  // Fixed local-time date avoids UTC-midnight drift across CI timezones.
+  const now = new Date(2026, 2, 28); // March 28, 2026
+
   it("computes age correctly before birthday this year", () => {
-    expect(computeAge("1993-12-15", new Date("2026-03-28"))).toBe(32);
+    expect(computeAge("1993-12-15", now)).toBe(32);
   });
 
   it("computes age correctly after birthday this year", () => {
-    expect(computeAge("1993-01-10", new Date("2026-03-28"))).toBe(33);
+    expect(computeAge("1993-01-10", now)).toBe(33);
   });
 
   it("returns null for undefined dateOfBirth", () => {
-    expect(computeAge(undefined, new Date())).toBeNull();
+    expect(computeAge(undefined, now)).toBeNull();
   });
 
   it("returns null for invalid date string", () => {
-    expect(computeAge("not-a-date", new Date())).toBeNull();
+    expect(computeAge("not-a-date", now)).toBeNull();
   });
 
   it("rejects impossible dates like Feb 30", () => {
-    expect(computeAge("1993-02-30", new Date("2026-03-28"))).toBeNull();
+    expect(computeAge("1993-02-30", now)).toBeNull();
   });
 
   it("rejects partial dates without day", () => {
-    expect(computeAge("1993-06", new Date("2026-03-28"))).toBeNull();
+    expect(computeAge("1993-06", now)).toBeNull();
   });
 
   it("rejects dates with trailing text", () => {
-    expect(computeAge("1993-06-15T00:00:00Z", new Date("2026-03-28"))).toBeNull();
+    expect(computeAge("1993-06-15T00:00:00Z", now)).toBeNull();
   });
 });

--- a/convex/ai/snapshotHelpers.test.ts
+++ b/convex/ai/snapshotHelpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildExerciseCatalogSection,
   capitalizeWorkoutType,
+  computeAge,
   formatExternalActivityLine,
   getHrIntensityLabel,
   SNAPSHOT_MAX_CHARS,
@@ -317,5 +318,39 @@ describe("buildExerciseCatalogSection", () => {
   it("has priority 6.5", () => {
     const result = buildExerciseCatalogSection([makeMovement()], undefined);
     expect(result!.priority).toBe(6.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAge
+// ---------------------------------------------------------------------------
+
+describe("computeAge", () => {
+  it("computes age correctly before birthday this year", () => {
+    expect(computeAge("1993-12-15", new Date("2026-03-28"))).toBe(32);
+  });
+
+  it("computes age correctly after birthday this year", () => {
+    expect(computeAge("1993-01-10", new Date("2026-03-28"))).toBe(33);
+  });
+
+  it("returns null for undefined dateOfBirth", () => {
+    expect(computeAge(undefined, new Date())).toBeNull();
+  });
+
+  it("returns null for invalid date string", () => {
+    expect(computeAge("not-a-date", new Date())).toBeNull();
+  });
+
+  it("rejects impossible dates like Feb 30", () => {
+    expect(computeAge("1993-02-30", new Date("2026-03-28"))).toBeNull();
+  });
+
+  it("rejects partial dates without day", () => {
+    expect(computeAge("1993-06", new Date("2026-03-28"))).toBeNull();
+  });
+
+  it("rejects dates with trailing text", () => {
+    expect(computeAge("1993-06-15T00:00:00Z", new Date("2026-03-28"))).toBeNull();
   });
 });

--- a/convex/ai/snapshotHelpers.ts
+++ b/convex/ai/snapshotHelpers.ts
@@ -170,14 +170,30 @@ function resolveGroupName(apiAccessory: string | undefined): string {
   return ACCESSORY_DISPLAY[profileKey];
 }
 
-/** Compute age in years from an ISO date-of-birth string. Returns null if invalid. */
+/**
+ * Compute age in years from a YYYY-MM-DD date-of-birth string.
+ *
+ * Parses the DOB components directly from the string instead of going
+ * through `new Date(dob)`. `new Date("1990-06-15")` is interpreted as UTC
+ * midnight, so `getMonth()`/`getDate()` return local-time values that can
+ * be one day off in UTC-negative zones — producing a wrong age on and
+ * just after the user's birthday. The `now` argument is still compared
+ * in local time, which is what we want.
+ *
+ * Returns null if the string does not parse as YYYY-MM-DD.
+ */
 export function computeAge(dateOfBirth: string | undefined, now: Date): number | null {
   if (!dateOfBirth) return null;
-  const dob = new Date(dateOfBirth);
-  if (isNaN(dob.getTime())) return null;
-  let age = now.getFullYear() - dob.getFullYear();
-  const monthDiff = now.getMonth() - dob.getMonth();
-  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < dob.getDate())) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateOfBirth);
+  if (!match) return null;
+  const dobYear = Number(match[1]);
+  const dobMonth = Number(match[2]);
+  const dobDay = Number(match[3]);
+  if (dobMonth < 1 || dobMonth > 12 || dobDay < 1 || dobDay > 31) return null;
+
+  let age = now.getFullYear() - dobYear;
+  const monthDiff = now.getMonth() + 1 - dobMonth;
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < dobDay)) {
     age--;
   }
   return age;

--- a/convex/ai/snapshotHelpers.ts
+++ b/convex/ai/snapshotHelpers.ts
@@ -171,25 +171,26 @@ function resolveGroupName(apiAccessory: string | undefined): string {
 }
 
 /**
- * Compute age in years from a YYYY-MM-DD date-of-birth string.
- *
- * Parses the DOB components directly from the string instead of going
- * through `new Date(dob)`. `new Date("1990-06-15")` is interpreted as UTC
- * midnight, so `getMonth()`/`getDate()` return local-time values that can
- * be one day off in UTC-negative zones — producing a wrong age on and
- * just after the user's birthday. The `now` argument is still compared
- * in local time, which is what we want.
- *
- * Returns null if the string does not parse as YYYY-MM-DD.
+ * Compute age from a YYYY-MM-DD DOB string. Parses components directly
+ * to avoid UTC-midnight timezone drift from `new Date(dob)`.
  */
 export function computeAge(dateOfBirth: string | undefined, now: Date): number | null {
   if (!dateOfBirth) return null;
-  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateOfBirth);
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateOfBirth);
   if (!match) return null;
   const dobYear = Number(match[1]);
   const dobMonth = Number(match[2]);
   const dobDay = Number(match[3]);
-  if (dobMonth < 1 || dobMonth > 12 || dobDay < 1 || dobDay > 31) return null;
+
+  // Validate the date is real (rejects Feb 30, etc.)
+  const check = new Date(dobYear, dobMonth - 1, dobDay);
+  if (
+    check.getFullYear() !== dobYear ||
+    check.getMonth() !== dobMonth - 1 ||
+    check.getDate() !== dobDay
+  ) {
+    return null;
+  }
 
   let age = now.getFullYear() - dobYear;
   const monthDiff = now.getMonth() + 1 - dobMonth;

--- a/convex/ai/timeDecay.test.ts
+++ b/convex/ai/timeDecay.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getRecencyLabel, sanitizeTimezone } from "./timeDecay";
+
+describe("getRecencyLabel", () => {
+  it("returns 'today' for same-day timestamps", () => {
+    const now = new Date("2026-03-16T15:00:00Z");
+    expect(getRecencyLabel("2026-03-16T08:00:00Z", now)).toBe("today");
+  });
+
+  it("returns 'yesterday' for previous day", () => {
+    const now = new Date("2026-03-16T15:00:00Z");
+    expect(getRecencyLabel("2026-03-15T20:00:00Z", now)).toBe("yesterday");
+  });
+
+  it("returns 'this week' for 3 days ago", () => {
+    const now = new Date("2026-03-16T15:00:00Z");
+    expect(getRecencyLabel("2026-03-13T10:00:00Z", now)).toBe("this week");
+  });
+
+  it("returns 'last week' for 10 days ago", () => {
+    const now = new Date("2026-03-16T15:00:00Z");
+    expect(getRecencyLabel("2026-03-06T10:00:00Z", now)).toBe("last week");
+  });
+
+  it("returns 'older' for 20+ days ago", () => {
+    const now = new Date("2026-03-16T15:00:00Z");
+    expect(getRecencyLabel("2026-02-20T10:00:00Z", now)).toBe("older");
+  });
+
+  it("returns 'today' using user timezone near midnight UTC", () => {
+    const now = new Date("2026-03-16T23:30:00Z");
+    expect(getRecencyLabel("2026-03-16T20:00:00Z", now, "America/Los_Angeles")).toBe("today");
+  });
+
+  it("returns 'yesterday' using user timezone", () => {
+    const now = new Date("2026-03-17T06:00:00Z");
+    expect(getRecencyLabel("2026-03-16T02:00:00Z", now, "America/Los_Angeles")).toBe("yesterday");
+  });
+
+  it("returns 'today' near midnight in positive-UTC timezone", () => {
+    const now = new Date("2026-03-15T22:00:00Z");
+    expect(getRecencyLabel("2026-03-15T20:00:00Z", now, "Asia/Tokyo")).toBe("today");
+  });
+});
+
+describe("sanitizeTimezone", () => {
+  it("accepts valid IANA timezones", () => {
+    expect(sanitizeTimezone("America/New_York")).toBe("America/New_York");
+    expect(sanitizeTimezone("UTC")).toBe("UTC");
+  });
+
+  it("rejects invalid timezones", () => {
+    expect(sanitizeTimezone("Not/A/Zone")).toBeUndefined();
+    expect(sanitizeTimezone("")).toBeUndefined();
+    expect(sanitizeTimezone(undefined)).toBeUndefined();
+  });
+
+  it("trims whitespace", () => {
+    expect(sanitizeTimezone("  America/Chicago  ")).toBe("America/Chicago");
+  });
+});

--- a/convex/ai/timeDecay.ts
+++ b/convex/ai/timeDecay.ts
@@ -27,6 +27,26 @@ function calendarDay(date: Date, timeZone: string | undefined): string {
   return date.toISOString().slice(0, 10);
 }
 
+/** Subtract one calendar day from a YYYY-MM-DD string. */
+function prevCalendarDay(ymd: string): string {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const prev = new Date(Date.UTC(y, m - 1, d - 1));
+  return prev.toISOString().slice(0, 10);
+}
+
+/** Validate a user-supplied IANA timezone, returning undefined if invalid. */
+export function sanitizeTimezone(tz: string | undefined): string | undefined {
+  if (!tz || typeof tz !== "string") return undefined;
+  const trimmed = tz.trim();
+  if (trimmed.length === 0 || trimmed.length > 64) return undefined;
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: trimmed });
+    return trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
 export function getRecencyLabel(
   isoTimestamp: string,
   now: Date = new Date(),
@@ -37,10 +57,7 @@ export function getRecencyLabel(
   const tsDay = calendarDay(ts, timeZone);
   const nowDay = calendarDay(now, timeZone);
   if (tsDay === nowDay) return "today";
-  // Check if ts is the previous calendar day
-  const yesterdayDate = new Date(now);
-  yesterdayDate.setDate(yesterdayDate.getDate() - 1);
-  if (tsDay === calendarDay(yesterdayDate, timeZone)) return "yesterday";
+  if (tsDay === prevCalendarDay(nowDay)) return "yesterday";
   if (days < 7) return "this week";
   if (days < 14) return "last week";
   return "older";

--- a/convex/ai/timeDecay.ts
+++ b/convex/ai/timeDecay.ts
@@ -5,11 +5,42 @@
 
 export type RecencyLabel = "today" | "yesterday" | "this week" | "last week" | "older";
 
-export function getRecencyLabel(isoTimestamp: string, now: Date = new Date()): RecencyLabel {
+/**
+ * Return the YYYY-MM-DD calendar day for a Date in the given IANA
+ * timezone. Falls back to UTC if the timezone is missing or invalid.
+ */
+function calendarDay(date: Date, timeZone: string | undefined): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timeZone ?? "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(date);
+    const y = parts.find((p) => p.type === "year")?.value;
+    const m = parts.find((p) => p.type === "month")?.value;
+    const d = parts.find((p) => p.type === "day")?.value;
+    if (y && m && d) return `${y}-${m}-${d}`;
+  } catch {
+    // Unknown timezone — fall through to UTC.
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+export function getRecencyLabel(
+  isoTimestamp: string,
+  now: Date = new Date(),
+  timeZone?: string,
+): RecencyLabel {
   const ts = new Date(isoTimestamp);
   const days = (now.getTime() - ts.getTime()) / 86_400_000;
-  if (days < 1 && ts.toISOString().slice(0, 10) === now.toISOString().slice(0, 10)) return "today";
-  if (days < 2) return "yesterday";
+  const tsDay = calendarDay(ts, timeZone);
+  const nowDay = calendarDay(now, timeZone);
+  if (tsDay === nowDay) return "today";
+  // Check if ts is the previous calendar day
+  const yesterdayDate = new Date(now);
+  yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+  if (tsDay === calendarDay(yesterdayDate, timeZone)) return "yesterday";
   if (days < 7) return "this week";
   if (days < 14) return "last week";
   return "older";

--- a/convex/ai/weekModificationTools.ts
+++ b/convex/ai/weekModificationTools.ts
@@ -12,7 +12,7 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { DAY_NAMES } from "../coach/weekProgrammingHelpers";
 import { getWeekStartDateString } from "../weekPlanHelpers";
-import { requireUserId, withToolTracking } from "./helpers";
+import { requireUserId, toSessionDuration, withToolTracking } from "./helpers";
 
 const VALIDATION_PREFIXES = [
   "Invalid movementId",
@@ -270,7 +270,7 @@ export const adjustSessionDurationTool = createTool({
         userId,
         weekPlanId: weekPlan._id,
         dayIndex: input.dayIndex,
-        newDurationMinutes: parseInt(input.newDurationMinutes) as 30 | 45 | 60,
+        newDurationMinutes: toSessionDuration(input.newDurationMinutes),
       });
 
       return {

--- a/convex/ai/weekTools.ts
+++ b/convex/ai/weekTools.ts
@@ -16,7 +16,7 @@ import type { WorkoutPerformanceSummary } from "../coach/prDetection";
 import type { WeekPushResult } from "../coach/pushAndVerify";
 import type { Movement } from "../tonal/types";
 import { getWeekStartDateString } from "../weekPlanHelpers";
-import { requireUserId, withToolTracking } from "./helpers";
+import { requireUserId, toSessionDuration, withToolTracking } from "./helpers";
 import { buildReasoningPrompt } from "./weekReasoning";
 
 // ---------------------------------------------------------------------------
@@ -77,9 +77,11 @@ export const programWeekTool = createTool({
       } | null;
 
       const preferredSplit = input.preferredSplit ?? saved?.preferredSplit ?? "ppl";
-      const sessionDuration = input.sessionDurationMinutes
-        ? (parseInt(input.sessionDurationMinutes) as 30 | 45 | 60)
-        : ((saved?.sessionDurationMinutes as 30 | 45 | 60 | undefined) ?? 45);
+      const sessionDuration: 30 | 45 | 60 = input.sessionDurationMinutes
+        ? toSessionDuration(input.sessionDurationMinutes)
+        : saved?.sessionDurationMinutes !== undefined
+          ? toSessionDuration(saved.sessionDurationMinutes)
+          : 45;
 
       const targetDays =
         input.trainingDays?.length ?? input.targetDays ?? saved?.trainingDays?.length ?? 3;
@@ -293,10 +295,6 @@ export const deleteWeekPlanTool = createTool({
     },
   ),
 });
-
-// ---------------------------------------------------------------------------
-// approveWeekPlanTool
-// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // getWorkoutPerformanceTool

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -17,6 +17,7 @@ import { buildCoachAgentForStorageOnly, buildCoachAgentsForProvider } from "./ai
 import { type ProviderKeyResult, resolveProviderKey } from "./byok";
 import { checkDailyBudget, classifyByokError, streamWithRetry } from "./ai/resilience";
 import { rateLimiter } from "./rateLimits";
+import { sanitizeTimezone } from "./ai/timeDecay";
 import * as analytics from "./lib/posthog";
 
 const MAX_IMAGES_PER_MESSAGE = 4;
@@ -158,7 +159,8 @@ export const createThreadWithMessage = action({
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
     userTimezone: v.optional(v.string()),
   },
-  handler: async (ctx, { threadId, prompt, imageStorageIds, userTimezone }) => {
+  handler: async (ctx, { threadId, prompt, imageStorageIds, userTimezone: rawTz }) => {
+    const userTimezone = sanitizeTimezone(rawTz);
     const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 
@@ -280,7 +282,8 @@ export const continueAfterApproval = action({
     messageId: v.string(),
     userTimezone: v.optional(v.string()),
   },
-  handler: async (ctx, { threadId, messageId, userTimezone }) => {
+  handler: async (ctx, { threadId, messageId, userTimezone: rawTz }) => {
+    const userTimezone = sanitizeTimezone(rawTz);
     const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 
@@ -321,7 +324,8 @@ export const sendMessageToThread = mutation({
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
     userTimezone: v.optional(v.string()),
   },
-  handler: async (ctx, { prompt, threadId, imageStorageIds, userTimezone }) => {
+  handler: async (ctx, { prompt, threadId, imageStorageIds, userTimezone: rawTz }) => {
+    const userTimezone = sanitizeTimezone(rawTz);
     const userId = await getEffectiveUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
@@ -349,7 +353,7 @@ export const sendMessageToThread = mutation({
 export const processMessage = internalAction({
   args: {
     threadId: v.string(),
-    userId: v.id("users"),
+    userId: v.string(),
     prompt: v.string(),
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
     userTimezone: v.optional(v.string()),

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -353,7 +353,7 @@ export const sendMessageToThread = mutation({
 export const processMessage = internalAction({
   args: {
     threadId: v.string(),
-    userId: v.string(),
+    userId: v.id("users"),
     prompt: v.string(),
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
     userTimezone: v.optional(v.string()),

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -83,10 +83,7 @@ async function withByokErrorSanitization<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-/**
- * Resolves storage IDs to URLs and builds a multimodal ModelMessage array.
- * Returns the plain text string when no images are provided.
- */
+/** Resolves storage IDs to URLs and builds a multimodal ModelMessage array. */
 async function buildPrompt(
   ctx: ActionCtx,
   text: string,
@@ -358,7 +355,8 @@ export const processMessage = internalAction({
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
     userTimezone: v.optional(v.string()),
   },
-  handler: async (ctx, { threadId, userId, prompt, imageStorageIds, userTimezone }) => {
+  handler: async (ctx, { threadId, userId, prompt, imageStorageIds, userTimezone: rawTz }) => {
+    const userTimezone = sanitizeTimezone(rawTz);
     const budgetExceeded = await checkDailyBudget(ctx, userId, threadId);
     if (budgetExceeded) return;
 

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -156,8 +156,9 @@ export const createThreadWithMessage = action({
     threadId: v.optional(v.string()),
     prompt: v.string(),
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
+    userTimezone: v.optional(v.string()),
   },
-  handler: async (ctx, { threadId, prompt, imageStorageIds }) => {
+  handler: async (ctx, { threadId, prompt, imageStorageIds, userTimezone }) => {
     const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 
@@ -209,6 +210,7 @@ export const createThreadWithMessage = action({
       userId,
       prompt,
       imageStorageIds,
+      userTimezone,
     });
 
     return { threadId: targetThreadId };
@@ -276,15 +278,19 @@ export const continueAfterApproval = action({
   args: {
     threadId: v.string(),
     messageId: v.string(),
+    userTimezone: v.optional(v.string()),
   },
-  handler: async (ctx, { threadId, messageId }) => {
+  handler: async (ctx, { threadId, messageId, userTimezone }) => {
     const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 
     const providerConfig = await resolveUserProviderConfig(ctx, userId);
 
     const startTime = Date.now();
-    const { primary, fallback } = buildCoachAgentsForProvider(providerConfig);
+    const { primary, fallback } = buildCoachAgentsForProvider({
+      ...providerConfig,
+      userTimezone,
+    });
     await withByokErrorSanitization(() =>
       streamWithRetry(ctx, {
         primaryAgent: primary,
@@ -313,8 +319,9 @@ export const sendMessageToThread = mutation({
     prompt: v.string(),
     threadId: v.string(),
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
+    userTimezone: v.optional(v.string()),
   },
-  handler: async (ctx, { prompt, threadId, imageStorageIds }) => {
+  handler: async (ctx, { prompt, threadId, imageStorageIds, userTimezone }) => {
     const userId = await getEffectiveUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
@@ -332,6 +339,7 @@ export const sendMessageToThread = mutation({
       userId,
       prompt,
       imageStorageIds,
+      userTimezone,
     });
 
     return { threadId };
@@ -341,11 +349,12 @@ export const sendMessageToThread = mutation({
 export const processMessage = internalAction({
   args: {
     threadId: v.string(),
-    userId: v.string(),
+    userId: v.id("users"),
     prompt: v.string(),
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
+    userTimezone: v.optional(v.string()),
   },
-  handler: async (ctx, { threadId, userId, prompt, imageStorageIds }) => {
+  handler: async (ctx, { threadId, userId, prompt, imageStorageIds, userTimezone }) => {
     const budgetExceeded = await checkDailyBudget(ctx, userId, threadId);
     if (budgetExceeded) return;
 
@@ -362,7 +371,10 @@ export const processMessage = internalAction({
     });
 
     const startTime = Date.now();
-    const { primary, fallback } = buildCoachAgentsForProvider(providerConfig);
+    const { primary, fallback } = buildCoachAgentsForProvider({
+      ...providerConfig,
+      userTimezone,
+    });
     await withByokErrorSanitization(() =>
       streamWithRetry(ctx, {
         primaryAgent: primary,

--- a/convex/tonal/client.ts
+++ b/convex/tonal/client.ts
@@ -72,7 +72,12 @@ export async function fetchWorkoutActivitiesPage<T>(
   }
 
   const items = (await res.json()) as T[];
-  const pgTotal = parseInt(res.headers.get("pg-total") ?? "0", 10);
+  // Tonal sets pg-total on paginated endpoints. If the header is missing or
+  // malformed, fall back to the item count so callers don't silently loop
+  // against NaN or issue negative-progress requests.
+  const rawPgTotal = res.headers.get("pg-total");
+  const parsed = rawPgTotal !== null ? Number(rawPgTotal) : Number.NaN;
+  const pgTotal = Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : items.length;
   return { items, pgTotal };
 }
 

--- a/convex/tonal/client.ts
+++ b/convex/tonal/client.ts
@@ -80,7 +80,11 @@ export async function fetchWorkoutActivitiesPage<T>(
   // When the header is valid, use it. Otherwise, if the page is full,
   // assume at least one more item exists so callers continue paginating.
   const fallback = items.length >= limit ? items.length + 1 : items.length;
-  const pgTotal = Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+  const validHeader = Number.isFinite(parsed) && parsed >= 0;
+  if (!validHeader && rawPgTotal !== null) {
+    console.warn(`[fetchWorkoutActivitiesPage] Malformed pg-total header: "${rawPgTotal}"`);
+  }
+  const pgTotal = validHeader ? Math.floor(parsed) : fallback;
   return { items, pgTotal };
 }
 

--- a/convex/tonal/client.ts
+++ b/convex/tonal/client.ts
@@ -77,7 +77,10 @@ export async function fetchWorkoutActivitiesPage<T>(
   // against NaN or issue negative-progress requests.
   const rawPgTotal = res.headers.get("pg-total");
   const parsed = rawPgTotal !== null ? Number(rawPgTotal) : Number.NaN;
-  const pgTotal = Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : items.length;
+  // When the header is valid, use it. Otherwise, if the page is full,
+  // assume at least one more item exists so callers continue paginating.
+  const fallback = items.length >= limit ? items.length + 1 : items.length;
+  const pgTotal = Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
   return { items, pgTotal };
 }
 

--- a/convex/workoutPlans.ts
+++ b/convex/workoutPlans.ts
@@ -8,7 +8,8 @@ import {
 } from "./_generated/server";
 import { getEffectiveUserId } from "./lib/auth";
 import { api, internal } from "./_generated/api";
-import type { Doc } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
 import { blockInputValidator } from "./validators";
 import * as analytics from "./lib/posthog";
 
@@ -151,19 +152,31 @@ export const getByIdInternal = internalQuery({
   },
 });
 
-/**
- * Returns the set of Tonal workout IDs already claimed by any of the
- * user's existing workoutPlans. Used by stuck-push recovery to avoid
- * linking a plan to a workoutId that another plan already owns.
- */
-export const getClaimedTonalWorkoutIdsForUser = internalQuery({
-  args: { userId: v.id("users") },
-  handler: async (ctx, { userId }): Promise<string[]> => {
+/** Atomically claim a recovered Tonal workout if no other plan already owns it. */
+export const claimRecoveredWorkout = internalMutation({
+  args: {
+    planId: v.id("workoutPlans"),
+    userId: v.id("users"),
+    tonalWorkoutId: v.string(),
+    pushedAt: v.number(),
+  },
+  handler: async (ctx, { planId, userId, tonalWorkoutId, pushedAt }) => {
     const plans = await ctx.db
       .query("workoutPlans")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .collect();
-    return plans.flatMap((p) => (p.tonalWorkoutId ? [p.tonalWorkoutId] : []));
+
+    if (plans.some((p) => p._id !== planId && p.tonalWorkoutId === tonalWorkoutId)) {
+      return { error: "Workout already claimed" } as const;
+    }
+
+    await ctx.db.patch(planId, {
+      status: "pushed" as const,
+      tonalWorkoutId,
+      pushedAt,
+      pushErrorReason: undefined,
+    });
+    return { ok: true } as const;
   },
 });
 
@@ -249,6 +262,60 @@ export const getStuckPushingPlanIds = internalQuery({
   },
 });
 
+/** Try to find and claim a matching workout on Tonal for a stuck plan. */
+async function tryRecoverPlan(
+  ctx: ActionCtx,
+  planId: Id<"workoutPlans">,
+  plan: Doc<"workoutPlans">,
+): Promise<boolean> {
+  try {
+    const customWorkouts = await ctx.runAction(internal.tonal.proxy.fetchCustomWorkouts, {
+      userId: plan.userId,
+    });
+    const planCreatedIso = new Date(plan.createdAt).toISOString();
+    const candidates = customWorkouts.filter(
+      (w: { id: string; title: string; createdAt: string }) =>
+        w.title === plan.title && w.createdAt >= planCreatedIso,
+    );
+
+    if (candidates.length > 1) {
+      await ctx.runMutation(internal.workoutPlans.updatePushOutcome, {
+        planId,
+        status: "failed",
+        pushErrorReason: `Ambiguous: ${candidates.length} Tonal matches for "${plan.title}"`,
+      });
+      console.warn(
+        `[stuckPushRecovery] ${candidates.length} ambiguous Tonal matches for plan ${planId} - marking failed`,
+      );
+      return true;
+    }
+
+    if (candidates.length === 1) {
+      const result = await ctx.runMutation(internal.workoutPlans.claimRecoveredWorkout, {
+        planId,
+        userId: plan.userId,
+        tonalWorkoutId: candidates[0].id,
+        pushedAt: Date.now(),
+      });
+      if ("ok" in result) {
+        analytics.capture(plan.userId, "workout_push_recovered", { plan_id: planId });
+        console.log(
+          `[stuckPushRecovery] Recovered plan ${planId} - found matching workout ${candidates[0].id} on Tonal`,
+        );
+        return true;
+      }
+      console.warn(
+        `[stuckPushRecovery] Could not claim workout ${candidates[0].id} for plan ${planId}: ${result.error}`,
+      );
+    }
+
+    return false;
+  } catch (err) {
+    console.warn(`[stuckPushRecovery] Could not check Tonal for plan ${planId}:`, err);
+    return false;
+  }
+}
+
 /** Cron: mark stuck "pushing" plans as failed, recovering any that made it to Tonal. */
 export const runStuckPushRecovery = internalAction({
   args: {},
@@ -261,55 +328,16 @@ export const runStuckPushRecovery = internalAction({
       });
       for (const planId of ids) {
         const plan = await ctx.runQuery(internal.workoutPlans.getByIdInternal, { planId });
-
-        // Try to recover: check if the workout made it to Tonal
-        let recovered = false;
-        if (plan) {
-          try {
-            const customWorkouts = await ctx.runAction(internal.tonal.proxy.fetchCustomWorkouts, {
-              userId: plan.userId,
-            });
-            const claimed = new Set(
-              await ctx.runQuery(internal.workoutPlans.getClaimedTonalWorkoutIdsForUser, {
-                userId: plan.userId,
-              }),
-            );
-            // Only consider workouts (a) whose title matches, (b) created
-            // at-or-after the plan was queued (anything older can't be this
-            // push), and (c) not already claimed by another workoutPlan.
-            const planCreatedIso = new Date(plan.createdAt).toISOString();
-            const candidates = customWorkouts.filter(
-              (w: { id: string; title: string; createdAt: string }) =>
-                w.title === plan.title && w.createdAt >= planCreatedIso && !claimed.has(w.id),
-            );
-            // Require an unambiguous match. If multiple candidates remain
-            // after filtering, we don't know which one this plan produced —
-            // leave it failed rather than link the wrong workoutId.
-            const match = candidates.length === 1 ? candidates[0] : undefined;
-            if (candidates.length > 1) {
-              console.warn(
-                `[stuckPushRecovery] ${candidates.length} ambiguous Tonal matches for plan ${planId} title="${plan.title}" - leaving failed`,
-              );
-            }
-            if (match) {
-              await ctx.runMutation(internal.workoutPlans.updatePushOutcome, {
-                planId,
-                status: "pushed",
-                tonalWorkoutId: match.id,
-                pushedAt: Date.now(),
-              });
-              recovered = true;
-              analytics.capture(plan.userId, "workout_push_recovered", { plan_id: planId });
-              console.log(
-                `[stuckPushRecovery] Recovered plan ${planId} - found matching workout ${match.id} on Tonal`,
-              );
-            }
-          } catch (err) {
-            // If Tonal is unreachable, fall through to mark as failed
-            console.warn(`[stuckPushRecovery] Could not check Tonal for plan ${planId}:`, err);
-          }
+        if (!plan) {
+          await ctx.runMutation(internal.workoutPlans.updatePushOutcome, {
+            planId,
+            status: "failed",
+            pushErrorReason: "Push timed out",
+          });
+          continue;
         }
 
+        const recovered = await tryRecoverPlan(ctx, planId, plan);
         if (!recovered) {
           await ctx.runMutation(internal.workoutPlans.updatePushOutcome, {
             planId,

--- a/convex/workoutPlans.ts
+++ b/convex/workoutPlans.ts
@@ -340,11 +340,7 @@ export const runStuckPushRecovery = internalAction({
       for (const planId of ids) {
         const plan = await ctx.runQuery(internal.workoutPlans.getByIdInternal, { planId });
         if (!plan) {
-          await ctx.runMutation(internal.workoutPlans.updatePushOutcome, {
-            planId,
-            status: "failed",
-            pushErrorReason: "Push timed out",
-          });
+          console.warn(`[stuckPushRecovery] Plan ${planId} no longer exists, skipping`);
           continue;
         }
 

--- a/convex/workoutPlans.ts
+++ b/convex/workoutPlans.ts
@@ -161,6 +161,11 @@ export const claimRecoveredWorkout = internalMutation({
     pushedAt: v.number(),
   },
   handler: async (ctx, { planId, userId, tonalWorkoutId, pushedAt }) => {
+    const plan = await ctx.db.get(planId);
+    if (!plan || plan.userId !== userId) {
+      return { error: "Plan not found or not owned by user" } as const;
+    }
+
     const plans = await ctx.db
       .query("workoutPlans")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
@@ -304,9 +309,15 @@ async function tryRecoverPlan(
         );
         return true;
       }
+      await ctx.runMutation(internal.workoutPlans.updatePushOutcome, {
+        planId,
+        status: "failed",
+        pushErrorReason: result.error,
+      });
       console.warn(
         `[stuckPushRecovery] Could not claim workout ${candidates[0].id} for plan ${planId}: ${result.error}`,
       );
+      return true; // Handled with specific reason, not generic timeout.
     }
 
     return false;

--- a/convex/workoutPlans.ts
+++ b/convex/workoutPlans.ts
@@ -151,6 +151,22 @@ export const getByIdInternal = internalQuery({
   },
 });
 
+/**
+ * Returns the set of Tonal workout IDs already claimed by any of the
+ * user's existing workoutPlans. Used by stuck-push recovery to avoid
+ * linking a plan to a workoutId that another plan already owns.
+ */
+export const getClaimedTonalWorkoutIdsForUser = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }): Promise<string[]> => {
+    const plans = await ctx.db
+      .query("workoutPlans")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    return plans.flatMap((p) => (p.tonalWorkoutId ? [p.tonalWorkoutId] : []));
+  },
+});
+
 /** Retry pushing a failed/draft plan to Tonal. TOCTOU-safe via transitionToPushing. */
 export const retryPush = action({
   args: { planId: v.id("workoutPlans") },
@@ -253,16 +269,28 @@ export const runStuckPushRecovery = internalAction({
             const customWorkouts = await ctx.runAction(internal.tonal.proxy.fetchCustomWorkouts, {
               userId: plan.userId,
             });
-            const matches = customWorkouts.filter(
-              (w: { id: string; title: string }) => w.title === plan.title,
+            const claimed = new Set(
+              await ctx.runQuery(internal.workoutPlans.getClaimedTonalWorkoutIdsForUser, {
+                userId: plan.userId,
+              }),
             );
-            if (matches.length > 1) {
+            // Only consider workouts (a) whose title matches, (b) created
+            // at-or-after the plan was queued (anything older can't be this
+            // push), and (c) not already claimed by another workoutPlan.
+            const planCreatedIso = new Date(plan.createdAt).toISOString();
+            const candidates = customWorkouts.filter(
+              (w: { id: string; title: string; createdAt: string }) =>
+                w.title === plan.title && w.createdAt >= planCreatedIso && !claimed.has(w.id),
+            );
+            // Require an unambiguous match. If multiple candidates remain
+            // after filtering, we don't know which one this plan produced —
+            // leave it failed rather than link the wrong workoutId.
+            const match = candidates.length === 1 ? candidates[0] : undefined;
+            if (candidates.length > 1) {
               console.warn(
-                `[stuckPushRecovery] Multiple Tonal workouts match title "${plan.title}" for plan ${planId} - using most recent`,
+                `[stuckPushRecovery] ${candidates.length} ambiguous Tonal matches for plan ${planId} title="${plan.title}" - leaving failed`,
               );
             }
-            // Use the last match (most recently created on Tonal)
-            const match = matches.length > 0 ? matches[matches.length - 1] : undefined;
             if (match) {
               await ctx.runMutation(internal.workoutPlans.updatePushOutcome, {
                 planId,

--- a/src/app/(app)/chat/page.tsx
+++ b/src/app/(app)/chat/page.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { ImagePreviewRow } from "@/features/chat/ImagePreviewRow";
 import { useImageUpload } from "@/hooks/useImageUpload";
 import { useAnalytics } from "@/lib/analytics";
+import { getBrowserTimezone } from "@/lib/timezone";
 import {
   Activity,
   Dumbbell,
@@ -53,7 +54,7 @@ function ChatPageInner() {
   const sendAndWait = async (args: { prompt: string; imageStorageIds?: Id<"_storage">[] }) => {
     setWaitingForCoach(true);
     try {
-      return await createThreadWithMessage(args);
+      return await createThreadWithMessage({ ...args, userTimezone: getBrowserTimezone() });
     } finally {
       setWaitingForCoach(false);
     }

--- a/src/features/chat/ChatInput.tsx
+++ b/src/features/chat/ChatInput.tsx
@@ -12,6 +12,7 @@ import { parseByokError } from "@/features/byok/parseByokError";
 import { useImageUpload } from "@/hooks/useImageUpload";
 import { ImagePlus, Loader2, SendHorizontal } from "lucide-react";
 import { useAnalytics } from "@/lib/analytics";
+import { getBrowserTimezone } from "@/lib/timezone";
 
 const MAX_TEXTAREA_HEIGHT = 160;
 
@@ -76,6 +77,7 @@ export function ChatInput({ threadId, disabled, onSend }: ChatInputProps) {
       await sendMessage({
         prompt: trimmed || "What do you see in these images?",
         threadId,
+        userTimezone: getBrowserTimezone(),
         ...(imageStorageIds && imageStorageIds.length > 0 && { imageStorageIds }),
       });
       setByokError(null);

--- a/src/features/chat/ToolApprovalCard.tsx
+++ b/src/features/chat/ToolApprovalCard.tsx
@@ -5,6 +5,7 @@ import { useAction, useMutation } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { useAnalytics } from "@/lib/analytics";
+import { getBrowserTimezone } from "@/lib/timezone";
 import { Check, Loader2, X } from "lucide-react";
 import { toast } from "sonner";
 
@@ -40,7 +41,7 @@ export function ToolApprovalCard({ toolName, approvalId, threadId }: ToolApprova
     setStatus(approved ? "approving" : "denying");
     try {
       const { messageId } = await respond({ threadId, approvalId, approved });
-      await continueAgent({ threadId, messageId });
+      await continueAgent({ threadId, messageId, userTimezone: getBrowserTimezone() });
       if (approved) {
         track("tool_approved", {
           tool_name: toolName,

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,11 +1,6 @@
-/**
- * Returns the browser's IANA timezone (e.g. "America/Los_Angeles"), or
- * undefined if unavailable. Safe to call on the server — returns undefined
- * there. Pass the result to Convex actions that format recency-sensitive
- * coach context so "today"/"yesterday" match the user's local wall clock.
- */
+/** Returns the browser's IANA timezone, or undefined on the server. */
 export function getBrowserTimezone(): string | undefined {
-  if (typeof Intl === "undefined") return undefined;
+  if (typeof window === "undefined") return undefined;
   try {
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     return tz || undefined;

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns the browser's IANA timezone (e.g. "America/Los_Angeles"), or
+ * undefined if unavailable. Safe to call on the server — returns undefined
+ * there. Pass the result to Convex actions that format recency-sensitive
+ * coach context so "today"/"yesterday" match the user's local wall clock.
+ */
+export function getBrowserTimezone(): string | undefined {
+  if (typeof Intl === "undefined") return undefined;
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return tz || undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

- improvements to timezone and validation hardening

## Changes

- added toSessionDuration() validator for 30/45/60 literals.
- replaced blind parseInt(...) as 30|45|60 casts with toSessionDuration() calls.
- computeAge now parses YYYY-MM-DD directly (no UTC/local drift on birthdays).
- getRecencyLabel accepts optional IANA timeZone and compares calendar days via Intl.DateTimeFormat.
- buildTrainingSnapshot threads userTimezone to both getRecencyLabel call sites.
- new getClaimedTonalWorkoutIdsForUser internalQuery; stuck-push recovery now requires title match + createdAt >= plan.createdAt + unclaimed + exactly one candidate (otherwise leaves failed).
- mount ref, error-handled auto-send, error UI, and passes getBrowserTimezone() to createThreadWithMessage.
- passes getBrowserTimezone() to sendMessageToThread.
passes getBrowserTimezone() to continueAfterApproval.
- new getBrowserTimezone() helper wrapping Intl.DateTimeFormat().resolvedOptions().timeZone.

## Checklist

- [X] `npx tsc --noEmit` passes
- [X] `npm run lint` passes
- [X] `npm test` passes (existing + new tests)
- [X]  New logic has tests (happy path + at least one error/edge case)
- [X] No new or materially expanded file exceeds the 300-line soft cap
- [X] No file exceeds the 400-line hard cap (enforced by CI)
- [X] Functions stay near the 60-line convention
- [X] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [X] Tested in browser (if UI changes)
- [X] Commits follow conventional format (`type: description`)
- [X] No unused exports or dead code introduced

## Test Plan

npm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timezone-aware AI coaching with automatic browser timezone detection integrated into chat/coach flows

* **Bug Fixes**
  * More accurate recency labels (today/yesterday) using calendar dates in the user timezone
  * Prevent ambiguous workout-plan linking during recovery; clearer failure handling
  * More robust pagination handling for external API responses

* **Refactor**
  * Centralized session-duration validation

* **Tests**
  * New tests covering timezone handling, recency labeling, age parsing, and session-duration validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->