### PR TITLE
fix: complete backfill after enrichment failures

### DIFF
--- a/convex/tonal/backfillCompletion.test.ts
+++ b/convex/tonal/backfillCompletion.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Id } from "../_generated/dataModel";
+import { finalizeSuccessfulBackfill } from "./backfillCompletion";
+
+const USER_ID = "user_123" as Id<"users">;
+
+describe("finalizeSuccessfulBackfill", () => {
+  it("marks sync complete even when enrichment data fails", async () => {
+    const updateLastSyncedActivityDate = vi.fn().mockResolvedValue(undefined);
+    const syncStrengthOnly = vi.fn().mockResolvedValue(undefined);
+    const persistNewTableData = vi.fn().mockResolvedValue(3);
+    const maybeRefreshProfile = vi.fn().mockResolvedValue(undefined);
+    const updateSyncStatus = vi.fn().mockResolvedValue(undefined);
+    const captureHistorySyncCompleted = vi.fn();
+    const flushAnalytics = vi.fn().mockResolvedValue(undefined);
+    const logWarning = vi.fn();
+
+    await finalizeSuccessfulBackfill(
+      {
+        userId: USER_ID,
+        newestActivityDate: "2026-04-14",
+        newWorkouts: 12,
+      },
+      {
+        updateLastSyncedActivityDate,
+        syncStrengthOnly,
+        persistNewTableData,
+        maybeRefreshProfile,
+        updateSyncStatus,
+        captureHistorySyncCompleted,
+        flushAnalytics,
+        logWarning,
+      },
+    );
+
+    expect(updateLastSyncedActivityDate).toHaveBeenCalledWith({
+      userId: USER_ID,
+      date: "2026-04-14",
+    });
+    expect(syncStrengthOnly).toHaveBeenCalledOnce();
+    expect(persistNewTableData).toHaveBeenCalledOnce();
+    expect(logWarning).toHaveBeenCalledWith(
+      `[historySync] Backfill enrichment completed with 3 failure(s) for user ${USER_ID}`,
+    );
+    expect(maybeRefreshProfile).toHaveBeenCalledOnce();
+    expect(updateSyncStatus).toHaveBeenCalledWith({
+      userId: USER_ID,
+      syncStatus: "complete",
+    });
+    expect(captureHistorySyncCompleted).toHaveBeenCalledWith({
+      new_workouts: 12,
+      backfill: true,
+      enrichment_failures: 3,
+    });
+    expect(flushAnalytics).toHaveBeenCalledOnce();
+  });
+
+  it("skips the date update and warning when there is no newest date and enrichment succeeds", async () => {
+    const updateLastSyncedActivityDate = vi.fn().mockResolvedValue(undefined);
+    const syncStrengthOnly = vi.fn().mockResolvedValue(undefined);
+    const persistNewTableData = vi.fn().mockResolvedValue(0);
+    const maybeRefreshProfile = vi.fn().mockResolvedValue(undefined);
+    const updateSyncStatus = vi.fn().mockResolvedValue(undefined);
+    const captureHistorySyncCompleted = vi.fn();
+    const flushAnalytics = vi.fn().mockResolvedValue(undefined);
+    const logWarning = vi.fn();
+
+    await finalizeSuccessfulBackfill(
+      {
+        userId: USER_ID,
+        newWorkouts: 0,
+      },
+      {
+        updateLastSyncedActivityDate,
+        syncStrengthOnly,
+        persistNewTableData,
+        maybeRefreshProfile,
+        updateSyncStatus,
+        captureHistorySyncCompleted,
+        flushAnalytics,
+        logWarning,
+      },
+    );
+
+    expect(updateLastSyncedActivityDate).not.toHaveBeenCalled();
+    expect(logWarning).not.toHaveBeenCalled();
+    expect(updateSyncStatus).toHaveBeenCalledWith({
+      userId: USER_ID,
+      syncStatus: "complete",
+    });
+    expect(captureHistorySyncCompleted).toHaveBeenCalledWith({
+      new_workouts: 0,
+      backfill: true,
+      enrichment_failures: 0,
+    });
+  });
+});

