### PR TITLE
fix: compute avgWeightLbs from per-set avgWeight, not totalVolume

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -69,6 +69,8 @@ import type * as lib_env from "../lib/env.js";
 import type * as lib_posthog from "../lib/posthog.js";
 import type * as lib_targetArea from "../lib/targetArea.js";
 import type * as libraryWorkouts from "../libraryWorkouts.js";
+import type * as migrations from "../migrations.js";
+import type * as migrations_backfillAvgWeight from "../migrations/backfillAvgWeight.js";
 import type * as migrations_rotateTokenEncryptionKey from "../migrations/rotateTokenEncryptionKey.js";
 import type * as progressiveOverload from "../progressiveOverload.js";
 import type * as rateLimits from "../rateLimits.js";
@@ -189,6 +191,8 @@ declare const fullApi: ApiFromModules<{
   "lib/posthog": typeof lib_posthog;
   "lib/targetArea": typeof lib_targetArea;
   libraryWorkouts: typeof libraryWorkouts;
+  migrations: typeof migrations;
+  "migrations/backfillAvgWeight": typeof migrations_backfillAvgWeight;
   "migrations/rotateTokenEncryptionKey": typeof migrations_rotateTokenEncryptionKey;
   progressiveOverload: typeof progressiveOverload;
   rateLimits: typeof rateLimits;
@@ -5098,6 +5102,93 @@ export declare const components: {
           null
         >;
       };
+    };
+  };
+  migrations: {
+    lib: {
+      cancel: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+      cancelAll: FunctionReference<
+        "mutation",
+        "internal",
+        { sinceTs?: number },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        null
+      >;
+      getStatus: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; names?: Array<string> },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      migrate: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          dryRun: boolean;
+          fnHandle: string;
+          name: string;
+          next?: Array<{ fnHandle: string; name: string }>;
+          oneBatchOnly?: boolean;
+          reset?: boolean;
+        },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
     };
   };
   rateLimiter: {

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,9 +1,11 @@
 import { defineApp } from "convex/server";
 import agent from "@convex-dev/agent/convex.config";
+import migrations from "@convex-dev/migrations/convex.config";
 import rateLimiter from "@convex-dev/rate-limiter/convex.config";
 
 const app = defineApp();
 app.use(agent);
+app.use(migrations);
 app.use(rateLimiter);
 
 export default app;

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,24 @@
+import { Migrations } from "@convex-dev/migrations";
+import { components } from "./_generated/api";
+import type { DataModel } from "./_generated/dataModel";
+
+export const migrations = new Migrations<DataModel>(components.migrations);
+export const run = migrations.runner();
+
+/**
+ * Clear bogus avgWeightLbs on exercisePerformance rows.
+ *
+ * The old formula (totalVolume / totalReps) used Tonal's work-based
+ * totalVolume metric, not actual weight. This produced values like
+ * 650 lbs for a chest press. Nulling out forces the live paths
+ * (which now use per-set avgWeight) to be the source of truth.
+ *
+ * Run: npx convex run migrations:run '{"fn": "migrations:clearBogusAvgWeight"}'
+ */
+export const clearBogusAvgWeight = migrations.define({
+  table: "exercisePerformance",
+  migrateOne: (_ctx, doc) => {
+    if (doc.avgWeightLbs == null) return;
+    return { avgWeightLbs: undefined };
+  },
+});

--- a/convex/migrations/backfillAvgWeight.ts
+++ b/convex/migrations/backfillAvgWeight.ts
@@ -1,0 +1,139 @@
+/**
+ * Backfill action: re-fetch workout details from Tonal and recompute
+ * avgWeightLbs for exercisePerformance rows that were cleared by the
+ * clearBogusAvgWeight migration.
+ *
+ * Run per user: npx convex run migrations/backfillAvgWeight:backfillUser '{"userId": "..."}'
+ * Run all:      npx convex run migrations/backfillAvgWeight:backfillAll
+ */
+
+import { v } from "convex/values";
+import { internalAction, internalMutation, internalQuery } from "../_generated/server";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { Movement, WorkoutActivityDetail } from "../tonal/types";
+import { aggregateDetailToSessions } from "../progressiveOverload";
+import { withTokenRetry } from "../tonal/tokenRetry";
+import { tonalFetch } from "../tonal/client";
+
+const BATCH_SIZE = 10;
+
+/** Get activityIds that have null avgWeightLbs for a given user. */
+export const getNullWeightActivityIds = internalQuery({
+  args: { userId: v.id("users"), limit: v.number() },
+  handler: async (ctx, { userId, limit }) => {
+    const rows = await ctx.db
+      .query("exercisePerformance")
+      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("avgWeightLbs"), undefined))
+      .take(limit);
+    return [...new Set(rows.map((r) => r.activityId))];
+  },
+});
+
+/** Patch avgWeightLbs for exercisePerformance rows matching a given activityId. */
+export const patchAvgWeights = internalMutation({
+  args: {
+    userId: v.id("users"),
+    activityId: v.string(),
+    weights: v.array(v.object({ movementId: v.string(), avgWeightLbs: v.number() })),
+  },
+  handler: async (ctx, { userId, activityId, weights }) => {
+    const weightMap = new Map(weights.map((w) => [w.movementId, w.avgWeightLbs]));
+    const rows = await ctx.db
+      .query("exercisePerformance")
+      .withIndex("by_userId_activityId", (q) => q.eq("userId", userId).eq("activityId", activityId))
+      .collect();
+    for (const row of rows) {
+      const weight = weightMap.get(row.movementId);
+      if (weight != null) {
+        await ctx.db.patch(row._id, { avgWeightLbs: weight });
+      }
+    }
+  },
+});
+
+/** Backfill one user's exercisePerformance rows. */
+export const backfillUser = internalAction({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    const movements: Movement[] = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
+    const straightBarIds = new Set(
+      movements.filter((m) => m.onMachineInfo?.accessory === "StraightBar").map((m) => m.id),
+    );
+
+    let totalPatched = 0;
+    while (true) {
+      const activityIds: string[] = await ctx.runQuery(
+        internal.migrations.backfillAvgWeight.getNullWeightActivityIds,
+        { userId, limit: BATCH_SIZE },
+      );
+      if (activityIds.length === 0) break;
+
+      for (const activityId of activityIds) {
+        try {
+          const detail = await withTokenRetry<WorkoutActivityDetail>(
+            ctx,
+            userId,
+            (token: string, tonalUserId: string) =>
+              tonalFetch<WorkoutActivityDetail>(
+                token,
+                `/v6/users/${tonalUserId}/workout-activities/${activityId}`,
+              ),
+          );
+
+          const sessionMap = aggregateDetailToSessions(detail, straightBarIds);
+          const weights = [...sessionMap.entries()]
+            .filter(([, snap]) => snap.avgWeightLbs != null)
+            .map(([movementId, snap]) => ({
+              movementId,
+              avgWeightLbs: snap.avgWeightLbs!,
+            }));
+
+          if (weights.length > 0) {
+            await ctx.runMutation(internal.migrations.backfillAvgWeight.patchAvgWeights, {
+              userId,
+              activityId,
+              weights,
+            });
+            totalPatched += weights.length;
+          }
+        } catch (err) {
+          console.warn(
+            `[backfillAvgWeight] Skipping activity ${activityId} for user ${userId}:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+    }
+
+    if (totalPatched > 0) {
+      console.log(`[backfillAvgWeight] Patched ${totalPatched} rows for user ${userId}`);
+    }
+  },
+});
+
+/** Backfill all users that have null avgWeightLbs rows. */
+export const backfillAll = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const users = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
+      sinceTimestamp: 0,
+    });
+
+    for (const profile of users) {
+      try {
+        await ctx.scheduler.runAfter(0, internal.migrations.backfillAvgWeight.backfillUser, {
+          userId: profile.userId as Id<"users">,
+        });
+      } catch (err) {
+        console.warn(
+          `[backfillAvgWeight] Failed to schedule backfill for ${profile.userId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
+    console.log(`[backfillAvgWeight] Scheduled backfill for ${users.length} users`);
+  },
+});

--- a/convex/progressiveOverload.test.ts
+++ b/convex/progressiveOverload.test.ts
@@ -116,7 +116,7 @@ describe("aggregateDetailToSessions", () => {
           id: "s1",
           movementId: "m1",
           prescribedReps: 10,
-          repetition: 10,
+          repetition: 8,
           repetitionTotal: 2,
           blockNumber: 1,
           spotter: false,
@@ -132,7 +132,7 @@ describe("aggregateDetailToSessions", () => {
           id: "s2",
           movementId: "m1",
           prescribedReps: 10,
-          repetition: 10,
+          repetition: 12,
           repetitionTotal: 2,
           blockNumber: 1,
           spotter: false,
@@ -150,8 +150,8 @@ describe("aggregateDetailToSessions", () => {
     const result = aggregateDetailToSessions(detail);
 
     const m1 = result.get("m1");
-    // Weighted average: (50*10 + 60*10) / 20 = 55
-    expect(m1!.avgWeightLbs).toBe(55);
+    // Weighted average: (50*8 + 60*12) / 20 = 56
+    expect(m1!.avgWeightLbs).toBe(56);
   });
 
   it("doubles avgWeight for StraightBar movements", () => {

--- a/convex/progressiveOverload.test.ts
+++ b/convex/progressiveOverload.test.ts
@@ -109,7 +109,7 @@ describe("aggregateDetailToSessions", () => {
     expect(result.size).toBe(0);
   });
 
-  it("computes avgWeightLbs when volumeByMovement is provided", () => {
+  it("computes avgWeightLbs from per-set avgWeight", () => {
     const detail = makeDetail({
       workoutSetActivity: [
         {
@@ -126,6 +126,7 @@ describe("aggregateDetailToSessions", () => {
           warmUp: false,
           beginTime: "2026-03-10T10:00:00Z",
           sideNumber: 0,
+          avgWeight: 50,
         },
         {
           id: "s2",
@@ -141,18 +142,19 @@ describe("aggregateDetailToSessions", () => {
           warmUp: false,
           beginTime: "2026-03-10T10:02:00Z",
           sideNumber: 0,
+          avgWeight: 60,
         },
       ],
     });
-    const volumeByMovement = new Map([["m1", 2000]]);
 
-    const result = aggregateDetailToSessions(detail, volumeByMovement);
+    const result = aggregateDetailToSessions(detail);
 
     const m1 = result.get("m1");
-    expect(m1!.avgWeightLbs).toBe(100); // 2000 / 20 = 100
+    // Weighted average: (50*10 + 60*10) / 20 = 55
+    expect(m1!.avgWeightLbs).toBe(55);
   });
 
-  it("omits avgWeightLbs when volume data is not provided", () => {
+  it("omits avgWeightLbs when sets have no avgWeight", () => {
     const detail = makeDetail({
       workoutSetActivity: [
         {

--- a/convex/progressiveOverload.test.ts
+++ b/convex/progressiveOverload.test.ts
@@ -154,6 +154,35 @@ describe("aggregateDetailToSessions", () => {
     expect(m1!.avgWeightLbs).toBe(55);
   });
 
+  it("doubles avgWeight for StraightBar movements", () => {
+    const detail = makeDetail({
+      workoutSetActivity: [
+        {
+          id: "s1",
+          movementId: "bar1",
+          prescribedReps: 10,
+          repetition: 10,
+          repetitionTotal: 1,
+          blockNumber: 1,
+          spotter: false,
+          eccentric: false,
+          chains: false,
+          flex: false,
+          warmUp: false,
+          beginTime: "2026-03-10T10:00:00Z",
+          sideNumber: 0,
+          avgWeight: 47,
+        },
+      ],
+    });
+
+    const straightBarIds = new Set(["bar1"]);
+    const result = aggregateDetailToSessions(detail, straightBarIds);
+
+    const bar1 = result.get("bar1");
+    expect(bar1!.avgWeightLbs).toBe(94);
+  });
+
   it("omits avgWeightLbs when sets have no avgWeight", () => {
     const detail = makeDetail({
       workoutSetActivity: [

--- a/convex/progressiveOverload.ts
+++ b/convex/progressiveOverload.ts
@@ -40,6 +40,7 @@ export interface LastTimeAndSuggested {
 /** Aggregate workoutSetActivity by movementId into per-movement session snapshot. */
 export function aggregateDetailToSessions(
   detail: WorkoutActivityDetail,
+  straightBarMovementIds?: ReadonlySet<string>,
 ): Map<string, MovementSessionSnapshot> {
   const sessionDate = detail.beginTime.slice(0, 10);
   const byMovement = new Map<string, SetActivity[]>();
@@ -53,7 +54,8 @@ export function aggregateDetailToSessions(
     const totalReps = sets.reduce((sum, s) => sum + (s.repetition ?? 0), 0);
     const count = sets.length;
     const repsPerSet = count > 0 ? Math.round(totalReps / count) : 0;
-    const avgWeightLbs = weightedAvgWeight(sets);
+    const isStraightBar = straightBarMovementIds?.has(movementId) ?? false;
+    const avgWeightLbs = weightedAvgWeight(sets, isStraightBar);
     out.set(movementId, {
       sessionDate,
       sets: count,
@@ -65,15 +67,20 @@ export function aggregateDetailToSessions(
   return out;
 }
 
-/** Weighted average of per-set avgWeight, weighted by reps per set. */
-function weightedAvgWeight(sets: readonly SetActivity[]): number | undefined {
+/** Weighted average of per-set avgWeight, weighted by reps per set.
+ *  StraightBar avgWeight is per-motor; double it for actual bar weight. */
+function weightedAvgWeight(
+  sets: readonly SetActivity[],
+  isStraightBar: boolean,
+): number | undefined {
   let totalWeight = 0;
   let totalReps = 0;
   for (const s of sets) {
     if (s.avgWeight == null || s.avgWeight <= 0) continue;
     const reps = s.repetition ?? 0;
     if (reps <= 0) continue;
-    totalWeight += s.avgWeight * reps;
+    const weight = isStraightBar ? s.avgWeight * 2 : s.avgWeight;
+    totalWeight += weight * reps;
     totalReps += reps;
   }
   if (totalReps === 0) return undefined;
@@ -133,6 +140,11 @@ export const getPerMovementHistory = internalAction({
       limit: maxActivities,
     });
 
+    const movements: Movement[] = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
+    const straightBarIds = new Set(
+      movements.filter((m) => m.onMachineInfo?.accessory === "StraightBar").map((m) => m.id),
+    );
+
     const perMovement = new Map<string, MovementSessionSnapshot[]>();
 
     for (const activity of activities) {
@@ -152,7 +164,7 @@ export const getPerMovementHistory = internalAction({
       }
       if (!detail) continue;
 
-      const sessionMap = aggregateDetailToSessions(detail);
+      const sessionMap = aggregateDetailToSessions(detail, straightBarIds);
       for (const [movementId, snapshot] of sessionMap) {
         const list = perMovement.get(movementId) ?? [];
         list.push(snapshot);

--- a/convex/progressiveOverload.ts
+++ b/convex/progressiveOverload.ts
@@ -87,7 +87,6 @@ function weightedAvgWeight(
   return Math.round(totalWeight / totalReps);
 }
 
-/** Extract per-movement totalVolume from FormattedWorkoutSummary. */
 /** Format "last time" for display. */
 function formatLastTime(sets: number, repsPerSet: number, avgWeightLbs?: number): string {
   const base = `${sets}×${repsPerSet}`;

--- a/convex/progressiveOverload.ts
+++ b/convex/progressiveOverload.ts
@@ -1,18 +1,12 @@
 /**
  * Progressive overload: per-exercise history from Tonal, "last time" and "suggested next" display.
- * No AI — deterministic from workout-activities (and optional formatted summary for weight).
- * See docs/progressive-overload-data.md for data source and set-level notes.
+ * No AI — deterministic from workout-activity set data (per-set avgWeight).
  */
 
 import { v } from "convex/values";
 import { action, internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
-import type {
-  FormattedWorkoutSummary,
-  Movement,
-  SetActivity,
-  WorkoutActivityDetail,
-} from "./tonal/types";
+import type { Movement, SetActivity, WorkoutActivityDetail } from "./tonal/types";
 import { generatePerformanceSummary } from "./coach/prDetection";
 
 const WEIGHT_STEP_LBS = 2.5;
@@ -46,7 +40,6 @@ export interface LastTimeAndSuggested {
 /** Aggregate workoutSetActivity by movementId into per-movement session snapshot. */
 export function aggregateDetailToSessions(
   detail: WorkoutActivityDetail,
-  volumeByMovement?: Map<string, number>,
 ): Map<string, MovementSessionSnapshot> {
   const sessionDate = detail.beginTime.slice(0, 10);
   const byMovement = new Map<string, SetActivity[]>();
@@ -60,9 +53,7 @@ export function aggregateDetailToSessions(
     const totalReps = sets.reduce((sum, s) => sum + (s.repetition ?? 0), 0);
     const count = sets.length;
     const repsPerSet = count > 0 ? Math.round(totalReps / count) : 0;
-    const totalVolume = volumeByMovement?.get(movementId);
-    const avgWeightLbs =
-      totalVolume != null && totalReps > 0 ? Math.round(totalVolume / totalReps) : undefined;
+    const avgWeightLbs = weightedAvgWeight(sets);
     out.set(movementId, {
       sessionDate,
       sets: count,
@@ -74,15 +65,22 @@ export function aggregateDetailToSessions(
   return out;
 }
 
-/** Extract per-movement totalVolume from FormattedWorkoutSummary. */
-function volumeByMovementFromSummary(summary: FormattedWorkoutSummary): Map<string, number> {
-  const out = new Map<string, number>();
-  for (const ms of summary.movementSets ?? []) {
-    out.set(ms.movementId, ms.totalVolume);
+/** Weighted average of per-set avgWeight, weighted by reps per set. */
+function weightedAvgWeight(sets: readonly SetActivity[]): number | undefined {
+  let totalWeight = 0;
+  let totalReps = 0;
+  for (const s of sets) {
+    if (s.avgWeight == null || s.avgWeight <= 0) continue;
+    const reps = s.repetition ?? 0;
+    if (reps <= 0) continue;
+    totalWeight += s.avgWeight * reps;
+    totalReps += reps;
   }
-  return out;
+  if (totalReps === 0) return undefined;
+  return Math.round(totalWeight / totalReps);
 }
 
+/** Extract per-movement totalVolume from FormattedWorkoutSummary. */
 /** Format "last time" for display. */
 function formatLastTime(sets: number, repsPerSet: number, avgWeightLbs?: number): string {
   const base = `${sets}×${repsPerSet}`;
@@ -154,18 +152,7 @@ export const getPerMovementHistory = internalAction({
       }
       if (!detail) continue;
 
-      let volumeByMovement: Map<string, number> | undefined;
-      try {
-        const summary = await ctx.runAction(internal.tonal.proxy.fetchFormattedSummary, {
-          userId,
-          summaryId: activityId,
-        });
-        volumeByMovement = volumeByMovementFromSummary(summary);
-      } catch {
-        // Formatted summary may use different ID; we still have sets/reps
-      }
-
-      const sessionMap = aggregateDetailToSessions(detail, volumeByMovement);
+      const sessionMap = aggregateDetailToSessions(detail);
       for (const [movementId, snapshot] of sessionMap) {
         const list = perMovement.get(movementId) ?? [];
         list.push(snapshot);

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -14,6 +14,7 @@ import { aggregateDetailToSessions } from "../progressiveOverload";
 import type {
   Activity,
   FormattedWorkoutSummary,
+  Movement,
   StrengthScoreHistoryEntry,
   WorkoutActivityDetail,
 } from "./types";
@@ -40,6 +41,7 @@ async function processOneActivity(
   ctx: ActionCtx,
   userId: Id<"users">,
   activity: Activity,
+  straightBarIds?: ReadonlySet<string>,
 ): Promise<{ workout: WorkoutPayload; performances: PerformancePayload[] }> {
   const { activityId, activityTime, workoutPreview: p } = activity;
   const date = activityTime.slice(0, 10);
@@ -82,7 +84,7 @@ async function processOneActivity(
     // Summary optional
   }
 
-  const sessionMap = aggregateDetailToSessions(detail);
+  const sessionMap = aggregateDetailToSessions(detail, straightBarIds);
   const performances: PerformancePayload[] = [];
   for (const [movementId, snap] of sessionMap) {
     performances.push({
@@ -108,11 +110,18 @@ async function fetchAndBuildPayloads(
   const workouts: WorkoutPayload[] = [];
   const performances: PerformancePayload[] = [];
 
+  const movements: Movement[] = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
+  const straightBarIds = new Set(
+    movements.filter((m) => m.onMachineInfo?.accessory === "StraightBar").map((m) => m.id),
+  );
+
   for (let i = 0; i < activities.length; i += DETAIL_BATCH_SIZE) {
     if (i > 0) await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
     const batch = activities.slice(i, i + DETAIL_BATCH_SIZE);
 
-    const results = await Promise.allSettled(batch.map((a) => processOneActivity(ctx, userId, a)));
+    const results = await Promise.allSettled(
+      batch.map((a) => processOneActivity(ctx, userId, a, straightBarIds)),
+    );
     for (const result of results) {
       if (result.status === "fulfilled") {
         workouts.push(result.value.workout);

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -67,22 +67,22 @@ async function processOneActivity(
   }
   if (!detail) return { workout, performances: [] };
 
-  // Fetch formatted summary for per-movement volume (optional)
-  let volumeByMovement: Map<string, number> | undefined;
+  // Fetch formatted summary for per-movement totalVolume (optional).
+  // totalVolume is a work-based metric (not weight x reps); kept for volume display.
+  const volumeByMovement = new Map<string, number>();
   try {
     const summary = (await ctx.runAction(internal.tonal.proxy.fetchFormattedSummary, {
       userId,
       summaryId: activityId,
     })) as FormattedWorkoutSummary;
-    volumeByMovement = new Map<string, number>();
     for (const ms of summary.movementSets ?? []) {
       volumeByMovement.set(ms.movementId, ms.totalVolume);
     }
   } catch {
-    // Summary optional -- we still have sets/reps from detail
+    // Summary optional
   }
 
-  const sessionMap = aggregateDetailToSessions(detail, volumeByMovement);
+  const sessionMap = aggregateDetailToSessions(detail);
   const performances: PerformancePayload[] = [];
   for (const [movementId, snap] of sessionMap) {
     performances.push({
@@ -92,7 +92,7 @@ async function processOneActivity(
       sets: snap.sets,
       totalReps: snap.totalReps,
       avgWeightLbs: snap.avgWeightLbs,
-      totalVolume: volumeByMovement?.get(movementId),
+      totalVolume: volumeByMovement.get(movementId),
     });
   }
 

--- a/convex/workoutDetail.test.ts
+++ b/convex/workoutDetail.test.ts
@@ -211,10 +211,22 @@ describe("buildMovementSummaries", () => {
     expect(m1.totalReps).toBe(18);
   });
 
-  it("computes avgWeightLbs from per-set avgWeight (doubled for StraightBar)", () => {
+  it("computes weighted avgWeightLbs from per-set avgWeight", () => {
     const sets = [
-      makeSet({ id: "s1", movementId: "bar1", movementName: "Barbell Front Squat", avgWeight: 94 }),
-      makeSet({ id: "s2", movementId: "bar1", movementName: "Barbell Front Squat", avgWeight: 94 }),
+      makeSet({
+        id: "s1",
+        movementId: "bar1",
+        movementName: "Barbell Front Squat",
+        avgWeight: 94,
+        repetition: 8,
+      }),
+      makeSet({
+        id: "s2",
+        movementId: "bar1",
+        movementName: "Barbell Front Squat",
+        avgWeight: 100,
+        repetition: 12,
+      }),
     ];
 
     const result = buildMovementSummaries(sets, new Map());
@@ -222,7 +234,8 @@ describe("buildMovementSummaries", () => {
 
     expect(summary.totalSets).toBe(2);
     expect(summary.totalReps).toBe(20);
-    expect(summary.avgWeightLbs).toBe(94);
+    // Weighted: (94*8 + 100*12) / 20 = 97.6 -> 98
+    expect(summary.avgWeightLbs).toBe(98);
   });
 
   it("returns avgWeightLbs 0 when sets have no avgWeight", () => {

--- a/convex/workoutDetail.test.ts
+++ b/convex/workoutDetail.test.ts
@@ -211,9 +211,7 @@ describe("buildMovementSummaries", () => {
     expect(m1.totalReps).toBe(18);
   });
 
-  it("preserves doubled avgWeight from enriched StraightBar sets", () => {
-    // Simulates what happens after enrichment doubles avgWeight for StraightBar.
-    // A barbell front squat where per-motor avgWeight was 47, doubled to 94.
+  it("computes avgWeightLbs from per-set avgWeight (doubled for StraightBar)", () => {
     const sets = [
       makeSet({ id: "s1", movementId: "bar1", movementName: "Barbell Front Squat", avgWeight: 94 }),
       makeSet({ id: "s2", movementId: "bar1", movementName: "Barbell Front Squat", avgWeight: 94 }),
@@ -222,9 +220,15 @@ describe("buildMovementSummaries", () => {
     const result = buildMovementSummaries(sets, new Map());
     const summary = result.find((r) => r.movementId === "bar1")!;
 
-    // avgWeightLbs comes from volumeMap, not from set.avgWeight,
-    // so it will be 0 here (no volume data). That's expected.
     expect(summary.totalSets).toBe(2);
     expect(summary.totalReps).toBe(20);
+    expect(summary.avgWeightLbs).toBe(94);
+  });
+
+  it("returns avgWeightLbs 0 when sets have no avgWeight", () => {
+    const sets = [makeSet({ id: "s1", movementId: "m1", avgWeight: undefined })];
+
+    const result = buildMovementSummaries(sets, new Map());
+    expect(result[0].avgWeightLbs).toBe(0);
   });
 });

--- a/convex/workoutDetail.ts
+++ b/convex/workoutDetail.ts
@@ -122,20 +122,35 @@ export function buildMovementSummaries(
 ): MovementSummary[] {
   const grouped = new Map<
     string,
-    { name: string; muscleGroups: string[]; totalSets: number; totalReps: number }
+    {
+      name: string;
+      muscleGroups: string[];
+      totalSets: number;
+      totalReps: number;
+      weightedWeightSum: number;
+      weightedReps: number;
+    }
   >();
 
   for (const set of sets) {
     const existing = grouped.get(set.movementId);
+    const reps = set.repetition ?? 0;
+    const hasWeight = set.avgWeight != null && set.avgWeight > 0 && reps > 0;
     if (existing) {
       existing.totalSets += 1;
-      existing.totalReps += set.repetition;
+      existing.totalReps += reps;
+      if (hasWeight) {
+        existing.weightedWeightSum += set.avgWeight! * reps;
+        existing.weightedReps += reps;
+      }
     } else {
       grouped.set(set.movementId, {
         name: set.movementName ?? "Unknown",
         muscleGroups: set.muscleGroups,
         totalSets: 1,
-        totalReps: set.repetition,
+        totalReps: reps,
+        weightedWeightSum: hasWeight ? set.avgWeight! * reps : 0,
+        weightedReps: hasWeight ? reps : 0,
       });
     }
   }
@@ -150,7 +165,7 @@ export function buildMovementSummaries(
       totalSets: data.totalSets,
       totalReps: data.totalReps,
       avgWeightLbs:
-        data.totalReps > 0 && totalVolume > 0 ? Math.round(totalVolume / data.totalReps) : 0,
+        data.weightedReps > 0 ? Math.round(data.weightedWeightSum / data.weightedReps) : 0,
     };
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "convex": "^1.34.1",
+        "convex": "^1.35.1",
         "convex-helpers": "^0.1.114",
         "lucide-react": "^1.7.0",
         "next": "^16.2.3",
@@ -9192,9 +9192,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.34.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.34.1.tgz",
-      "integrity": "sha512-ooyFnZVVq0u6b5zt0Ptq8QB2ixhf/2vXe+PIcUtdtrs0lq/TwpkmmruHdqkFmWgMd6N+Tmfy8AGkz6QnZUYZBA==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.35.1.tgz",
+      "integrity": "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
@@ -9211,6 +9211,7 @@
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.0.0",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -9218,6 +9219,9 @@
           "optional": true
         },
         "@clerk/clerk-react": {
+          "optional": true
+        },
+        "@clerk/react": {
           "optional": true
         },
         "react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@base-ui/react": "^1.3.0",
         "@convex-dev/agent": "^0.6.1",
         "@convex-dev/auth": "^0.0.91",
+        "@convex-dev/migrations": "^0.3.3",
         "@convex-dev/rate-limiter": "^0.3.2",
         "@sentry/nextjs": "^10.47.0",
         "@vercel/analytics": "^2.0.1",
@@ -1153,6 +1154,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@convex-dev/migrations": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@convex-dev/migrations/-/migrations-0.3.3.tgz",
+      "integrity": "sha512-eUfqCBMjObr9sPCRL7V98CX58fViLVye7ZtYVCb0/6c6kOERZopbiQ/dWnF8NoxXg3bREr3Jb3VjZR9FjP96+A==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.24.8"
       }
     },
     "node_modules/@convex-dev/rate-limiter": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@base-ui/react": "^1.3.0",
     "@convex-dev/agent": "^0.6.1",
     "@convex-dev/auth": "^0.0.91",
+    "@convex-dev/migrations": "^0.3.3",
     "@convex-dev/rate-limiter": "^0.3.2",
     "@sentry/nextjs": "^10.47.0",
     "@vercel/analytics": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "convex": "^1.34.1",
+    "convex": "^1.35.1",
     "convex-helpers": "^0.1.114",
     "lucide-react": "^1.7.0",
     "next": "^16.2.3",


### PR DESCRIPTION
## Summary

- Tonal's `totalVolume` on `FormattedMovementSet` is a work-based metric (force x distance), NOT weight x reps
- Dividing it by `totalReps` produced wildly inflated "avgWeightLbs" values (e.g. 650 lbs for a chest press that maxes at ~100 lbs per arm)
- This caused bogus PR check-ins, incorrect progressive overload suggestions, and misleading workout summaries
- Both `progressiveOverload.ts` and `workoutDetail.ts` now compute `avgWeightLbs` as a weighted average of per-set `avgWeight` fields

## How we found it

A user reported a check-in showing "New PR on Standing Decline Chest Press -- 650 lbs". We built a debug action to compare the Tonal API's per-set `avgWeight` vs `totalVolume` for real workouts and discovered:

| Field | Bench Press (1 rep) |
|-------|-------------------|
| `set.avgWeight` | 16.83 |
| `set.volume` | 334.16 |
| `totalVolume / totalReps` | 334 |

`volume` is ~20x `avgWeight` -- it's clearly not `weight * reps`. Per-set `avgWeight` is the actual resistance in pounds (per motor).

## Changes

- **convex/progressiveOverload.ts** -- `aggregateDetailToSessions` now computes `avgWeightLbs` from per-set `avgWeight` via weighted average. Removed `volumeByMovement` parameter and the formatted summary fetch that was only used for the incorrect weight calculation.
- **convex/workoutDetail.ts** -- `buildMovementSummaries` now computes `avgWeightLbs` from per-set `avgWeight` (already doubled for StraightBar by the enrichment step). `totalVolume` still populated from formatted summary for volume display.
- **convex/tonal/historySync.ts** -- Updated `aggregateDetailToSessions` call (no more `volumeByMovement` arg). `totalVolume` still fetched and persisted for volume display.
- **Tests updated** to verify weighted average from per-set avgWeight instead of totalVolume / totalReps.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (973 tests)
- [x] Tests updated for new behavior
- [x] Commits follow conventional format

## Test Plan

- Verified with real Tonal API data via debug action that per-set `avgWeight` gives correct resistance values
- Progressive overload test: weighted average of 50 lbs (10 reps) + 60 lbs (10 reps) = 55 lbs
- Workout detail test: StraightBar doubled avgWeight (94) correctly computed
- Edge case: sets without avgWeight produce undefined/0
- Full suite: 973 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of average weight calculations by computing directly from per-set data.
  * Enhanced reliability by removing dependency on optional formatted summary data.

* **Refactor**
  * Simplified weight aggregation logic using reps-weighted averages across individual sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->