### PR TITLE
fix: improve tonalCache cleanup with index and daily cadence

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -51,7 +51,7 @@ if (cronsEnabled()) {
 
   crons.interval("vacuum-unused-files", { hours: 6 }, internal.fileGc.vacuumUnusedFiles);
 
-  crons.cron("data-retention", "0 2 * * 0", internal.dataRetention.runDataRetention, {});
+  crons.cron("data-retention", "0 2 * * *", internal.dataRetention.runDataRetention, {});
 }
 
 export default crons;

--- a/convex/dataRetention.ts
+++ b/convex/dataRetention.ts
@@ -50,7 +50,7 @@ export const getExpiredCacheIds = internalQuery({
   handler: async (ctx, { cutoff, limit }) => {
     const records = await ctx.db
       .query("tonalCache")
-      .filter((q) => q.lt(q.field("expiresAt"), cutoff))
+      .withIndex("by_expiresAt", (q) => q.lt("expiresAt", cutoff))
       .take(limit);
     return records.map((r) => r._id);
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -153,7 +153,8 @@ export default defineSchema({
     expiresAt: v.number(),
   })
     .index("by_userId_dataType", ["userId", "dataType"])
-    .index("by_dataType", ["dataType"]),
+    .index("by_dataType", ["dataType"])
+    .index("by_expiresAt", ["expiresAt"]),
 
   /** Tonal exercise catalog (synced daily at 3 AM from Tonal API). */
   movements: defineTable({


### PR DESCRIPTION
## Summary

- Per-resource cache keys (`workoutMeta:<id>`, `workoutDetail:<id>`, etc.) cause the `tonalCache` table to grow unbounded for active users (reported: 2000+ docs, ~800MB)
- Adds a `by_expiresAt` index so cleanup queries use an index scan instead of a full table scan
- Increases data-retention cron from weekly to daily to prevent multi-day accumulation of expired entries

Closes #164

## Changes

- **convex/schema.ts** - Added `by_expiresAt` index on `tonalCache`
- **convex/dataRetention.ts** - Switched `getExpiredCacheIds` from `.filter()` to `.withIndex("by_expiresAt")`
- **convex/crons.ts** - Changed data-retention cron from `0 2 * * 0` (weekly Sunday) to `0 2 * * *` (daily)

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [ ] New logic has tests (happy path + at least one error/edge case) - N/A, no new logic
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [ ] Tested in browser (if UI changes) - N/A, backend only
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- Type-check passes
- Existing `dataRetention.test.ts` passes (3/3)
- Index correctness will be validated by Convex on deploy (schema migration)
- Cron frequency change is a config-only change