--- a/convex/tonal/backfillCompletion.ts
+++ b/convex/tonal/backfillCompletion.ts
@@ -1,0 +1,56 @@
+import type { Id } from "../_generated/dataModel";
+
+export interface FinalizeSuccessfulBackfillArgs {
+  userId: Id<"users">;
+  newestActivityDate?: string;
+  newWorkouts: number;
+}
+
+export interface HistorySyncCompletedProps extends Record<string, unknown> {
+  new_workouts: number;
+  backfill: true;
+  enrichment_failures: number;
+}
+
+interface FinalizeSuccessfulBackfillDeps {
+  updateLastSyncedActivityDate: (args: { userId: Id<"users">; date: string }) => Promise<unknown>;
+  syncStrengthOnly: () => Promise<void>;
+  persistNewTableData: () => Promise<number>;
+  maybeRefreshProfile: () => Promise<void>;
+  updateSyncStatus: (args: { userId: Id<"users">; syncStatus: "complete" }) => Promise<unknown>;
+  captureHistorySyncCompleted: (props: HistorySyncCompletedProps) => void;
+  flushAnalytics: () => Promise<void>;
+  logWarning?: (message: string) => void;
+}
+
+export async function finalizeSuccessfulBackfill(
+  args: FinalizeSuccessfulBackfillArgs,
+  deps: FinalizeSuccessfulBackfillDeps,
+): Promise<void> {
+  const { userId, newestActivityDate, newWorkouts } = args;
+
+  if (newestActivityDate) {
+    await deps.updateLastSyncedActivityDate({
+      userId,
+      date: newestActivityDate,
+    });
+  }
+
+  await deps.syncStrengthOnly();
+
+  const enrichmentFailures = await deps.persistNewTableData();
+  if (enrichmentFailures > 0) {
+    deps.logWarning?.(
+      `[historySync] Backfill enrichment completed with ${enrichmentFailures} failure(s) for user ${userId}`,
+    );
+  }
+
+  await deps.maybeRefreshProfile();
+  await deps.updateSyncStatus({ userId, syncStatus: "complete" });
+  deps.captureHistorySyncCompleted({
+    new_workouts: newWorkouts,
+    backfill: true,
+    enrichment_failures: enrichmentFailures,
+  });
+  await deps.flushAnalytics();
+}

