### PR TITLE
fix: close retry-push race that could revert a successful push

### DIFF
--- a/convex/workoutPlans.test.ts
+++ b/convex/workoutPlans.test.ts
@@ -1,0 +1,66 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.*s");
+
+async function seedPlan(
+  t: ReturnType<typeof convexTest>,
+  status: Doc<"workoutPlans">["status"],
+): Promise<Id<"workoutPlans">> {
+  return t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {});
+    return ctx.db.insert("workoutPlans", {
+      userId,
+      title: "test",
+      blocks: [],
+      status,
+      createdAt: Date.now(),
+    });
+  });
+}
+
+describe("transitionToPushing — atomic claim for retry", () => {
+  test("claims a failed plan exactly once", async () => {
+    const t = convexTest(schema, modules);
+    const planId = await seedPlan(t, "failed");
+
+    const first = await t.mutation(internal.workoutPlans.transitionToPushing, { planId });
+    const second = await t.mutation(internal.workoutPlans.transitionToPushing, { planId });
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    const plan = await t.run(async (ctx) => ctx.db.get(planId));
+    expect(plan?.status).toBe("pushing");
+  });
+
+  test("claims a draft plan", async () => {
+    const t = convexTest(schema, modules);
+    const planId = await seedPlan(t, "draft");
+
+    const claimed = await t.mutation(internal.workoutPlans.transitionToPushing, { planId });
+
+    expect(claimed).toBe(true);
+  });
+
+  test("refuses to claim a pushed plan", async () => {
+    const t = convexTest(schema, modules);
+    const planId = await seedPlan(t, "pushed");
+
+    const claimed = await t.mutation(internal.workoutPlans.transitionToPushing, { planId });
+
+    expect(claimed).toBe(false);
+  });
+
+  test("refuses to claim a pushing plan (prevents double-retry)", async () => {
+    const t = convexTest(schema, modules);
+    const planId = await seedPlan(t, "pushing");
+
+    const claimed = await t.mutation(internal.workoutPlans.transitionToPushing, { planId });
+
+    expect(claimed).toBe(false);
+  });
+});

--- a/convex/workoutPlans.ts
+++ b/convex/workoutPlans.ts
@@ -148,7 +148,9 @@ export const getByIdInternal = internalQuery({
   },
 });
 
