### PR TITLE
fix: surface BYOK errors and clean up orphaned pending messages

### DIFF
--- a/convex/ai/providers.ts
+++ b/convex/ai/providers.ts
@@ -12,6 +12,8 @@ export interface ProviderConfig {
   keyRegex: RegExp;
   keyFormatError: string;
   keySourceUrl: string;
+  /** Where users go to top up or check quota/billing on this provider. */
+  billingUrl: string;
   keyPlaceholder: string;
   keyFieldName: string;
   keyTimestampFieldName: string;
@@ -27,6 +29,7 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     keyFormatError:
       "Key format looks wrong. Gemini keys start with 'AIza' and are 39 characters long.",
     keySourceUrl: "https://aistudio.google.com/app/apikey",
+    billingUrl: "https://aistudio.google.com/app/apikey",
     keyPlaceholder: "AIza...",
     keyFieldName: "geminiApiKeyEncrypted",
     keyTimestampFieldName: "geminiApiKeyAddedAt",
@@ -42,6 +45,7 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     keyRegex: /^sk-ant-/,
     keyFormatError: "Key format looks wrong. Claude keys start with 'sk-ant-'.",
     keySourceUrl: "https://console.anthropic.com/settings/keys",
+    billingUrl: "https://console.anthropic.com/settings/billing",
     keyPlaceholder: "sk-ant-...",
     keyFieldName: "claudeApiKeyEncrypted",
     keyTimestampFieldName: "claudeApiKeyAddedAt",
@@ -58,6 +62,7 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     keyFormatError:
       "Key format looks wrong. OpenAI keys start with 'sk-' (but not 'sk-ant-' or 'sk-or-').",
     keySourceUrl: "https://platform.openai.com/api-keys",
+    billingUrl: "https://platform.openai.com/settings/organization/billing",
     keyPlaceholder: "sk-...",
     keyFieldName: "openaiApiKeyEncrypted",
     keyTimestampFieldName: "openaiApiKeyAddedAt",
@@ -73,6 +78,7 @@ export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
     keyRegex: /^sk-or-/,
     keyFormatError: "Key format looks wrong. OpenRouter keys start with 'sk-or-'.",
     keySourceUrl: "https://openrouter.ai/keys",
+    billingUrl: "https://openrouter.ai/credits",
     keyPlaceholder: "sk-or-...",
     keyFieldName: "openrouterApiKeyEncrypted",
     keyTimestampFieldName: "openrouterApiKeyAddedAt",

--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -1,5 +1,22 @@
+import { APICallError } from "@ai-sdk/provider";
 import { describe, expect, it } from "vitest";
 import { classifyByokError, isTransientError, withByokErrorSanitization } from "./resilience";
+
+function apiCallError(overrides: {
+  statusCode?: number;
+  isRetryable?: boolean;
+  responseBody?: string;
+  message?: string;
+}): APICallError {
+  return new APICallError({
+    message: overrides.message ?? "API call failed",
+    url: "https://example.test/v1/messages",
+    requestBodyValues: {},
+    statusCode: overrides.statusCode,
+    isRetryable: overrides.isRetryable ?? false,
+    responseBody: overrides.responseBody,
+  });
+}
 
 describe("isTransientError", () => {
   it("returns true for network errors", () => {
@@ -71,6 +88,15 @@ describe("isTransientError", () => {
 
   it("returns false for generic errors without status", () => {
     expect(isTransientError(new Error("Something broke"))).toBe(false);
+  });
+
+  it("defers to APICallError.isRetryable = true", () => {
+    expect(isTransientError(apiCallError({ statusCode: 529, isRetryable: true }))).toBe(true);
+  });
+
+  it("defers to APICallError.isRetryable = false even when status looks transient", () => {
+    // SDK says don't retry (e.g., auth-layer 429), trust it.
+    expect(isTransientError(apiCallError({ statusCode: 429, isRetryable: false }))).toBe(false);
   });
 });
 
@@ -154,6 +180,22 @@ describe("classifyByokError", () => {
     expect(classifyByokError("oops")).toBeNull();
     expect(classifyByokError(null)).toBeNull();
     expect(classifyByokError(undefined)).toBeNull();
+  });
+
+  it("classifies APICallError 401 via statusCode, not ad-hoc .status", () => {
+    expect(classifyByokError(apiCallError({ statusCode: 401 }))).toBe("byok_key_invalid");
+  });
+
+  it("classifies APICallError 429 via statusCode", () => {
+    expect(classifyByokError(apiCallError({ statusCode: 429 }))).toBe("byok_quota_exceeded");
+  });
+
+  it("classifies APICallError 400 billing body via responseBody", () => {
+    const err = apiCallError({
+      statusCode: 400,
+      responseBody: JSON.stringify({ error: { message: "Your credit balance is too low" } }),
+    });
+    expect(classifyByokError(err)).toBe("byok_quota_exceeded");
   });
 });
 

--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -1,21 +1,12 @@
 import { describe, expect, it } from "vitest";
-import {
-  classifyByokError,
-  isByokQuotaError,
-  isTransientError,
-  throwIfByokError,
-  withByokErrorSanitization,
-} from "./resilience";
+import { classifyByokError, isTransientError, withByokErrorSanitization } from "./resilience";
 
 describe("isTransientError", () => {
   it("returns true for network errors", () => {
     expect(isTransientError(new TypeError("fetch failed"))).toBe(true);
   });
 
-  it("returns true for 429 rate limit (retryable; BYOK routing handled upstream)", () => {
-    // For house-key users, 429 from Gemini "high demand" should be retried.
-    // BYOK users' 429s are caught by throwIfByokError before isTransientError
-    // is ever called, so this classification is safe for both paths.
+  it("returns true for 429 rate limit", () => {
     const error = Object.assign(new Error("Rate limited"), { status: 429 });
     expect(isTransientError(error)).toBe(true);
   });
@@ -95,8 +86,6 @@ describe("classifyByokError", () => {
   });
 
   it("classifies an 'API key not valid' message as byok_key_invalid", () => {
-    // Google AI's actual error format. The classifier matches on substring
-    // so we never have to read the full body (which could echo the key).
     const error = new Error("API key not valid. Please pass a valid API key.");
     expect(classifyByokError(error)).toBe("byok_key_invalid");
   });
@@ -119,9 +108,6 @@ describe("classifyByokError", () => {
   });
 
   it("classifies Anthropic 'credit balance is too low' as byok_quota_exceeded", () => {
-    // The exact error text Anthropic returns when the account has no
-    // credit. This is what blocked Randy's thread for 24h before we
-    // realized the classifier wasn't seeing it.
     const error = new Error(
       "Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",
     );
@@ -129,9 +115,6 @@ describe("classifyByokError", () => {
   });
 
   it("classifies an error whose billing text lives on responseBody", () => {
-    // The Vercel AI SDK often surfaces a generic outer message like
-    // "API call failed" and keeps the provider's real text on `.responseBody`.
-    // The classifier must reach into that field or the error slips through.
     const error = Object.assign(new Error("AI_APICallError: Bad Request"), {
       status: 400,
       responseBody: JSON.stringify({
@@ -171,69 +154,6 @@ describe("classifyByokError", () => {
     expect(classifyByokError("oops")).toBeNull();
     expect(classifyByokError(null)).toBeNull();
     expect(classifyByokError(undefined)).toBeNull();
-  });
-});
-
-describe("isByokQuotaError", () => {
-  it("returns true for 429 status code", () => {
-    const error = Object.assign(new Error("Too Many Requests"), { status: 429 });
-    expect(isByokQuotaError(error)).toBe(true);
-  });
-
-  it("returns true for resource_exhausted message", () => {
-    const error = new Error("RESOURCE_EXHAUSTED: Quota exceeded");
-    expect(isByokQuotaError(error)).toBe(true);
-  });
-
-  it("returns true for quota message", () => {
-    const error = new Error("You have exceeded your quota for this model");
-    expect(isByokQuotaError(error)).toBe(true);
-  });
-
-  it("returns true for rate_limit message", () => {
-    const error = new Error("rate_limit_exceeded: try again later");
-    expect(isByokQuotaError(error)).toBe(true);
-  });
-
-  it("returns false for 500 server error", () => {
-    const error = Object.assign(new Error("Internal"), { status: 500 });
-    expect(isByokQuotaError(error)).toBe(false);
-  });
-
-  it("returns false for non-Error values", () => {
-    expect(isByokQuotaError("string error")).toBe(false);
-    expect(isByokQuotaError(null)).toBe(false);
-  });
-
-  it("returns false for generic errors", () => {
-    expect(isByokQuotaError(new Error("Something broke"))).toBe(false);
-  });
-});
-
-describe("throwIfByokError", () => {
-  it("throws a sanitized Error with the BYOK code as the message", () => {
-    const error = Object.assign(new Error("Unauthorized"), { status: 401 });
-    expect(() => throwIfByokError(error)).toThrow("byok_key_invalid");
-  });
-
-  it("does not leak the original error message into the sanitized error", () => {
-    // If the AI SDK ever wraps the key in the error message ("API key
-    // AIza... is invalid"), the sanitized error must not echo that.
-    const leakKey = "AIza_leak_for_throw_test";
-    const error = new Error(`API key not valid (${leakKey})`);
-    try {
-      throwIfByokError(error);
-      throw new Error("expected throwIfByokError to throw");
-    } catch (caught) {
-      expect(caught).toBeInstanceOf(Error);
-      expect((caught as Error).message).toBe("byok_key_invalid");
-      expect((caught as Error).message).not.toContain(leakKey);
-    }
-  });
-
-  it("returns without throwing for non-BYOK errors", () => {
-    const error = Object.assign(new Error("Internal"), { status: 500 });
-    expect(() => throwIfByokError(error)).not.toThrow();
   });
 });
 

--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -1,6 +1,11 @@
 import { APICallError } from "@ai-sdk/provider";
 import { describe, expect, it } from "vitest";
-import { classifyByokError, isTransientError, withByokErrorSanitization } from "./resilience";
+import {
+  buildByokErrorMessage,
+  classifyByokError,
+  isTransientError,
+  withByokErrorSanitization,
+} from "./resilience";
 
 function apiCallError(overrides: {
   statusCode?: number;
@@ -196,6 +201,30 @@ describe("classifyByokError", () => {
       responseBody: JSON.stringify({ error: { message: "Your credit balance is too low" } }),
     });
     expect(classifyByokError(err)).toBe("byok_quota_exceeded");
+  });
+});
+
+describe("buildByokErrorMessage", () => {
+  it("names the provider and links to its billing page on quota", () => {
+    const msg = buildByokErrorMessage("byok_quota_exceeded", "claude");
+
+    expect(msg).toContain("Anthropic Claude");
+    expect(msg).toContain("(https://console.anthropic.com/settings/billing)");
+    expect(msg).toContain("(/settings)");
+  });
+
+  it("names the provider and links to settings on invalid key", () => {
+    const msg = buildByokErrorMessage("byok_key_invalid", "gemini");
+
+    expect(msg).toContain("Google Gemini");
+    expect(msg).toContain("(/settings)");
+  });
+
+  it("uses the OpenAI billing URL for OpenAI quota errors", () => {
+    const msg = buildByokErrorMessage("byok_quota_exceeded", "openai");
+
+    expect(msg).toContain("OpenAI");
+    expect(msg).toContain("(https://platform.openai.com/settings/organization/billing)");
   });
 });
 

--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -118,6 +118,45 @@ describe("classifyByokError", () => {
     expect(classifyByokError(error)).toBe("byok_quota_exceeded");
   });
 
+  it("classifies Anthropic 'credit balance is too low' as byok_quota_exceeded", () => {
+    // The exact error text Anthropic returns when the account has no
+    // credit. This is what blocked Randy's thread for 24h before we
+    // realized the classifier wasn't seeing it.
+    const error = new Error(
+      "Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",
+    );
+    expect(classifyByokError(error)).toBe("byok_quota_exceeded");
+  });
+
+  it("classifies an error whose billing text lives on responseBody", () => {
+    // The Vercel AI SDK often surfaces a generic outer message like
+    // "API call failed" and keeps the provider's real text on `.responseBody`.
+    // The classifier must reach into that field or the error slips through.
+    const error = Object.assign(new Error("AI_APICallError: Bad Request"), {
+      status: 400,
+      responseBody: JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: "Your credit balance is too low",
+        },
+      }),
+    });
+    expect(classifyByokError(error)).toBe("byok_quota_exceeded");
+  });
+
+  it("classifies an error whose auth text lives on cause.message", () => {
+    const cause = new Error("invalid_api_key: authentication failed");
+    const error = new Error("request failed");
+    (error as Error & { cause?: unknown }).cause = cause;
+    expect(classifyByokError(error)).toBe("byok_key_invalid");
+  });
+
+  it("classifies OpenAI 'insufficient_quota' as byok_quota_exceeded", () => {
+    const error = new Error("You exceeded your current quota: insufficient_quota.");
+    expect(classifyByokError(error)).toBe("byok_quota_exceeded");
+  });
+
   it("classifies a 'safety' substring as byok_safety_blocked", () => {
     const error = new Error("Response was blocked due to safety filters");
     expect(classifyByokError(error)).toBe("byok_safety_blocked");

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -6,6 +6,7 @@ import { components, internal } from "../_generated/api";
 import type { ActionCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import { BUDGET_WARNING_THRESHOLD, DAILY_TOKEN_BUDGET } from "../aiUsage";
+import { getProviderConfig, type ProviderId } from "./providers";
 
 const AI_ERROR_MESSAGE = "I'm having trouble right now. Please try again in a moment.";
 const BUDGET_EXCEEDED_MESSAGE =
@@ -13,16 +14,22 @@ const BUDGET_EXCEEDED_MESSAGE =
 const MAX_OUTPUT_TOKENS = 4096;
 const RETRY_DELAY_MS = 3000;
 
-const BYOK_ERROR_MESSAGES: Record<ByokErrorCode, string> = {
-  byok_key_invalid:
-    "Your API key was rejected by the provider. Open **Settings → API Keys** to check or replace it, then try again.",
-  byok_quota_exceeded:
-    "Your API key's provider is rejecting requests — likely out of credit or over quota. Top up with your provider, or switch providers under **Settings → API Keys**, and try again.",
-  byok_safety_blocked:
-    "The provider blocked that response for safety reasons. Try rephrasing and sending again.",
-  byok_unknown_error:
-    "Your API key's provider returned an unexpected error. Double-check the key under **Settings → API Keys** or try again later.",
-};
+const SETTINGS_LINK = "[Settings](/settings)";
+
+export function buildByokErrorMessage(code: ByokErrorCode, provider: ProviderId): string {
+  const config = getProviderConfig(provider);
+  const billingLink = `[${config.label} billing](${config.billingUrl})`;
+  switch (code) {
+    case "byok_key_invalid":
+      return `**${config.label} rejected your API key.** Check or replace it in ${SETTINGS_LINK}, then try again.`;
+    case "byok_quota_exceeded":
+      return `**${config.label} is rejecting requests** — your account is out of credit or over quota. Top up at ${billingLink}, or switch providers in ${SETTINGS_LINK}, then try again.`;
+    case "byok_safety_blocked":
+      return `**${config.label} blocked that response for safety.** Try rephrasing and sending again.`;
+    case "byok_unknown_error":
+      return `**${config.label} returned an unexpected error.** Check your key in ${SETTINGS_LINK} or try again later.`;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Error classification
@@ -158,6 +165,8 @@ interface StreamWithRetryArgs {
   promptMessageId?: string;
   /** True when the user is on their own API key (not the house key). */
   isByok: boolean;
+  /** The active provider. Drives the provider-specific BYOK error message. */
+  provider: ProviderId;
 }
 
 type PromptArgs =
@@ -175,7 +184,7 @@ const ATTEMPT_TIMEOUT_MS = 180_000;
 type AttemptOutcome = { done: true } | { done: false; error: unknown };
 
 export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs): Promise<void> {
-  const { primaryAgent, fallbackAgent, threadId, userId, isByok } = args;
+  const { primaryAgent, fallbackAgent, threadId, userId, isByok, provider } = args;
   const promptArgs: PromptArgs = args.promptMessageId
     ? args.prompt !== undefined
       ? {
@@ -186,7 +195,7 @@ export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs)
       : { promptMessageId: args.promptMessageId, maxOutputTokens: MAX_OUTPUT_TOKENS }
     : { prompt: args.prompt!, maxOutputTokens: MAX_OUTPUT_TOKENS };
 
-  const errorReport = { threadId, userId, isByok };
+  const errorReport = { threadId, userId, isByok, provider };
 
   // `done` = success or terminal-error-already-reported; otherwise retryable transient.
   const runAttempt = async (agent: Agent): Promise<AttemptOutcome> => {
@@ -239,6 +248,7 @@ interface ErrorReport {
   userId: string;
   error: unknown;
   isByok: boolean;
+  provider: ProviderId;
 }
 
 // streamText's abortSignal handler finalizes on clean aborts; provider errors
@@ -271,11 +281,11 @@ async function tryReportByok(ctx: ActionCtx, report: ErrorReport): Promise<boole
   await saveMessage(ctx, components.agent, {
     threadId: report.threadId,
     userId: report.userId,
-    message: { role: "assistant", content: BYOK_ERROR_MESSAGES[code] },
+    message: { role: "assistant", content: buildByokErrorMessage(code, report.provider) },
   });
   await ctx.runAction(internal.discord.notifyError, {
     source: "streamWithRetry",
-    message: `${code} (${report.error instanceof Error ? report.error.name : "Unknown"})`,
+    message: `${code} on ${report.provider} (${report.error instanceof Error ? report.error.name : "Unknown"})`,
     userId: report.userId,
   });
   return true;

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -77,15 +77,14 @@ export type ByokErrorCode =
  */
 function gatherErrorText(error: Error): string {
   const parts: string[] = [error.message];
-  const extended = error as Error & {
-    responseBody?: unknown;
-    cause?: unknown;
-    data?: unknown;
-  };
-  if (typeof extended.responseBody === "string") parts.push(extended.responseBody);
-  if (extended.cause instanceof Error) parts.push(extended.cause.message);
-  if (extended.data && typeof extended.data === "object") {
-    parts.push(JSON.stringify(extended.data));
+  if ("responseBody" in error && typeof error.responseBody === "string") {
+    parts.push(error.responseBody);
+  }
+  if ("cause" in error && error.cause instanceof Error) {
+    parts.push(error.cause.message);
+  }
+  if ("data" in error && error.data && typeof error.data === "object") {
+    parts.push(JSON.stringify(error.data));
   }
   return parts.join(" ").toLowerCase();
 }
@@ -203,6 +202,8 @@ export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs)
       : { promptMessageId: args.promptMessageId, maxOutputTokens: MAX_OUTPUT_TOKENS }
     : { prompt: args.prompt!, maxOutputTokens: MAX_OUTPUT_TOKENS };
 
+  const errorReport = { threadId, userId, isByok };
+
   /**
    * Try one attempt. Returns `true` when the attempt succeeded OR produced
    * a terminal error that's already been surfaced to the user, so the
@@ -214,18 +215,9 @@ export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs)
       await attemptStream(ctx, agent, threadId, userId, promptArgs);
       return true;
     } catch (error) {
-      // BYOK errors always land as a user-visible assistant message so the
-      // user knows to fix their key — never silently abort and never fall
-      // back to the house key under BYOK.
-      if (isByok) {
-        const code = classifyByokError(error);
-        if (code !== null) {
-          await saveByokErrorAndNotify(ctx, threadId, userId, code, error);
-          return true;
-        }
-      }
+      if (await tryReportByok(ctx, { ...errorReport, error })) return true;
       if (!isTransientError(error)) {
-        await saveErrorAndNotify(ctx, threadId, userId, error);
+        await reportError(ctx, { ...errorReport, error });
         return true;
       }
       return false;
@@ -239,14 +231,8 @@ export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs)
   try {
     await attemptStream(ctx, fallbackAgent, threadId, userId, promptArgs);
   } catch (error) {
-    if (isByok) {
-      const code = classifyByokError(error);
-      if (code !== null) {
-        await saveByokErrorAndNotify(ctx, threadId, userId, code, error);
-        return;
-      }
-    }
-    await saveErrorAndNotify(ctx, threadId, userId, error);
+    if (await tryReportByok(ctx, { ...errorReport, error })) return;
+    await reportError(ctx, { ...errorReport, error });
   }
 }
 
@@ -269,6 +255,13 @@ async function attemptStream(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+interface ErrorReport {
+  threadId: string;
+  userId: string;
+  error: unknown;
+  isByok: boolean;
 }
 
 /**
@@ -299,50 +292,48 @@ async function finalizePendingMessages(
   }
 }
 
-async function saveErrorAndNotify(
-  ctx: ActionCtx,
-  threadId: string,
-  userId: string,
-  error: unknown,
-): Promise<void> {
-  const reason = error instanceof Error ? error.message : String(error);
-  await finalizePendingMessages(ctx, threadId, reason);
+/**
+ * If `error` is BYOK-classifiable, save an actionable assistant message and
+ * return true. Returns false when the error isn't BYOK-related (or the
+ * user isn't on BYOK), so the caller can fall through to transient /
+ * generic handling.
+ */
+async function tryReportByok(ctx: ActionCtx, report: ErrorReport): Promise<boolean> {
+  if (!report.isByok) return false;
+  const code = classifyByokError(report.error);
+  if (code === null) return false;
+  // Use the error code (not the raw message) as the finalize reason since
+  // the provider body can include the decrypted key.
+  await finalizePendingMessages(ctx, report.threadId, code);
   await saveMessage(ctx, components.agent, {
-    threadId,
-    userId,
+    threadId: report.threadId,
+    userId: report.userId,
+    message: { role: "assistant", content: BYOK_ERROR_MESSAGES[code] },
+  });
+  await ctx.runAction(internal.discord.notifyError, {
+    source: "streamWithRetry",
+    message: `${code} (${report.error instanceof Error ? report.error.name : "Unknown"})`,
+    userId: report.userId,
+  });
+  return true;
+}
+
+/**
+ * Generic terminal-error path: write the fallback "I'm having trouble"
+ * assistant message and notify ops with the raw error summary.
+ */
+async function reportError(ctx: ActionCtx, report: ErrorReport): Promise<void> {
+  const reason = report.error instanceof Error ? report.error.message : String(report.error);
+  await finalizePendingMessages(ctx, report.threadId, reason);
+  await saveMessage(ctx, components.agent, {
+    threadId: report.threadId,
+    userId: report.userId,
     message: { role: "assistant", content: AI_ERROR_MESSAGE },
   });
   await ctx.runAction(internal.discord.notifyError, {
     source: "streamWithRetry",
     message: reason,
-    userId,
-  });
-}
-
-/**
- * Save a user-visible assistant message explaining the BYOK error class so
- * the user can act on it, and ping ops with the (safe) error code only —
- * not the raw provider message, which can echo the decrypted key.
- */
-async function saveByokErrorAndNotify(
-  ctx: ActionCtx,
-  threadId: string,
-  userId: string,
-  code: ByokErrorCode,
-  error: unknown,
-): Promise<void> {
-  // Use the error code (not the raw message) as the finalize reason since
-  // the provider body can include the decrypted key.
-  await finalizePendingMessages(ctx, threadId, code);
-  await saveMessage(ctx, components.agent, {
-    threadId,
-    userId,
-    message: { role: "assistant", content: BYOK_ERROR_MESSAGES[code] },
-  });
-  await ctx.runAction(internal.discord.notifyError, {
-    source: "streamWithRetry",
-    message: `${code} (${error instanceof Error ? error.name : "Unknown"})`,
-    userId,
+    userId: report.userId,
   });
 }
 

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -12,6 +12,20 @@ const BUDGET_EXCEEDED_MESSAGE =
 const MAX_OUTPUT_TOKENS = 4096;
 const RETRY_DELAY_MS = 3000;
 
+// User-visible messages for each BYOK error class. Written directly into
+// the assistant side of the thread so the user sees an actionable message
+// instead of the generic "I'm having trouble" fallback.
+const BYOK_ERROR_MESSAGES: Record<ByokErrorCode, string> = {
+  byok_key_invalid:
+    "Your API key was rejected by the provider. Open **Settings → API Keys** to check or replace it, then try again.",
+  byok_quota_exceeded:
+    "Your API key's provider is rejecting requests — likely out of credit or over quota. Top up with your provider, or switch providers under **Settings → API Keys**, and try again.",
+  byok_safety_blocked:
+    "The provider blocked that response for safety reasons. Try rephrasing and sending again.",
+  byok_unknown_error:
+    "Your API key's provider returned an unexpected error. Double-check the key under **Settings → API Keys** or try again later.",
+};
+
 // ---------------------------------------------------------------------------
 // Error classification
 // ---------------------------------------------------------------------------
@@ -54,11 +68,33 @@ export type ByokErrorCode =
   | "byok_safety_blocked"
   | "byok_unknown_error";
 
+/**
+ * Collect every text fragment that could classify a BYOK error. The Vercel
+ * AI SDK often wraps provider errors in an `APICallError` whose `.message`
+ * is just "API call failed", while the real detail lives on `.responseBody`
+ * or `.cause.message`. We must pattern-match across all of them so errors
+ * like Anthropic's "Your credit balance is too low" don't slip through.
+ */
+function gatherErrorText(error: Error): string {
+  const parts: string[] = [error.message];
+  const extended = error as Error & {
+    responseBody?: unknown;
+    cause?: unknown;
+    data?: unknown;
+  };
+  if (typeof extended.responseBody === "string") parts.push(extended.responseBody);
+  if (extended.cause instanceof Error) parts.push(extended.cause.message);
+  if (extended.data && typeof extended.data === "object") {
+    parts.push(JSON.stringify(extended.data));
+  }
+  return parts.join(" ").toLowerCase();
+}
+
 export function classifyByokError(error: unknown): ByokErrorCode | null {
   if (!(error instanceof Error)) return null;
 
   const status = (error as Error & { status?: number }).status;
-  const lower = error.message.toLowerCase();
+  const lower = gatherErrorText(error);
 
   if (status === 401 || status === 403) return "byok_key_invalid";
   if (
@@ -78,6 +114,8 @@ export function classifyByokError(error: unknown): ByokErrorCode | null {
     lower.includes("rate_limit_error") ||
     lower.includes("rate_limit_exceeded") ||
     lower.includes("credits are depleted") ||
+    lower.includes("credit balance") ||
+    lower.includes("insufficient_quota") ||
     lower.includes("billing")
   ) {
     return "byok_quota_exceeded";
@@ -154,7 +192,7 @@ const STREAM_OPTIONS = {
 const ATTEMPT_TIMEOUT_MS = 180_000;
 
 export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs): Promise<void> {
-  const { primaryAgent, fallbackAgent, threadId, userId } = args;
+  const { primaryAgent, fallbackAgent, threadId, userId, isByok } = args;
   const promptArgs: PromptArgs = args.promptMessageId
     ? args.prompt !== undefined
       ? {
@@ -165,36 +203,49 @@ export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs)
       : { promptMessageId: args.promptMessageId, maxOutputTokens: MAX_OUTPUT_TOKENS }
     : { prompt: args.prompt!, maxOutputTokens: MAX_OUTPUT_TOKENS };
 
-  try {
-    await attemptStream(ctx, primaryAgent, threadId, userId, promptArgs);
-    return;
-  } catch (error) {
-    // BYOK errors are terminal under BYOK: never silently fall back to the house key.
-    throwIfByokError(error);
-    if (args.isByok && isByokQuotaError(error)) throw new Error("byok_quota_exceeded");
-    if (!isTransientError(error)) {
-      await saveErrorAndNotify(ctx, threadId, userId, error);
-      return;
+  /**
+   * Try one attempt. Returns `true` when the attempt succeeded OR produced
+   * a terminal error that's already been surfaced to the user, so the
+   * caller should stop. Returns `false` only for transient errors that
+   * should be retried on the next attempt in the chain.
+   */
+  const runAttempt = async (agent: Agent): Promise<boolean> => {
+    try {
+      await attemptStream(ctx, agent, threadId, userId, promptArgs);
+      return true;
+    } catch (error) {
+      // BYOK errors always land as a user-visible assistant message so the
+      // user knows to fix their key — never silently abort and never fall
+      // back to the house key under BYOK.
+      if (isByok) {
+        const code = classifyByokError(error);
+        if (code !== null) {
+          await saveByokErrorAndNotify(ctx, threadId, userId, code, error);
+          return true;
+        }
+      }
+      if (!isTransientError(error)) {
+        await saveErrorAndNotify(ctx, threadId, userId, error);
+        return true;
+      }
+      return false;
     }
-  }
+  };
 
+  if (await runAttempt(primaryAgent)) return;
   await delay(RETRY_DELAY_MS);
-  try {
-    await attemptStream(ctx, primaryAgent, threadId, userId, promptArgs);
-    return;
-  } catch (error) {
-    throwIfByokError(error);
-    if (args.isByok && isByokQuotaError(error)) throw new Error("byok_quota_exceeded");
-    if (!isTransientError(error)) {
-      await saveErrorAndNotify(ctx, threadId, userId, error);
-      return;
-    }
-  }
+  if (await runAttempt(primaryAgent)) return;
 
   try {
     await attemptStream(ctx, fallbackAgent, threadId, userId, promptArgs);
   } catch (error) {
-    throwIfByokError(error);
+    if (isByok) {
+      const code = classifyByokError(error);
+      if (code !== null) {
+        await saveByokErrorAndNotify(ctx, threadId, userId, code, error);
+        return;
+      }
+    }
     await saveErrorAndNotify(ctx, threadId, userId, error);
   }
 }
@@ -220,12 +271,42 @@ async function attemptStream(
   }
 }
 
+/**
+ * Finalize any assistant messages left in `pending` state on the thread.
+ * Normally `streamText`'s abortSignal handler does this, but provider
+ * errors (network/billing/auth) surface directly as throws from
+ * `result.text` — in that path the pending row is stranded forever until
+ * we explicitly mark it failed. Must run before we save the follow-up
+ * error message so the thread doesn't show a dangling spinner above the
+ * explanation.
+ */
+async function finalizePendingMessages(
+  ctx: ActionCtx,
+  threadId: string,
+  reason: string,
+): Promise<void> {
+  const result = await ctx.runQuery(components.agent.messages.listMessagesByThreadId, {
+    threadId,
+    paginationOpts: { cursor: null, numItems: 10 },
+    order: "desc",
+  });
+  for (const message of result.page) {
+    if (message.status !== "pending") continue;
+    await ctx.runMutation(components.agent.messages.finalizeMessage, {
+      messageId: message._id,
+      result: { status: "failed", error: reason },
+    });
+  }
+}
+
 async function saveErrorAndNotify(
   ctx: ActionCtx,
   threadId: string,
   userId: string,
   error: unknown,
 ): Promise<void> {
+  const reason = error instanceof Error ? error.message : String(error);
+  await finalizePendingMessages(ctx, threadId, reason);
   await saveMessage(ctx, components.agent, {
     threadId,
     userId,
@@ -233,7 +314,34 @@ async function saveErrorAndNotify(
   });
   await ctx.runAction(internal.discord.notifyError, {
     source: "streamWithRetry",
-    message: error instanceof Error ? error.message : String(error),
+    message: reason,
+    userId,
+  });
+}
+
+/**
+ * Save a user-visible assistant message explaining the BYOK error class so
+ * the user can act on it, and ping ops with the (safe) error code only —
+ * not the raw provider message, which can echo the decrypted key.
+ */
+async function saveByokErrorAndNotify(
+  ctx: ActionCtx,
+  threadId: string,
+  userId: string,
+  code: ByokErrorCode,
+  error: unknown,
+): Promise<void> {
+  // Use the error code (not the raw message) as the finalize reason since
+  // the provider body can include the decrypted key.
+  await finalizePendingMessages(ctx, threadId, code);
+  await saveMessage(ctx, components.agent, {
+    threadId,
+    userId,
+    message: { role: "assistant", content: BYOK_ERROR_MESSAGES[code] },
+  });
+  await ctx.runAction(internal.discord.notifyError, {
+    source: "streamWithRetry",
+    message: `${code} (${error instanceof Error ? error.name : "Unknown"})`,
     userId,
   });
 }

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -1,6 +1,7 @@
 import type { Agent } from "@convex-dev/agent";
 import type { ModelMessage } from "@ai-sdk/provider-utils";
 import { saveMessage } from "@convex-dev/agent";
+import { APICallError } from "@ai-sdk/provider";
 import { components, internal } from "../_generated/api";
 import type { ActionCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
@@ -39,6 +40,10 @@ const TRANSIENT_MESSAGE_PATTERNS = [
 ];
 
 export function isTransientError(error: unknown): boolean {
+  // Prefer the SDK's own retry decision — it knows provider-specific cases
+  // like Anthropic 529 "overloaded" that our pattern list would miss.
+  if (APICallError.isInstance(error)) return error.isRetryable;
+
   if (error instanceof TypeError && error.message.includes("fetch")) return true;
 
   if (error instanceof Error) {
@@ -84,7 +89,11 @@ function gatherErrorText(error: Error): string {
 export function classifyByokError(error: unknown): ByokErrorCode | null {
   if (!(error instanceof Error)) return null;
 
-  const status = (error as Error & { status?: number }).status;
+  // APICallError exposes a typed statusCode; fall back to ad-hoc `.status`
+  // on bare errors (raw fetch, provider SDKs that don't wrap in APICallError).
+  const status = APICallError.isInstance(error)
+    ? error.statusCode
+    : (error as Error & { status?: number }).status;
   const lower = gatherErrorText(error);
 
   if (status === 401 || status === 403) return "byok_key_invalid";

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -12,9 +12,6 @@ const BUDGET_EXCEEDED_MESSAGE =
 const MAX_OUTPUT_TOKENS = 4096;
 const RETRY_DELAY_MS = 3000;
 
-// User-visible messages for each BYOK error class. Written directly into
-// the assistant side of the thread so the user sees an actionable message
-// instead of the generic "I'm having trouble" fallback.
 const BYOK_ERROR_MESSAGES: Record<ByokErrorCode, string> = {
   byok_key_invalid:
     "Your API key was rejected by the provider. Open **Settings → API Keys** to check or replace it, then try again.",
@@ -68,13 +65,8 @@ export type ByokErrorCode =
   | "byok_safety_blocked"
   | "byok_unknown_error";
 
-/**
- * Collect every text fragment that could classify a BYOK error. The Vercel
- * AI SDK often wraps provider errors in an `APICallError` whose `.message`
- * is just "API call failed", while the real detail lives on `.responseBody`
- * or `.cause.message`. We must pattern-match across all of them so errors
- * like Anthropic's "Your credit balance is too low" don't slip through.
- */
+// Vercel AI SDK wraps provider errors: .message is generic, the real text
+// lives on .responseBody / .cause.message. Pattern-match across all of them.
 function gatherErrorText(error: Error): string {
   const parts: string[] = [error.message];
   if ("responseBody" in error && typeof error.responseBody === "string") {
@@ -133,30 +125,13 @@ export function classifyByokError(error: unknown): ByokErrorCode | null {
   return null;
 }
 
-export function throwIfByokError(error: unknown): void {
-  const code = classifyByokError(error);
-  if (code !== null) throw new Error(code);
-}
-
-export function isByokQuotaError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const status = (error as Error & { status?: number }).status;
-  if (status === 429) return true;
-  const lower = error.message.toLowerCase();
-  return (
-    lower.includes("resource_exhausted") || lower.includes("quota") || lower.includes("rate_limit")
-  );
-}
-
-// Sanitization is mandatory: Google AI error bodies can echo the decrypted key.
+// Google AI error bodies can echo the decrypted key — never rethrow raw.
 export async function withByokErrorSanitization<T>(fn: () => Promise<T>): Promise<T> {
   try {
     return await fn();
   } catch (err) {
     const code = classifyByokError(err);
-    if (code !== null) {
-      throw new Error(code);
-    }
+    if (code !== null) throw new Error(code);
     throw err;
   }
 }
@@ -170,7 +145,6 @@ interface StreamWithRetryArgs {
   fallbackAgent: Agent;
   threadId: string;
   userId: string;
-  /** Text prompt or multimodal message array (text + images). */
   prompt?: string | Array<ModelMessage>;
   promptMessageId?: string;
   /** True when the user is on their own API key (not the house key). */
@@ -186,9 +160,10 @@ const STREAM_OPTIONS = {
   saveStreamDeltas: { chunking: "word" as const, throttleMs: 100 },
 };
 
-// Convex actions have a 600s hard limit. Budget 180s per attempt so all three
-// attempts (primary + retry + fallback) fit within the action lifetime.
+// Convex actions have a 600s hard cap; budget 180s per attempt so 3 fit.
 const ATTEMPT_TIMEOUT_MS = 180_000;
+
+type AttemptOutcome = { done: true } | { done: false; error: unknown };
 
 export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs): Promise<void> {
   const { primaryAgent, fallbackAgent, threadId, userId, isByok } = args;
@@ -204,36 +179,29 @@ export async function streamWithRetry(ctx: ActionCtx, args: StreamWithRetryArgs)
 
   const errorReport = { threadId, userId, isByok };
 
-  /**
-   * Try one attempt. Returns `true` when the attempt succeeded OR produced
-   * a terminal error that's already been surfaced to the user, so the
-   * caller should stop. Returns `false` only for transient errors that
-   * should be retried on the next attempt in the chain.
-   */
-  const runAttempt = async (agent: Agent): Promise<boolean> => {
+  // `done` = success or terminal-error-already-reported; otherwise retryable transient.
+  const runAttempt = async (agent: Agent): Promise<AttemptOutcome> => {
     try {
       await attemptStream(ctx, agent, threadId, userId, promptArgs);
-      return true;
+      return { done: true };
     } catch (error) {
-      if (await tryReportByok(ctx, { ...errorReport, error })) return true;
+      if (await tryReportByok(ctx, { ...errorReport, error })) return { done: true };
       if (!isTransientError(error)) {
         await reportError(ctx, { ...errorReport, error });
-        return true;
+        return { done: true };
       }
-      return false;
+      return { done: false, error };
     }
   };
 
-  if (await runAttempt(primaryAgent)) return;
+  if ((await runAttempt(primaryAgent)).done) return;
   await delay(RETRY_DELAY_MS);
-  if (await runAttempt(primaryAgent)) return;
+  if ((await runAttempt(primaryAgent)).done) return;
 
-  try {
-    await attemptStream(ctx, fallbackAgent, threadId, userId, promptArgs);
-  } catch (error) {
-    if (await tryReportByok(ctx, { ...errorReport, error })) return;
-    await reportError(ctx, { ...errorReport, error });
-  }
+  const final = await runAttempt(fallbackAgent);
+  if (final.done) return;
+  // Fallback also hit a transient error — terminal now, surface the generic message.
+  await reportError(ctx, { ...errorReport, error: final.error });
 }
 
 async function attemptStream(
@@ -264,15 +232,8 @@ interface ErrorReport {
   isByok: boolean;
 }
 
-/**
- * Finalize any assistant messages left in `pending` state on the thread.
- * Normally `streamText`'s abortSignal handler does this, but provider
- * errors (network/billing/auth) surface directly as throws from
- * `result.text` — in that path the pending row is stranded forever until
- * we explicitly mark it failed. Must run before we save the follow-up
- * error message so the thread doesn't show a dangling spinner above the
- * explanation.
- */
+// streamText's abortSignal handler finalizes on clean aborts; provider errors
+// thrown from result.text bypass that path and leave a stranded pending row.
 async function finalizePendingMessages(
   ctx: ActionCtx,
   threadId: string,
@@ -292,18 +253,11 @@ async function finalizePendingMessages(
   }
 }
 
-/**
- * If `error` is BYOK-classifiable, save an actionable assistant message and
- * return true. Returns false when the error isn't BYOK-related (or the
- * user isn't on BYOK), so the caller can fall through to transient /
- * generic handling.
- */
 async function tryReportByok(ctx: ActionCtx, report: ErrorReport): Promise<boolean> {
   if (!report.isByok) return false;
   const code = classifyByokError(report.error);
   if (code === null) return false;
-  // Use the error code (not the raw message) as the finalize reason since
-  // the provider body can include the decrypted key.
+  // Provider bodies can include the decrypted key, so the finalize reason is the code only.
   await finalizePendingMessages(ctx, report.threadId, code);
   await saveMessage(ctx, components.agent, {
     threadId: report.threadId,
@@ -318,10 +272,6 @@ async function tryReportByok(ctx: ActionCtx, report: ErrorReport): Promise<boole
   return true;
 }
 
-/**
- * Generic terminal-error path: write the fallback "I'm having trouble"
- * assistant message and notify ops with the raw error summary.
- */
 async function reportError(ctx: ActionCtx, report: ErrorReport): Promise<void> {
   const reason = report.error instanceof Error ? report.error.message : String(report.error);
   await finalizePendingMessages(ctx, report.threadId, reason);
@@ -341,10 +291,6 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/**
- * Check if a user has exceeded their daily token budget.
- * Returns true if budget is exceeded (caller should abort).
- */
 export async function checkDailyBudget(
   ctx: ActionCtx,
   userId: string,

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -211,6 +211,7 @@ export const continueAfterApproval = action({
         userId,
         promptMessageId: messageId,
         isByok: !providerConfig.isHouseKey,
+        provider: providerConfig.provider,
       }),
     );
 
@@ -299,6 +300,7 @@ export const processMessage = internalAction({
         promptMessageId: messageId,
         prompt: typeof resolvedPrompt === "string" ? undefined : resolvedPrompt,
         isByok: !providerConfig.isHouseKey,
+        provider: providerConfig.provider,
       }),
     );
 


### PR DESCRIPTION
## Summary

- A production user's Claude API key ran out of credit, and the coach went silent for 24 hours because the billing error was neither classified correctly nor surfaced to the user
- Root cause in \`convex/ai/resilience.ts\`: \`classifyByokError\` only read \`error.message\`, but the Vercel AI SDK wraps Anthropic errors in a generic outer message while the real text ("Your credit balance is too low...") lives on \`.responseBody\` / \`.cause.message\`
- Even when a BYOK error did classify, the old flow threw a bare error code up the stack and never saved an actionable assistant message, so the user saw either an indefinite spinner or the generic "I'm having trouble right now"

## Evidence from prod

From the affected thread's \`streamingMessages\` (Randy Griffin, user \`k57055cst3zctrd5hrnwkj5dts84p833\`):

| Time | Provider | Error (raw stream reason) |
|---|---|---|
| ~26h | Gemini | You exceeded your current quota, please check your plan and billing details |
| ~4.3h | Claude | Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing... |
| ~3.4h | Claude | same (x3 attempts) |
| ~2.4h | Claude | Internal server error |

The thread's \`messages\` had three pending assistant rows hanging for 3.7-15.8 hours because the abort-path cleanup never ran.

## Changes

**\`convex/ai/resilience.ts\`**
- \`classifyByokError\` now gathers text from \`.message\`, \`.responseBody\`, \`.cause.message\`, and \`.data\`, and adds \"credit balance\" and \"insufficient_quota\" to the quota-exceeded patterns. It still returns only a classification code (never the raw body), so secret-in-error-body leakage is prevented.
- New \`BYOK_ERROR_MESSAGES\` map + \`saveByokErrorAndNotify\` write an actionable assistant message for each code (invalid / quota / safety / unknown), pointing the user to **Settings → API Keys**.
- \`streamWithRetry\` refactored: classifies once per attempt, routes BYOK errors through \`saveByokErrorAndNotify\` + return. No more bare throws up the stack that silently kill \`processMessage\`.
- New \`finalizePendingMessages\` sweeps the thread's last 10 messages before every error save and marks any pending assistant row as failed via the agent component's \`finalizeMessage\` mutation. This closes orphaned spinners left by previous failures as soon as the user sends another message, so existing stuck threads self-heal.

**\`convex/ai/resilience.test.ts\`**
- Added coverage for the Anthropic billing message, for errors whose classifiable text lives on \`responseBody\` or \`cause.message\`, and for OpenAI \`insufficient_quota\`.

## Checklist

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 1023 passing (+4 new)
- [x] \`npm run lint\` clean
- [x] \`npx knip\` clean
- [x] No new \`any\` types
- [x] Files under 300-line soft cap
- [ ] Tested in a real thread with an exhausted key (would be nice to verify on dev by temporarily using an invalid Claude key)

## Test Plan

1. On dev, set a user's Claude key to a string that triggers an insufficient-credit response (or mock).
2. Send a message → expect the thread to show the actionable "Your API key's provider is rejecting requests — likely out of credit or over quota..." message.
3. Verify the previous pending spinner in the thread gets cleaned up to failed status.
4. Swap to a valid Gemini key and confirm normal operation resumes.

## Not in scope

- A background cron that periodically sweeps stale pending messages. This PR handles cleanup on the next error save in the same thread, which covers the realistic recovery path (the user will re-send after seeing the error). A broader sweeper can be a follow-up if stale orphans from unrelated paths show up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and classification of API key and quota-related errors across multiple providers.
  * Added user-friendly error messages for billing and authentication failures.
  * Enhanced error handling to properly categorize and report provider-specific error conditions.

* **Tests**
  * Added comprehensive test coverage for error classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->