--- a/convex/tonal/backfillRunner.test.ts
+++ b/convex/tonal/backfillRunner.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Id } from "../_generated/dataModel";
+import { finalizeSuccessfulBackfill } from "./backfillCompletion";
+import {
+  BACKFILL_BATCH_SIZE,
+  BACKFILL_CONTINUATION_DELAY_MS,
+  BACKFILL_MAX_RETRIES,
+  backfillUserHistoryWithDeps,
+} from "./backfillRunner";
+import type { Activity } from "./types";
+
+const USER_ID = "user_123" as Id<"users">;
+
+function buildActivity(activityId: string, activityTime: string): Activity {
+  return {
+    activityId,
+    userId: "tonal-user-1",
+    activityTime,
+    activityType: "workout",
+    workoutPreview: {
+      activityId,
+      workoutId: `workout-${activityId}`,
+      workoutTitle: `Workout ${activityId}`,
+      programName: "12 Weeks to Unleash",
+      coachName: "Coach",
+      level: "advanced",
+      targetArea: "Upper Body",
+      isGuidedWorkout: true,
+      workoutType: "WEIGHTS",
+      beginTime: activityTime,
+      totalDuration: 1800,
+      totalVolume: 5000,
+      totalWork: 1000,
+      totalAchievements: 0,
+      activityType: "workout",
+    },
+  };
+}
+
+describe("backfillUserHistoryWithDeps", () => {
+  it("completes the backfill when enrichment partially fails", async () => {
+    const syncStatusWrites: string[] = [];
+    const setSyncingStatus = vi.fn(async () => {
+      syncStatusWrites.push("syncing");
+    });
+    const fetchWorkoutHistoryPage = vi.fn().mockResolvedValue({
+      activities: [
+        buildActivity("a1", "2026-04-13T08:00:00Z"),
+        buildActivity("a2", "2026-04-14T08:00:00Z"),
+      ],
+      pageSize: 2,
+      pgTotal: 2,
+    });
+    const syncActivitiesAndStrength = vi.fn().mockResolvedValue({
+      synced: 2,
+      remaining: 0,
+    });
+    const scheduleBackfill = vi.fn().mockResolvedValue(undefined);
+    const updateLastSyncedActivityDate = vi.fn().mockResolvedValue(undefined);
+    const syncStrengthOnly = vi.fn().mockResolvedValue(undefined);
+    const persistNewTableData = vi.fn().mockResolvedValue(3);
+    const maybeRefreshProfile = vi.fn().mockResolvedValue(undefined);
+    const updateSyncStatus = vi.fn(async ({ syncStatus }: { syncStatus: "complete" }) => {
+      syncStatusWrites.push(syncStatus);
+    });
+    const captureHistorySyncCompleted = vi.fn();
+    const flushAnalytics = vi.fn().mockResolvedValue(undefined);
+    const logWarning = vi.fn();
+    const markFailed = vi.fn().mockResolvedValue(undefined);
+    const notifyBackfillFailed = vi.fn().mockResolvedValue(undefined);
+    const logInfo = vi.fn();
+    const logError = vi.fn();
+
+    const result = await backfillUserHistoryWithDeps(
+      {
+        userId: USER_ID,
+      },
+      {
+        setSyncingStatus,
+        fetchWorkoutHistoryPage,
+        syncActivitiesAndStrength,
+        scheduleBackfill,
+        finalizeSuccessfulBackfill: (args) =>
+          finalizeSuccessfulBackfill(args, {
+            updateLastSyncedActivityDate,
+            syncStrengthOnly,
+            persistNewTableData,
+            maybeRefreshProfile,
+            updateSyncStatus,
+            captureHistorySyncCompleted,
+            flushAnalytics,
+            logWarning,
+          }),
+        markFailed,
+        notifyBackfillFailed,
+        logInfo,
+        logError,
+      },
+    );
+
+    expect(result).toEqual({ newWorkouts: 2, totalActivities: 2 });
+    expect(setSyncingStatus).toHaveBeenCalledOnce();
+    expect(fetchWorkoutHistoryPage).toHaveBeenCalledWith({ userId: USER_ID, offset: 0 });
+    expect(syncActivitiesAndStrength).toHaveBeenCalledWith(
+      [buildActivity("a1", "2026-04-13T08:00:00Z"), buildActivity("a2", "2026-04-14T08:00:00Z")],
+      BACKFILL_BATCH_SIZE,
+    );
+    expect(updateLastSyncedActivityDate).toHaveBeenCalledWith({
+      userId: USER_ID,
+      date: "2026-04-14",
+    });
+    expect(logWarning).toHaveBeenCalledWith(
+      `[historySync] Backfill enrichment completed with 3 failure(s) for user ${USER_ID}`,
+    );
+    expect(syncStatusWrites).toEqual(["syncing", "complete"]);
+    expect(captureHistorySyncCompleted).toHaveBeenCalledWith({
+      new_workouts: 2,
+      backfill: true,
+      enrichment_failures: 3,
+    });
+    expect(scheduleBackfill).not.toHaveBeenCalled();
+    expect(markFailed).not.toHaveBeenCalled();
+    expect(notifyBackfillFailed).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("schedules a continuation when the current page still has remaining workouts", async () => {
+    const setSyncingStatus = vi.fn().mockResolvedValue(undefined);
+    const fetchWorkoutHistoryPage = vi.fn().mockResolvedValue({
+      activities: [buildActivity("a1", "2026-04-14T08:00:00Z")],
+      pageSize: 200,
+      pgTotal: 200,
+    });
+    const syncActivitiesAndStrength = vi.fn().mockResolvedValue({
+      synced: 20,
+      remaining: 4,
+    });
+    const scheduleBackfill = vi.fn().mockResolvedValue(undefined);
+    const finalizeBackfill = vi.fn().mockResolvedValue(undefined);
+    const markFailed = vi.fn().mockResolvedValue(undefined);
+    const notifyBackfillFailed = vi.fn().mockResolvedValue(undefined);
+
+    const result = await backfillUserHistoryWithDeps(
+      {
+        userId: USER_ID,
+      },
+      {
+        setSyncingStatus,
+        fetchWorkoutHistoryPage,
+        syncActivitiesAndStrength,
+        scheduleBackfill,
+        finalizeSuccessfulBackfill: finalizeBackfill,
+        markFailed,
+        notifyBackfillFailed,
+      },
+    );
+
+    expect(result).toEqual({ newWorkouts: 20, totalActivities: 200 });
+    expect(scheduleBackfill).toHaveBeenCalledWith(BACKFILL_CONTINUATION_DELAY_MS, {
+      userId: USER_ID,
+      retryCount: 0,
+      pgOffset: 0,
+      newestActivityDate: "2026-04-14",
+    });
+    expect(finalizeBackfill).not.toHaveBeenCalled();
+    expect(markFailed).not.toHaveBeenCalled();
+    expect(notifyBackfillFailed).not.toHaveBeenCalled();
+  });
+
+  it("marks the sync failed and swallows notification errors after the last retry", async () => {
+    const fetchError = new Error("Tonal unavailable");
+    const notifyError = new Error("Discord unavailable");
+    const setSyncingStatus = vi.fn().mockResolvedValue(undefined);
+    const fetchWorkoutHistoryPage = vi.fn().mockRejectedValue(fetchError);
+    const syncActivitiesAndStrength = vi.fn().mockResolvedValue({
+      synced: 0,
+      remaining: 0,
+    });
+    const scheduleBackfill = vi.fn().mockResolvedValue(undefined);
+    const finalizeBackfill = vi.fn().mockResolvedValue(undefined);
+    const markFailed = vi.fn().mockResolvedValue(undefined);
+    const notifyBackfillFailed = vi.fn().mockRejectedValue(notifyError);
+    const logError = vi.fn();
+
+    const result = await backfillUserHistoryWithDeps(
+      {
+        userId: USER_ID,
+        retryCount: BACKFILL_MAX_RETRIES,
+      },
+      {
+        setSyncingStatus,
+        fetchWorkoutHistoryPage,
+        syncActivitiesAndStrength,
+        scheduleBackfill,
+        finalizeSuccessfulBackfill: finalizeBackfill,
+        markFailed,
+        notifyBackfillFailed,
+        logError,
+      },
+    );
+
+    await Promise.resolve();
+
+    expect(result).toEqual({ newWorkouts: 0, totalActivities: 0 });
+    expect(setSyncingStatus).not.toHaveBeenCalled();
+    expect(scheduleBackfill).not.toHaveBeenCalled();
+    expect(finalizeBackfill).not.toHaveBeenCalled();
+    expect(markFailed).toHaveBeenCalledOnce();
+    expect(notifyBackfillFailed).toHaveBeenCalledWith(
+      `Backfill failed after ${BACKFILL_MAX_RETRIES + 1} attempts for user ${USER_ID}: ${fetchError.message}`,
+    );
+    expect(logError).toHaveBeenNthCalledWith(
+      1,
+      `[historySync] Backfill failed (attempt ${BACKFILL_MAX_RETRIES + 1})`,
+      fetchError,
+    );
+    expect(logError).toHaveBeenNthCalledWith(
+      2,
+      "[historySync] Backfill failure notification failed",
+      notifyError,
+    );
+  });
+});

--- a/convex/tonal/backfillRunner.ts
+++ b/convex/tonal/backfillRunner.ts
@@ -1,0 +1,141 @@
+import type { Id } from "../_generated/dataModel";
+import type { FinalizeSuccessfulBackfillArgs } from "./backfillCompletion";
+import type { Activity } from "./types";
+
+export const BACKFILL_MAX_RETRIES = 3;
+export const BACKFILL_RETRY_DELAYS = [30_000, 60_000, 120_000];
+export const BACKFILL_BATCH_SIZE = 20;
+export const BACKFILL_CONTINUATION_DELAY_MS = 5_000;
+
+export interface BackfillUserHistoryArgs {
+  userId: Id<"users">;
+  retryCount?: number;
+  pgOffset?: number;
+  newestActivityDate?: string;
+}
+
+interface WorkoutHistoryPage {
+  activities: Activity[];
+  pageSize: number;
+  pgTotal: number;
+}
+
+interface ScheduledBackfillArgs {
+  userId: Id<"users">;
+  retryCount: number;
+  pgOffset: number;
+  newestActivityDate?: string;
+}
+
+interface BackfillUserHistoryDeps {
+  setSyncingStatus: () => Promise<unknown>;
+  fetchWorkoutHistoryPage: (args: {
+    userId: Id<"users">;
+    offset: number;
+  }) => Promise<WorkoutHistoryPage>;
+  syncActivitiesAndStrength: (
+    activities: Activity[],
+    maxNew: number,
+  ) => Promise<{ synced: number; remaining: number }>;
+  scheduleBackfill: (delayMs: number, args: ScheduledBackfillArgs) => Promise<unknown>;
+  finalizeSuccessfulBackfill: (args: FinalizeSuccessfulBackfillArgs) => Promise<void>;
+  markFailed: () => Promise<unknown>;
+  notifyBackfillFailed: (message: string) => Promise<unknown> | void;
+  logInfo?: (message: string) => void;
+  logError?: (message: string, error: unknown) => void;
+}
+
+export async function backfillUserHistoryWithDeps(
+  args: BackfillUserHistoryArgs,
+  deps: BackfillUserHistoryDeps,
+): Promise<{ newWorkouts: number; totalActivities: number }> {
+  const retryCount = args.retryCount ?? 0;
+  const pgOffset = args.pgOffset ?? 0;
+
+  if (retryCount === 0 && pgOffset === 0) {
+    await deps.setSyncingStatus();
+  }
+
+  try {
+    const { activities, pageSize, pgTotal } = await deps.fetchWorkoutHistoryPage({
+      userId: args.userId,
+      offset: pgOffset,
+    });
+
+    const { synced, remaining } =
+      activities.length > 0
+        ? await deps.syncActivitiesAndStrength(activities, BACKFILL_BATCH_SIZE)
+        : { synced: 0, remaining: 0 };
+
+    const pageNewestDate =
+      activities.length > 0
+        ? activities[activities.length - 1].activityTime.slice(0, 10)
+        : undefined;
+    const bestDate = pageNewestDate ?? args.newestActivityDate;
+
+    if (remaining > 0) {
+      deps.logInfo?.(
+        `[historySync] Backfill page offset=${pgOffset}: ${synced} synced, ${remaining} remaining`,
+      );
+      await deps.scheduleBackfill(BACKFILL_CONTINUATION_DELAY_MS, {
+        userId: args.userId,
+        retryCount,
+        pgOffset,
+        newestActivityDate: bestDate,
+      });
+      return { newWorkouts: synced, totalActivities: pgTotal };
+    }
+
+    const nextOffset = pgOffset + pageSize;
+    if (nextOffset < pgTotal) {
+      deps.logInfo?.(
+        `[historySync] Backfill page offset=${pgOffset}: ${synced} synced, advancing to offset=${nextOffset}/${pgTotal}`,
+      );
+      await deps.scheduleBackfill(BACKFILL_CONTINUATION_DELAY_MS, {
+        userId: args.userId,
+        retryCount,
+        pgOffset: nextOffset,
+        newestActivityDate: bestDate,
+      });
+      return { newWorkouts: synced, totalActivities: pgTotal };
+    }
+
+    await deps.finalizeSuccessfulBackfill({
+      userId: args.userId,
+      newestActivityDate: bestDate,
+      newWorkouts: synced,
+    });
+    deps.logInfo?.(`[historySync] Backfill complete for user ${args.userId} (${pgTotal} total)`);
+
+    return { newWorkouts: synced, totalActivities: pgTotal };
+  } catch (err) {
+    deps.logError?.(`[historySync] Backfill failed (attempt ${retryCount + 1})`, err);
+
+    if (retryCount < BACKFILL_MAX_RETRIES) {
+      const delay = BACKFILL_RETRY_DELAYS[retryCount] ?? 120_000;
+      await deps.scheduleBackfill(delay, {
+        userId: args.userId,
+        retryCount: retryCount + 1,
+        pgOffset,
+        newestActivityDate: args.newestActivityDate,
+      });
+      return { newWorkouts: 0, totalActivities: 0 };
+    }
+
+    await deps.markFailed();
+    const failureMessage = `Backfill failed after ${BACKFILL_MAX_RETRIES + 1} attempts for user ${args.userId}: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+
+    try {
+      const notifyResult = deps.notifyBackfillFailed(failureMessage);
+      void Promise.resolve(notifyResult).catch((notifyErr) => {
+        deps.logError?.("[historySync] Backfill failure notification failed", notifyErr);
+      });
+    } catch (notifyErr) {
+      deps.logError?.("[historySync] Backfill failure notification failed", notifyErr);
+    }
+
+    return { newWorkouts: 0, totalActivities: 0 };
+  }
+}

--- a/convex/tonal/historySync.test.ts
+++ b/convex/tonal/historySync.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getFunctionName } from "convex/server";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { ActionCtx } from "../_generated/server";
+import * as analytics from "../lib/posthog";
+import { backfillUserHistoryHandler } from "./historySync";
+import type { StrengthScore } from "./types";
+
+vi.mock("../lib/posthog", () => ({
+  capture: vi.fn(),
+  flush: vi.fn().mockResolvedValue(undefined),
+}));
+
+const USER_ID = "user_123" as Id<"users">;
+const FUNCTION_NAMES = {
+  fetchWorkoutHistoryPage: getFunctionName(
+    internal.tonal.workoutHistoryProxy.fetchWorkoutHistoryPage,
+  ),
+  fetchStrengthHistory: getFunctionName(internal.tonal.proxy.fetchStrengthHistory),
+  fetchStrengthScores: getFunctionName(internal.tonal.proxy.fetchStrengthScores),
+  fetchMuscleReadiness: getFunctionName(internal.tonal.proxy.fetchMuscleReadiness),
+  fetchExternalActivities: getFunctionName(internal.tonal.proxy.fetchExternalActivities),
+  updateSyncStatus: getFunctionName(internal.userProfiles.updateSyncStatus),
+  persistCurrentStrengthScores: getFunctionName(
+    internal.tonal.historySyncMutations.persistCurrentStrengthScores,
+  ),
+  getByUserId: getFunctionName(internal.userProfiles.getByUserId),
+};
+
+describe("backfillUserHistoryHandler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("marks the real backfill action complete when enrichment partially fails", async () => {
+    const strengthScores: StrengthScore[] = [
+      {
+        id: "score-1",
+        userId: "tonal-user-1",
+        strengthBodyRegion: "upper",
+        bodyRegionDisplay: "Upper",
+        score: 109,
+        current: true,
+      },
+    ];
+    const syncStatusWrites: string[] = [];
+    const runAfter = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const runAction = vi.fn(async (ref: unknown) => {
+      const functionName = getFunctionName(ref as Parameters<typeof getFunctionName>[0]);
+
+      if (functionName === FUNCTION_NAMES.fetchWorkoutHistoryPage) {
+        return { activities: [], pageSize: 0, pgTotal: 0 };
+      }
+      if (functionName === FUNCTION_NAMES.fetchStrengthHistory) {
+        return [];
+      }
+      if (functionName === FUNCTION_NAMES.fetchStrengthScores) {
+        return strengthScores;
+      }
+      if (functionName === FUNCTION_NAMES.fetchMuscleReadiness) {
+        throw new Error("Muscle readiness unavailable");
+      }
+      if (functionName === FUNCTION_NAMES.fetchExternalActivities) {
+        return [];
+      }
+      throw new Error(`Unexpected action reference: ${functionName}`);
+    });
+    const runMutation = vi.fn(async (ref: unknown, args: unknown) => {
+      if (
+        getFunctionName(ref as Parameters<typeof getFunctionName>[0]) ===
+        FUNCTION_NAMES.updateSyncStatus
+      ) {
+        syncStatusWrites.push((args as { syncStatus: string }).syncStatus);
+      }
+      return null;
+    });
+    const runQuery = vi.fn(async (ref: unknown) => {
+      if (
+        getFunctionName(ref as Parameters<typeof getFunctionName>[0]) === FUNCTION_NAMES.getByUserId
+      ) {
+        return { profileDataRefreshedAt: Date.now() };
+      }
+      throw new Error(
+        `Unexpected query reference: ${getFunctionName(ref as Parameters<typeof getFunctionName>[0])}`,
+      );
+    });
+    const ctx = {
+      runAction,
+      runMutation,
+      runQuery,
+      scheduler: { runAfter },
+    } as unknown as ActionCtx;
+
+    const result = await backfillUserHistoryHandler(ctx, {
+      userId: USER_ID,
+    });
+
+    expect(result).toEqual({ newWorkouts: 0, totalActivities: 0 });
+    expect(syncStatusWrites).toEqual(["syncing", "complete"]);
+    expect(runAfter).not.toHaveBeenCalled();
+    const persistStrengthScoresCall = runMutation.mock.calls.find(
+      ([ref]) =>
+        getFunctionName(ref as Parameters<typeof getFunctionName>[0]) ===
+        FUNCTION_NAMES.persistCurrentStrengthScores,
+    );
+    expect(persistStrengthScoresCall?.[1]).toEqual({
+      userId: USER_ID,
+      scores: [{ bodyRegion: "Upper", score: 109 }],
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[historySync] Muscle readiness fetch failed",
+      expect.any(Error),
+    );
+    expect(consoleWarn).toHaveBeenCalledWith(
+      `[historySync] Backfill enrichment completed with 1 failure(s) for user ${USER_ID}`,
+    );
+    expect(analytics.capture).toHaveBeenCalledWith(USER_ID, "history_sync_completed", {
+      new_workouts: 0,
+      backfill: true,
+      enrichment_failures: 1,
+    });
+    expect(analytics.flush).toHaveBeenCalledOnce();
+  });
+});

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -20,6 +20,8 @@ import type {
 import type { performanceValidator, workoutValidator } from "./historySyncMutations";
 import { toUserProfileData } from "./profileData";
 import { persistNewTableData } from "./enrichmentSync";
+import { finalizeSuccessfulBackfill } from "./backfillCompletion";
+import { type BackfillUserHistoryArgs, backfillUserHistoryWithDeps } from "./backfillRunner";
 import * as analytics from "../lib/posthog";
 
 type WorkoutPayload = typeof workoutValidator.type;
@@ -261,13 +263,64 @@ export const syncUserHistory = internalAction({
   },
 });
 
-const BACKFILL_MAX_RETRIES = 3;
-const BACKFILL_RETRY_DELAYS = [30_000, 60_000, 120_000];
-const BACKFILL_BATCH_SIZE = 20;
-const BACKFILL_CONTINUATION_DELAY_MS = 5_000;
-
 /** Page-by-page backfill. Each invocation fetches one API page (200 items),
  *  diffs against DB, processes up to 20 new workouts, then continues. */
+export async function backfillUserHistoryHandler(
+  ctx: ActionCtx,
+  { userId, retryCount = 0, pgOffset = 0, newestActivityDate }: BackfillUserHistoryArgs,
+): Promise<{ newWorkouts: number; totalActivities: number }> {
+  return backfillUserHistoryWithDeps(
+    {
+      userId,
+      retryCount,
+      pgOffset,
+      newestActivityDate,
+    },
+    {
+      setSyncingStatus: () =>
+        ctx.runMutation(internal.userProfiles.updateSyncStatus, {
+          userId,
+          syncStatus: "syncing",
+        }),
+      fetchWorkoutHistoryPage: ({ userId, offset }) =>
+        ctx.runAction(internal.tonal.workoutHistoryProxy.fetchWorkoutHistoryPage, {
+          userId,
+          offset,
+        }) as Promise<{ activities: Activity[]; pageSize: number; pgTotal: number }>,
+      syncActivitiesAndStrength: (activities, maxNew) =>
+        syncActivitiesAndStrength(ctx, userId, activities, maxNew),
+      scheduleBackfill: (delayMs, args) =>
+        ctx.scheduler.runAfter(delayMs, internal.tonal.historySync.backfillUserHistory, args),
+      finalizeSuccessfulBackfill: (args) =>
+        finalizeSuccessfulBackfill(args, {
+          updateLastSyncedActivityDate: (args) =>
+            ctx.runMutation(internal.userProfiles.updateLastSyncedActivityDate, args),
+          syncStrengthOnly: () => syncStrengthOnly(ctx, userId),
+          persistNewTableData: () => persistNewTableData(ctx, userId),
+          maybeRefreshProfile: () => maybeRefreshProfile(ctx, userId),
+          updateSyncStatus: (args) => ctx.runMutation(internal.userProfiles.updateSyncStatus, args),
+          captureHistorySyncCompleted: (props) =>
+            analytics.capture(userId, "history_sync_completed", props),
+          flushAnalytics: () => analytics.flush(),
+          logWarning: (message) => console.warn(message),
+        }),
+      markFailed: () =>
+        ctx.runMutation(internal.userProfiles.updateSyncStatus, {
+          userId,
+          syncStatus: "failed",
+        }),
+      notifyBackfillFailed: (message) =>
+        ctx.runAction(internal.discord.notifyError, {
+          source: "backfillUserHistory",
+          message,
+          userId,
+        }),
+      logInfo: (message) => console.log(message),
+      logError: (message, error) => console.error(message, error),
+    },
+  );
+}
+
 export const backfillUserHistory = internalAction({
   args: {
     userId: v.id("users"),
@@ -275,108 +328,5 @@ export const backfillUserHistory = internalAction({
     pgOffset: v.optional(v.number()),
     newestActivityDate: v.optional(v.string()),
   },
-  handler: async (
-    ctx,
-    { userId, retryCount = 0, pgOffset = 0, newestActivityDate },
-  ): Promise<{ newWorkouts: number; totalActivities: number }> => {
-    if (retryCount === 0 && pgOffset === 0) {
-      await ctx.runMutation(internal.userProfiles.updateSyncStatus, {
-        userId,
-        syncStatus: "syncing",
-      });
-    }
-
-    try {
-      const { activities, pageSize, pgTotal } = (await ctx.runAction(
-        internal.tonal.workoutHistoryProxy.fetchWorkoutHistoryPage,
-        { userId, offset: pgOffset },
-      )) as { activities: Activity[]; pageSize: number; pgTotal: number };
-
-      const { synced, remaining } =
-        activities.length > 0
-          ? await syncActivitiesAndStrength(ctx, userId, activities, BACKFILL_BATCH_SIZE)
-          : { synced: 0, remaining: 0 };
-
-      // Track the newest date seen across all pages (API returns oldest-first)
-      const pageNewestDate =
-        activities.length > 0
-          ? activities[activities.length - 1].activityTime.slice(0, 10)
-          : undefined;
-      const bestDate = pageNewestDate ?? newestActivityDate;
-
-      // More new workouts on this page to process
-      if (remaining > 0) {
-        console.log(
-          `[historySync] Backfill page offset=${pgOffset}: ${synced} synced, ${remaining} remaining`,
-        );
-        await ctx.scheduler.runAfter(
-          BACKFILL_CONTINUATION_DELAY_MS,
-          internal.tonal.historySync.backfillUserHistory,
-          { userId, retryCount, pgOffset, newestActivityDate: bestDate },
-        );
-        return { newWorkouts: synced, totalActivities: pgTotal };
-      }
-
-      // More pages to fetch (use raw pageSize, not filtered activities.length)
-      const nextOffset = pgOffset + pageSize;
-      if (nextOffset < pgTotal) {
-        console.log(
-          `[historySync] Backfill page offset=${pgOffset}: ${synced} synced, advancing to offset=${nextOffset}/${pgTotal}`,
-        );
-        await ctx.scheduler.runAfter(
-          BACKFILL_CONTINUATION_DELAY_MS,
-          internal.tonal.historySync.backfillUserHistory,
-          { userId, retryCount, pgOffset: nextOffset, newestActivityDate: bestDate },
-        );
-        return { newWorkouts: synced, totalActivities: pgTotal };
-      }
-
-      // All pages processed - finalize
-      if (bestDate) {
-        await ctx.runMutation(internal.userProfiles.updateLastSyncedActivityDate, {
-          userId,
-          date: bestDate,
-        });
-      }
-      await syncStrengthOnly(ctx, userId);
-      const enrichmentFailures = await persistNewTableData(ctx, userId);
-      await maybeRefreshProfile(ctx, userId);
-      await ctx.runMutation(internal.userProfiles.updateSyncStatus, {
-        userId,
-        syncStatus: enrichmentFailures >= 3 ? "failed" : "complete",
-      });
-
-      console.log(`[historySync] Backfill complete for user ${userId} (${pgTotal} total)`);
-      analytics.capture(userId, "history_sync_completed", { new_workouts: synced, backfill: true });
-      await analytics.flush();
-
-      return { newWorkouts: synced, totalActivities: pgTotal };
-    } catch (err) {
-      console.error(`[historySync] Backfill failed (attempt ${retryCount + 1})`, err);
-
-      if (retryCount < BACKFILL_MAX_RETRIES) {
-        const delay = BACKFILL_RETRY_DELAYS[retryCount] ?? 120_000;
-        await ctx.scheduler.runAfter(delay, internal.tonal.historySync.backfillUserHistory, {
-          userId,
-          retryCount: retryCount + 1,
-          pgOffset,
-          newestActivityDate,
-        });
-        return { newWorkouts: 0, totalActivities: 0 };
-      }
-
-      await ctx.runMutation(internal.userProfiles.updateSyncStatus, {
-        userId,
-        syncStatus: "failed",
-      });
-
-      void ctx.runAction(internal.discord.notifyError, {
-        source: "backfillUserHistory",
-        message: `Backfill failed after ${BACKFILL_MAX_RETRIES + 1} attempts for user ${userId}: ${err instanceof Error ? err.message : String(err)}`,
-        userId,
-      });
-
-      return { newWorkouts: 0, totalActivities: 0 };
-    }
-  },
+  handler: async (ctx, args) => backfillUserHistoryHandler(ctx, args),
 });


### PR DESCRIPTION
## Summary

- Keep workout-history backfills marked complete even when enrichment fetches fail independently.
- Extract the backfill orchestration into focused helpers so the completion and retry behavior are easier to test.
- Add regression coverage for successful completion, continuation, exhausted retries, and real action wiring.

## Changes

- Split backfill finalization into `backfillCompletion.ts` so successful backfills always write `syncStatus: "complete"` and record `enrichment_failures` separately.
- Move the page-by-page backfill control flow into `backfillRunner.ts`, including best-effort Discord notification on terminal failure.
- Add focused tests for completion semantics, exhausted retries with a failing notifier, and the real `historySync` action wiring.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [x] New logic has tests (happy path + at least one error/edge case)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [x] Tested in browser (if UI changes)
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- Run `npm run typecheck`.
- Run `npm run lint`.
- Run `npm test`.
- Run `npx vitest run convex/tonal/backfillCompletion.test.ts convex/tonal/backfillRunner.test.ts convex/tonal/historySync.test.ts` to verify successful completion with enrichment failures, exhausted retries with notifier failure, and real action wiring.