-/** Durable workflow: claim plan, push to Tonal, record outcome, invalidate cache. */
+// Assumes the caller has already claimed the plan (status: pushing) — the
+// retryPush action does that synchronously so a double-click can't start
+// two workflows.
 export const retryPushWorkflow = workflow.define({
   args: {
     planId: v.id("workoutPlans"),
@@ -157,11 +159,6 @@ export const retryPushWorkflow = workflow.define({
     blocks: blockInputValidator,
   },
   handler: async (step, args): Promise<{ workoutId: string }> => {
-    const claimed = await step.runMutation(internal.workoutPlans.transitionToPushing, {
-      planId: args.planId,
-    });
-    if (!claimed) throw new Error("Plan cannot be retried or another push is in progress");
-
     const result = await step.runAction(internal.tonal.mutations.pushWorkoutToTonal, {
       userId: args.userId,
       title: args.title,
@@ -223,7 +220,12 @@ export const retryPush = action({
     })) as Doc<"workoutPlans"> | null;
     if (!plan) return { success: false, error: "Plan not found or access denied" };
     const userId = plan.userId;
-    if (plan.status !== "failed" && plan.status !== "draft")
+
+    // Atomic claim up front: a double-click loses the second claim here and
+    // can't start a second workflow (which would otherwise overwrite the
+    // first workflow's success via onRetryPushComplete's fail branch).
+    const claimed = await ctx.runMutation(internal.workoutPlans.transitionToPushing, { planId });
+    if (!claimed) {
       return {
         success: false,
         error:
@@ -231,16 +233,28 @@ export const retryPush = action({
             ? "Push already in progress"
             : `Plan cannot be retried (status: ${plan.status})`,
       };
+    }
 
-    await workflow.start(
-      ctx,
-      internal.workoutPlans.retryPushWorkflow,
-      { planId, userId, title: plan.title, blocks: plan.blocks },
-      {
-        onComplete: internal.workoutPlans.onRetryPushComplete,
-        context: { planId, userId },
-      },
-    );
+    try {
+      await workflow.start(
+        ctx,
+        internal.workoutPlans.retryPushWorkflow,
+        { planId, userId, title: plan.title, blocks: plan.blocks },
+        {
+          onComplete: internal.workoutPlans.onRetryPushComplete,
+          context: { planId, userId },
+        },
+      );
+    } catch (err) {
+      // Release the claim so the plan isn't stuck in "pushing" forever.
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.runMutation(internal.workoutPlans.updatePushOutcome, {
+        planId,
+        status: "failed",
+        pushErrorReason: `Failed to start retry workflow: ${message}`,
+      });
+      return { success: false, error: "Failed to start retry workflow" };
+    }
 
     return { success: true, started: true };
   },

--- a/convex/workoutPlans.ts
+++ b/convex/workoutPlans.ts
@@ -226,12 +226,16 @@ export const retryPush = action({
     // first workflow's success via onRetryPushComplete's fail branch).
     const claimed = await ctx.runMutation(internal.workoutPlans.transitionToPushing, { planId });
     if (!claimed) {
+      // Re-read since the failure means status changed between our initial
+      // read and the claim — typically because a parallel retry just won.
+      const current = await ctx.runQuery(internal.workoutPlans.getByIdInternal, { planId });
+      const currentStatus = current?.status ?? plan.status;
       return {
         success: false,
         error:
-          plan.status === "pushing"
+          currentStatus === "pushing" || currentStatus === "pushed"
             ? "Push already in progress"
-            : `Plan cannot be retried (status: ${plan.status})`,
+            : `Plan cannot be retried (status: ${currentStatus})`,
       };
     }
 


### PR DESCRIPTION
## Summary

A race surfaced in the clean-code pass on the workflow integration that landed via #183. A rapid double-click on Retry could queue two workflows, both claim the plan in sequence, and the second workflow's \`onRetryPushComplete\` fail branch would overwrite the first workflow's successful push with \`status: \"failed\"\`.

## The bug, step by step

\`\`\`
Plan { status: \"failed\" }

User double-clicks Retry
├─ Action A: plan.status === \"failed\" ✓  →  workflow.start
└─ Action B: plan.status === \"failed\" ✓  →  workflow.start   (both read before either claims)

Workflow A runs
├─ step: transitionToPushing → true   (failed → pushing)
├─ step: pushWorkoutToTonal → { id } ✓
├─ step: updatePushOutcome → status: \"pushed\"
└─ onRetryPushComplete { kind: \"success\" }

Workflow B runs
├─ step: transitionToPushing → false   (status is already \"pushed\")
└─ handler throws
   └─ onRetryPushComplete { kind: \"failed\", error: \"Plan cannot be retried…\" }
      └─ ctx.db.patch(planId, { status: \"failed\", pushErrorReason: \"Plan cannot be retried…\" })
           ^^^ clobbers A's success
\`\`\`

## Fix

Move the atomic claim into the \`retryPush\` action so the second click loses the claim **before** \`workflow.start\`. The second click never starts a second workflow, \`onRetryPushComplete\` never fires for it, and nothing overwrites the good state.

- \`retryPush\` action: claim first, reject second click with \`\"Push already in progress\"\`
- Wrap \`workflow.start\` in try/catch so if it throws (workpool unavailable, validator mismatch), the claim is released and the plan isn't stuck in \`\"pushing\"\`
- Drop the now-redundant claim step from \`retryPushWorkflow\`'s handler

## Tests

New \`convex/workoutPlans.test.ts\`:

- \`transitionToPushing\` claims a failed plan exactly once (double-call returns \`false\` the second time)
- Claims a draft plan
- Refuses to claim a \`pushed\` plan
- Refuses to claim a \`pushing\` plan (direct double-retry coverage)

4/4 new tests pass; 1024/1024 total.

## Checklist

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 1024 passing (+4 new)
- [x] \`npm run lint\` clean
- [x] \`npx knip\` clean
- [x] No new \`any\`, no new \`as\` casts
- [x] Files under 300-line soft cap

## Not in scope

Follow-ups queued from the same clean-code pass (separate PRs):

- \`movementSync.ts\` + \`workoutCatalogSync.ts\`: replace serial for-loops over per-movement \`ctx.runQuery\`/\`ctx.runMutation\` with batch + \`Promise.all\`
- \`historySync.ts:163-176\`: add an upper-bound guard on the backfill \`while\` loop
- \`workoutPlans.ts:45-88\`: three remaining \`.collect().filter()\` queries missed by the #174 sweep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for workout plan push failures with automatic status recovery when retry workflows fail to start.

* **Tests**
  * Added comprehensive test suite verifying workout plan state transition logic during retry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->