### PR TITLE
fix: replace .filter() with index ranges and fix query patterns

### DIFF
--- a/convex/dataRetention.ts
+++ b/convex/dataRetention.ts
@@ -26,8 +26,7 @@ export const getExpiredAiUsageIds = internalQuery({
   handler: async (ctx, { cutoff, limit }) => {
     const records = await ctx.db
       .query("aiUsage")
-      .withIndex("by_createdAt")
-      .filter((q) => q.lt(q.field("createdAt"), cutoff))
+      .withIndex("by_createdAt", (q) => q.lt("createdAt", cutoff))
       .take(limit);
     return records.map((r) => r._id);
   },
@@ -39,8 +38,7 @@ export const getExpiredToolCallIds = internalQuery({
   handler: async (ctx, { cutoff, limit }) => {
     const records = await ctx.db
       .query("aiToolCalls")
-      .withIndex("by_createdAt")
-      .filter((q) => q.lt(q.field("createdAt"), cutoff))
+      .withIndex("by_createdAt", (q) => q.lt("createdAt", cutoff))
       .take(limit);
     return records.map((r) => r._id);
   },

--- a/convex/healthCheck.ts
+++ b/convex/healthCheck.ts
@@ -43,9 +43,8 @@ export const getExpiredTokenCount = internalQuery({
     const now = Date.now();
     const profiles = await ctx.db
       .query("userProfiles")
-      .withIndex("by_tonalTokenExpiresAt")
-      .filter((q) =>
-        q.and(q.gt(q.field("tonalTokenExpiresAt"), 0), q.lt(q.field("tonalTokenExpiresAt"), now)),
+      .withIndex("by_tonalTokenExpiresAt", (q) =>
+        q.gt("tonalTokenExpiresAt", 0).lt("tonalTokenExpiresAt", now),
       )
       .collect();
     return profiles.length;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -233,7 +233,8 @@ export default defineSchema({
     pushedAt: v.optional(v.number()),
   })
     .index("by_userId", ["userId"])
-    .index("by_status", ["status"]),
+    .index("by_status", ["status"])
+    .index("by_tonalWorkoutId", ["tonalWorkoutId"]),
 
   /** 7-day training schedule. Each day has a session type, status, and optional linked workout. */
   weekPlans: defineTable({
@@ -441,6 +442,7 @@ export default defineSchema({
   })
     .index("by_userId_movementId", ["userId", "movementId"])
     .index("by_userId_activityId", ["userId", "activityId"])
+    .index("by_userId_activityId_movementId", ["userId", "activityId", "movementId"])
     .index("by_userId_date", ["userId", "date"]),
 
   /** Strength score snapshots over time (synced from Tonal history). */

--- a/convex/tonal/historySyncMutations.ts
+++ b/convex/tonal/historySyncMutations.ts
@@ -100,10 +100,9 @@ export const persistExercisePerformance = internalMutation({
     for (const p of performances) {
       const existing = await ctx.db
         .query("exercisePerformance")
-        .withIndex("by_userId_activityId", (q) =>
-          q.eq("userId", userId).eq("activityId", p.activityId),
+        .withIndex("by_userId_activityId_movementId", (q) =>
+          q.eq("userId", userId).eq("activityId", p.activityId).eq("movementId", p.movementId),
         )
-        .filter((q) => q.eq(q.field("movementId"), p.movementId))
         .first();
       if (existing) continue;
       await ctx.db.insert("exercisePerformance", { userId, ...p, syncedAt: Date.now() });

--- a/convex/tonal/resync.ts
+++ b/convex/tonal/resync.ts
@@ -81,10 +81,11 @@ export const resyncAllUsers = internalAction({
 export const getConnectedUsers = internalQuery({
   args: {},
   handler: async (ctx) => {
-    const profiles = await ctx.db.query("userProfiles").collect();
-    return profiles
-      .filter((p) => p.tonalUserId)
-      .map((p) => ({ userId: p.userId, syncStatus: p.syncStatus }));
+    const profiles = await ctx.db
+      .query("userProfiles")
+      .withIndex("by_tonalUserId", (q) => q.gt("tonalUserId", ""))
+      .collect();
+    return profiles.map((p) => ({ userId: p.userId, syncStatus: p.syncStatus }));
   },
 });
 
@@ -92,8 +93,10 @@ export const getConnectedUsers = internalQuery({
 export const getSyncDiagnostics = internalQuery({
   args: {},
   handler: async (ctx) => {
-    const profiles = await ctx.db.query("userProfiles").collect();
-    const connected = profiles.filter((p) => p.tonalUserId);
+    const connected = await ctx.db
+      .query("userProfiles")
+      .withIndex("by_tonalUserId", (q) => q.gt("tonalUserId", ""))
+      .collect();
 
     const results = [];
     for (const p of connected) {

--- a/convex/workoutPlans.ts
+++ b/convex/workoutPlans.ts
@@ -369,7 +369,7 @@ export const markDeleted = internalMutation({
   handler: async (ctx, { tonalWorkoutId }) => {
     const plan = await ctx.db
       .query("workoutPlans")
-      .filter((q) => q.eq(q.field("tonalWorkoutId"), tonalWorkoutId))
+      .withIndex("by_tonalWorkoutId", (q) => q.eq("tonalWorkoutId", tonalWorkoutId))
       .unique();
 
     if (plan) {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -130,7 +130,7 @@ export default function ContactPage() {
                   placeholder="What's on your mind?"
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
-                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                   disabled={status === "submitting"}
                 />
               </div>

--- a/src/features/chat/ChatThread.tsx
+++ b/src/features/chat/ChatThread.tsx
@@ -3,9 +3,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "convex/react";
 import { useUIMessages } from "@convex-dev/agent/react";
-import { toUIMessages } from "@convex-dev/agent";
-import type { MessageDoc } from "@convex-dev/agent";
+import { toUIMessages, vMessageDoc } from "@convex-dev/agent";
 import type { UIMessage } from "@convex-dev/agent/react";
+import { parse } from "convex-helpers/validators";
 import { api } from "../../../convex/_generated/api";
 import { MessageList } from "./MessageList";
 import { ChatInput } from "./ChatInput";
@@ -51,8 +51,13 @@ export function ChatThread({ userInitial, threadId }: ChatThreadProps) {
 
   const handleLoadEarlier = () => {
     if (!history || history.messages.length === 0) return;
-    const converted = toUIMessages(history.messages as unknown as MessageDoc[]);
-    setHistoricalMessages((prev) => [...converted, ...prev]);
+    try {
+      const validated = history.messages.map((m) => parse(vMessageDoc, m));
+      const converted = toUIMessages(validated);
+      setHistoricalMessages((prev) => [...converted, ...prev]);
+    } catch (e) {
+      console.error("Failed to parse historical messages:", e);
+    }
   };
 
   // Show a local pending message until the server confirms it.

--- a/src/features/chat/ChatThread.tsx
+++ b/src/features/chat/ChatThread.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "convex/react";
 import { useUIMessages } from "@convex-dev/agent/react";
 import { toUIMessages } from "@convex-dev/agent";
+import type { MessageDoc } from "@convex-dev/agent";
 import type { UIMessage } from "@convex-dev/agent/react";
 import { api } from "../../../convex/_generated/api";
 import { MessageList } from "./MessageList";
@@ -50,8 +51,7 @@ export function ChatThread({ userInitial, threadId }: ChatThreadProps) {
 
   const handleLoadEarlier = () => {
     if (!history || history.messages.length === 0) return;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const converted = toUIMessages(history.messages as any);
+    const converted = toUIMessages(history.messages as unknown as MessageDoc[]);
     setHistoricalMessages((prev) => [...converted, ...prev]);
   };
 


### PR DESCRIPTION
## Summary

- Replace Convex DB `.filter()` calls with proper `.withIndex()` range bounds across 5 files
- Add 2 new indexes to eliminate remaining full/partial table scans
- Fix accessibility and type safety violations found by clean-code audit

## Changes

**Convex query optimization:**
- `convex/dataRetention.ts` -- Move `.filter(q.lt(...))` into `.withIndex()` range bounds for `aiUsage` and `aiToolCalls` queries
- `convex/healthCheck.ts` -- Move `.filter(q.and(q.gt(...), q.lt(...)))` into `.withIndex()` range for `by_tonalTokenExpiresAt`
- `convex/workoutPlans.ts` -- Replace `.filter()` with new `by_tonalWorkoutId` index
- `convex/tonal/historySyncMutations.ts` -- Replace `.filter()` on `movementId` with new `by_userId_activityId_movementId` compound index

**Schema:**
- `convex/schema.ts` -- Add `by_tonalWorkoutId` index on `workoutPlans`, `by_userId_activityId_movementId` index on `exercisePerformance`

**Unbounded collect cleanup:**
- `convex/tonal/resync.ts` -- Replace 2 full `userProfiles` table scans with `by_tonalUserId` indexed queries

**Frontend:**
- `src/app/contact/page.tsx` -- `focus:` changed to `focus-visible:` for keyboard-only focus rings
- `src/features/chat/ChatThread.tsx` -- Replace `as any` with typed `as unknown as MessageDoc[]`, remove eslint-disable comment

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [ ] New logic has tests (happy path + at least one error/edge case) -- no new logic, only query optimization
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [ ] Tested in browser (if UI changes) -- contact page focus ring change is CSS-only
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- `npx tsc --noEmit` -- passes with zero errors
- `npm test` -- 974/974 tests pass
- Schema changes add indexes only (no field changes) -- backward compatible, no data migration needed
- New indexes will be built automatically on next `npx convex dev` or `npx convex deploy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated contact form input focus behavior for improved keyboard navigation and accessibility.

* **Chores**
  * Optimized backend database queries and added strategic indexes for improved system performance.

* **Refactor**
  * Enhanced type safety in chat messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->