### PR TITLE
feat: added check in step to onboarding

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -67,6 +67,7 @@ import type * as injuries from "../injuries.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_env from "../lib/env.js";
 import type * as lib_posthog from "../lib/posthog.js";
+import type * as lib_targetArea from "../lib/targetArea.js";
 import type * as libraryWorkouts from "../libraryWorkouts.js";
 import type * as migrations_rotateTokenEncryptionKey from "../migrations/rotateTokenEncryptionKey.js";
 import type * as progressiveOverload from "../progressiveOverload.js";
@@ -186,6 +187,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/env": typeof lib_env;
   "lib/posthog": typeof lib_posthog;
+  "lib/targetArea": typeof lib_targetArea;
   libraryWorkouts: typeof libraryWorkouts;
   "migrations/rotateTokenEncryptionKey": typeof migrations_rotateTokenEncryptionKey;
   progressiveOverload: typeof progressiveOverload;

--- a/convex/dashboard.ts
+++ b/convex/dashboard.ts
@@ -1,6 +1,7 @@
 import { action, mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { getEffectiveUserId } from "./lib/auth";
+import { normalizeTargetArea } from "./lib/targetArea";
 import type { MuscleReadiness, StrengthDistribution, StrengthScore } from "./tonal/types";
 
 // ---------------------------------------------------------------------------
@@ -121,15 +122,6 @@ export const getWorkoutHistory = query({
       }));
   },
 });
-
-function normalizeTargetArea(area: string): string {
-  return area
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((w) => w[0].toUpperCase() + w.slice(1))
-    .join(" ");
-}
 
 // ---------------------------------------------------------------------------
 // 4. getTrainingFrequency -- query from sync table (last 30 days)

--- a/convex/dashboard.ts
+++ b/convex/dashboard.ts
@@ -122,6 +122,15 @@ export const getWorkoutHistory = query({
   },
 });
 
+function normalizeTargetArea(area: string): string {
+  return area
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
 // ---------------------------------------------------------------------------
 // 4. getTrainingFrequency -- query from sync table (last 30 days)
 // ---------------------------------------------------------------------------
@@ -145,8 +154,8 @@ export const getTrainingFrequency = query({
     const lastDates: Record<string, string> = {};
 
     for (const row of rows) {
-      const area = row.targetArea;
-      if (!area) continue;
+      if (!row.targetArea) continue;
+      const area = normalizeTargetArea(row.targetArea);
       counts[area] = (counts[area] ?? 0) + 1;
       if (!lastDates[area] || row.date > lastDates[area]) {
         lastDates[area] = row.date;

--- a/convex/lib/targetArea.test.ts
+++ b/convex/lib/targetArea.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTargetArea } from "./targetArea";
+
+describe("normalizeTargetArea", () => {
+  it("title-cases a lowercase string", () => {
+    expect(normalizeTargetArea("upper body")).toBe("Upper Body");
+  });
+
+  it("normalizes all-caps input", () => {
+    expect(normalizeTargetArea("LOWER BODY")).toBe("Lower Body");
+  });
+
+  it("handles mixed case", () => {
+    expect(normalizeTargetArea("full BODY")).toBe("Full Body");
+  });
+
+  it("collapses extra whitespace", () => {
+    expect(normalizeTargetArea("  upper   body  ")).toBe("Upper Body");
+  });
+
+  it("handles single word", () => {
+    expect(normalizeTargetArea("core")).toBe("Core");
+  });
+});

--- a/convex/lib/targetArea.test.ts
+++ b/convex/lib/targetArea.test.ts
@@ -21,4 +21,9 @@ describe("normalizeTargetArea", () => {
   it("handles single word", () => {
     expect(normalizeTargetArea("core")).toBe("Core");
   });
+
+  it("returns Unknown for whitespace-only input", () => {
+    expect(normalizeTargetArea("   ")).toBe("Unknown");
+    expect(normalizeTargetArea("")).toBe("Unknown");
+  });
 });

--- a/convex/lib/targetArea.ts
+++ b/convex/lib/targetArea.ts
@@ -1,0 +1,8 @@
+export function normalizeTargetArea(area: string): string {
+  return area
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/convex/lib/targetArea.ts
+++ b/convex/lib/targetArea.ts
@@ -1,8 +1,9 @@
 export function normalizeTargetArea(area: string): string {
-  return area
+  const trimmed = area.trim();
+  if (!trimmed) return "Unknown";
+  return trimmed
     .toLowerCase()
     .split(/\s+/)
-    .filter(Boolean)
     .map((w) => w[0].toUpperCase() + w.slice(1))
     .join(" ");
 }

--- a/convex/stats.ts
+++ b/convex/stats.ts
@@ -1,5 +1,6 @@
 import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
+import { normalizeTargetArea } from "./lib/targetArea";
 import type { Activity, StrengthScoreHistoryEntry } from "./tonal/types";
 
 // ---------------------------------------------------------------------------
@@ -55,7 +56,8 @@ export function computeProgressMetrics(activities: readonly Activity[]): Progres
     totalVolume += preview.totalVolume;
     totalDuration += preview.totalDuration;
 
-    const area = preview.targetArea ?? "Unknown";
+    const rawArea = preview.targetArea;
+    const area = rawArea ? normalizeTargetArea(rawArea) : "Unknown";
     workoutsByTargetArea[area] = (workoutsByTargetArea[area] ?? 0) + 1;
   }
 

--- a/convex/tonal/resync.ts
+++ b/convex/tonal/resync.ts
@@ -12,10 +12,13 @@ import type { ActionCtx } from "../_generated/server";
 import { internalAction, internalQuery } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
+import { TONAL_REFRESH_CACHE_KEYS } from "./refresh";
 
-/** Cache keys to clear before a resync (old per-limit keys + current key). */
+/** Cache keys to clear before a resync. Includes the full refresh set
+ *  (profile, strength, readiness, current history) plus legacy per-limit
+ *  workout-history keys that may still linger in older deployments. */
 const STALE_CACHE_KEYS = [
-  "workoutHistory_v3",
+  ...TONAL_REFRESH_CACHE_KEYS,
   "workoutHistory_v3_full",
   "workoutHistory_v2",
   "workoutHistory_v2:1",

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -23,6 +23,7 @@ export const getMe = query({
       email: user?.email as string | undefined,
       hasTonalProfile: !!profile,
       onboardingCompleted: !!profile?.onboardingData?.completedAt,
+      hasCheckInPreferences: !!profile?.checkInPreferences,
       tonalName: profile?.profileData
         ? `${profile.profileData.firstName} ${profile.profileData.lastName}`
         : undefined,

--- a/src/app/onboarding/CheckInsStep.tsx
+++ b/src/app/onboarding/CheckInsStep.tsx
@@ -18,7 +18,7 @@ type Frequency = (typeof FREQUENCY_OPTIONS)[number]["value"];
 
 export function CheckInsStep({ onComplete }: { readonly onComplete: () => void }) {
   const [enabled, setEnabled] = useState(true);
-  const [frequency, setFrequency] = useState<Frequency>("every_other_day");
+  const [frequency, setFrequency] = useState<Frequency>("daily");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/app/onboarding/CheckInsStep.tsx
+++ b/src/app/onboarding/CheckInsStep.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Bell, BellOff, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const FREQUENCY_OPTIONS = [
+  { value: "daily", label: "Daily" },
+  { value: "every_other_day", label: "Every other day" },
+  { value: "weekly", label: "Weekly" },
+] as const;
+
+type Frequency = (typeof FREQUENCY_OPTIONS)[number]["value"];
+
+export function CheckInsStep({ onComplete }: { readonly onComplete: () => void }) {
+  const [enabled, setEnabled] = useState(true);
+  const [frequency, setFrequency] = useState<Frequency>("every_other_day");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updatePreferences = useMutation(api.checkIns.updatePreferences);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (saving) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      await updatePreferences({ enabled, frequency });
+      setSaving(false);
+      onComplete();
+    } catch (err) {
+      console.error("Failed to save check-in preferences:", err);
+      setError("Failed to save preferences. Please try again.");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="mb-6 text-center">
+          <h1 className="text-xl font-semibold text-foreground">Proactive check-ins</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Your coach can send you proactive messages after missed sessions, strength milestones,
+            and weekly recaps.
+          </p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              onClick={() => setEnabled(true)}
+              aria-pressed={enabled}
+              className={cn(
+                "flex flex-col items-center gap-2 rounded-lg border p-4 text-sm font-medium transition-colors",
+                enabled
+                  ? "border-primary bg-primary/5 text-foreground"
+                  : "border-border text-muted-foreground hover:border-primary/40",
+              )}
+            >
+              <Bell className="size-5" />
+              Enable check-ins
+            </button>
+            <button
+              type="button"
+              onClick={() => setEnabled(false)}
+              aria-pressed={!enabled}
+              className={cn(
+                "flex flex-col items-center gap-2 rounded-lg border p-4 text-sm font-medium transition-colors",
+                !enabled
+                  ? "border-primary bg-primary/5 text-foreground"
+                  : "border-border text-muted-foreground hover:border-primary/40",
+              )}
+            >
+              <BellOff className="size-5" />
+              Not right now
+            </button>
+          </div>
+
+          {enabled && (
+            <div className="space-y-3 border-t border-border pt-4">
+              <p className="text-xs font-semibold text-muted-foreground">Frequency</p>
+              <div className="flex gap-2">
+                {FREQUENCY_OPTIONS.map(({ value, label }) => (
+                  <Button
+                    key={value}
+                    type="button"
+                    variant={frequency === value ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setFrequency(value)}
+                    aria-pressed={frequency === value}
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                You can change this anytime in Settings.
+              </p>
+            </div>
+          )}
+
+          {error && <p className="text-center text-sm text-destructive">{error}</p>}
+          <Button type="submit" className="w-full" size="lg" disabled={saving}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save and continue"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -10,10 +10,11 @@ import { useAnalytics } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { ConnectStep } from "./ConnectStep";
 import { PreferencesStep } from "./PreferencesStep";
+import { CheckInsStep } from "./CheckInsStep";
 import { ReadyStep } from "./ReadyStep";
 import { ProviderKeyStep } from "./ProviderKeyStep";
 
-type StepId = "connect" | "preferences" | "byok" | "ready";
+type StepId = "connect" | "preferences" | "checkins" | "byok" | "ready";
 
 interface StepDef {
   id: StepId;
@@ -23,12 +24,14 @@ interface StepDef {
 const BASE_STEPS: readonly StepDef[] = [
   { id: "connect", label: "Connect Tonal" },
   { id: "preferences", label: "Preferences" },
+  { id: "checkins", label: "Check-ins" },
   { id: "ready", label: "Ready" },
 ];
 
 const BYOK_STEPS: readonly StepDef[] = [
   { id: "connect", label: "Connect Tonal" },
   { id: "preferences", label: "Preferences" },
+  { id: "checkins", label: "Check-ins" },
   { id: "byok", label: "AI provider" },
   { id: "ready", label: "Ready" },
 ];
@@ -127,6 +130,7 @@ function OnboardingFlow({
       <StepIndicator steps={steps} currentIndex={stepIndex} />
       {currentStep?.id === "connect" && <ConnectStep onComplete={advance} />}
       {currentStep?.id === "preferences" && <PreferencesStep onComplete={advance} />}
+      {currentStep?.id === "checkins" && <CheckInsStep onComplete={advance} />}
       {currentStep?.id === "byok" && <ProviderKeyStep onComplete={advance} />}
       {currentStep?.id === "ready" && <ReadyStep firstName={firstName} />}
     </div>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -61,6 +61,7 @@ export default function OnboardingPage() {
       steps={steps}
       hasTonalProfile={!!me?.hasTonalProfile}
       onboardingCompleted={!!me?.onboardingCompleted}
+      hasCheckInPreferences={!!me?.hasCheckInPreferences}
       needsByokStep={needsByokStep}
       firstName={me?.tonalName?.split(" ")[0]}
     />
@@ -71,10 +72,12 @@ function pickInitialStepIndex(
   steps: readonly StepDef[],
   hasTonalProfile: boolean,
   onboardingCompleted: boolean,
+  hasCheckInPreferences: boolean,
   needsByokStep: boolean,
 ): number {
   if (!hasTonalProfile) return steps.findIndex((s) => s.id === "connect");
   if (!onboardingCompleted) return steps.findIndex((s) => s.id === "preferences");
+  if (!hasCheckInPreferences) return steps.findIndex((s) => s.id === "checkins");
   if (needsByokStep) return steps.findIndex((s) => s.id === "byok");
   return steps.findIndex((s) => s.id === "ready");
 }
@@ -83,12 +86,14 @@ function OnboardingFlow({
   steps: initialSteps,
   hasTonalProfile,
   onboardingCompleted,
+  hasCheckInPreferences,
   needsByokStep,
   firstName,
 }: {
   readonly steps: readonly StepDef[];
   readonly hasTonalProfile: boolean;
   readonly onboardingCompleted: boolean;
+  readonly hasCheckInPreferences: boolean;
   readonly needsByokStep: boolean;
   readonly firstName: string | undefined;
 }) {
@@ -98,7 +103,13 @@ function OnboardingFlow({
   // flow rendering BASE_STEPS[3] === undefined (blank screen).
   const [steps] = useState<readonly StepDef[]>(() => initialSteps);
   const [stepIndex, setStepIndex] = useState<number>(() =>
-    pickInitialStepIndex(steps, hasTonalProfile, onboardingCompleted, needsByokStep),
+    pickInitialStepIndex(
+      steps,
+      hasTonalProfile,
+      onboardingCompleted,
+      hasCheckInPreferences,
+      needsByokStep,
+    ),
   );
   const { track } = useAnalytics();
   const startTimeRef = useRef(Date.now());

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -88,7 +88,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   }, [authLoading, isAuthenticated, router]);
 
   useEffect(() => {
-    if (me && (!me.hasTonalProfile || !me.onboardingCompleted)) {
+    if (me && (!me.hasTonalProfile || !me.onboardingCompleted || !me.hasCheckInPreferences)) {
       router.replace("/onboarding");
     }
   }, [me, router]);
@@ -101,7 +101,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     );
   }
 
-  if (!isAuthenticated || (me && (!me.hasTonalProfile || !me.onboardingCompleted))) {
+  if (
+    !isAuthenticated ||
+    (me && (!me.hasTonalProfile || !me.onboardingCompleted || !me.hasCheckInPreferences))
+  ) {
     return null;
   }
 


### PR DESCRIPTION
previously checkInPreferences were not being set in userProfiles table unless user found it under settings

## Summary

New Check-In Step added to onboarding

## Changes

- New Check-In Step added to onboarding
- normalizeTargetArea in "TRAINING FREQUENCY" for dashboard

## Checklist

- [X] `npx tsc --noEmit` passes
- [X] `npm run lint` passes
- [X] `npm test` passes (existing + new tests)
- [X] New logic has tests (happy path + at least one error/edge case)
- [X] No new or materially expanded file exceeds the 300-line soft cap
- [X] No file exceeds the 400-line hard cap (enforced by CI)
- [X] Functions stay near the 60-line convention
- [X] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [X] Tested in browser (if UI changes)
- [X] Commits follow conventional format (`type: description`)
- [X] No unused exports or dead code introduced

## Test Plan

npm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proactive check-ins onboarding step, allowing users to enable/disable check-ins and select preferred frequency (daily, every other day, weekly).

* **Improvements**
  * Enhanced target area value normalization for consistent data grouping across training metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->