### PR TITLE
perf(ai): enable Anthropic prompt caching for static instructions + tools

### DIFF
--- a/convex/ai/coach.test.ts
+++ b/convex/ai/coach.test.ts
@@ -20,6 +20,10 @@ async function runContextHandler(allMessages: ModelMessage[]): Promise<ModelMess
   return testConfig.contextHandler!(undefined as never, args);
 }
 
+function nonSystemMessages(messages: ModelMessage[]): ModelMessage[] {
+  return messages.filter((m) => m.role !== "system");
+}
+
 describe("coachAgentConfig.contextHandler", () => {
   it("trims leading assistant messages so context starts with a user turn", async () => {
     const messages: ModelMessage[] = [
@@ -34,7 +38,7 @@ describe("coachAgentConfig.contextHandler", () => {
       { role: "user", content: "What does this change?" },
     ];
 
-    await expect(runContextHandler(messages)).resolves.toEqual([
+    expect(nonSystemMessages(await runContextHandler(messages))).toEqual([
       { role: "user", content: "What does this change?" },
     ]);
   });
@@ -70,7 +74,7 @@ describe("coachAgentConfig.contextHandler", () => {
       },
     ]);
 
-    expect(result).toEqual([
+    expect(nonSystemMessages(result)).toEqual([
       {
         role: "user",
         content: [
@@ -81,5 +85,32 @@ describe("coachAgentConfig.contextHandler", () => {
         ],
       },
     ]);
+  });
+});
+
+describe("coachAgentConfig.contextHandler — Anthropic prompt caching", () => {
+  it("emits the static instructions as the first system message with cacheControl", async () => {
+    const result = await runContextHandler([{ role: "user", content: "hi" }]);
+
+    const first = result[0];
+    expect(first.role).toBe("system");
+    expect(typeof first.content === "string" && first.content).toContain("PERSONALITY:");
+    expect(first.providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+  });
+
+  it("emits exactly one cacheControl marker", async () => {
+    const result = await runContextHandler([{ role: "user", content: "hi" }]);
+
+    const tagged = result.filter((m) => m.providerOptions?.anthropic?.cacheControl);
+    expect(tagged).toHaveLength(1);
+  });
+
+  it("omits the snapshot system message when no userId is present", async () => {
+    const result = await runContextHandler([{ role: "user", content: "hi" }]);
+
+    const systemMessages = result.filter((m) => m.role === "system");
+    expect(systemMessages).toHaveLength(1);
   });
 });

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -1,6 +1,7 @@
 import { Agent } from "@convex-dev/agent";
 import type { ContextHandler, UsageHandler } from "@convex-dev/agent";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { ModelMessage } from "ai";
 import { components, internal } from "../_generated/api";
 import { getProviderConfig, type ProviderId } from "./providers";
 import type { Id } from "../_generated/dataModel";
@@ -78,6 +79,8 @@ const serverProvider = createGoogleGenerativeAI({
 });
 const sharedEmbeddingModel = serverProvider.textEmbeddingModel("gemini-embedding-001");
 
+const STATIC_INSTRUCTIONS = buildInstructions();
+
 export const coachAgentConfig = {
   embeddingModel: sharedEmbeddingModel,
 
@@ -93,7 +96,7 @@ export const coachAgentConfig = {
     },
   },
 
-  instructions: buildInstructions(),
+  // No `instructions` here — STATIC_INSTRUCTIONS is injected by contextHandler so it can carry cacheControl.
 
   tools: {
     search_exercises: searchExercisesTool,
@@ -174,12 +177,22 @@ export function makeCoachAgentConfig(userTimezone?: string) {
           stripImagesFromOlderMessages(stripOrphanedToolCalls(args.allMessages)),
         ),
       );
-      if (!args.userId) return messages;
-      const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
-      return [
-        { role: "system" as const, content: `<training-data>\n${snapshot}\n</training-data>` },
-        ...messages,
+      // Snapshot is added after this so the per-call snapshot doesn't bust the prefix cache.
+      const systemMessages: ModelMessage[] = [
+        {
+          role: "system",
+          content: STATIC_INSTRUCTIONS,
+          providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+        },
       ];
+      if (args.userId) {
+        const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
+        systemMessages.push({
+          role: "system",
+          content: `<training-data>\n${snapshot}\n</training-data>`,
+        });
+      }
+      return [...systemMessages, ...messages];
     }) satisfies ContextHandler,
   };
 }


### PR DESCRIPTION
## Summary

- Mark the static system instructions with Anthropic's \`cacheControl: { type: \"ephemeral\" }\` so tools + instructions (~8.5K tokens) are cached for 5 minutes per Anthropic key.
- Move the dynamic training snapshot to a second system message after the cache breakpoint so it can change per-call without invalidating the prefix.
- Single edit to \`makeCoachAgentConfig\` propagates to all agent variants (Gemini fixed, multi-provider, storage-only). The provider option is namespaced to \`anthropic\` and is inert for Gemini/OpenAI/OpenRouter.

## Why

\"Hello\" on a fresh Claude key was billing ~34K input tokens. ~5,098 are static instructions and ~3,400 are tool definitions — both reused on every call but resent uncached every time. Anthropic gives a 90% discount on cache hits within 5-minute windows; net savings are ~67% on the static portion across a typical 5-message session, ~80%+ on tool-heavy programming sessions where each step is a separate API call.

## Changes

### \`convex/ai/coach.ts\`
- Removed \`instructions: buildInstructions()\` from \`coachAgentConfig\`. The AI SDK would otherwise append a duplicate uncached system message via \`system: args.system ?? this.options.instructions\`.
- Hoisted \`STATIC_INSTRUCTIONS = buildInstructions()\` to module scope so the cache key stays stable.
- \`makeCoachAgentConfig.contextHandler\` now returns up to two system messages: \`STATIC_INSTRUCTIONS\` (with \`cacheControl\`) followed by the dynamic snapshot (no marker). Order matters — the snapshot must come AFTER the breakpoint or it would invalidate the prefix every call.

### \`convex/ai/coach.test.ts\`
- Updated two existing tests to filter system messages before equality checks (they were asserting the contextHandler's full return).
- Added three new tests covering: (1) the marker is on the first system message, (2) exactly one marker is emitted, (3) the snapshot system message is omitted when no userId is present.

## How caching works here

Anthropic's request order is **tools → system → messages**. A cache breakpoint includes everything before and at that block. So one marker on the first system content block caches \`tools + STATIC_INSTRUCTIONS\` as one prefix; the snapshot block sits after it and is sent fresh each call. We use 1 of the 4 available cache breakpoints — plenty of headroom for future history-caching work.

## Coverage across agent variants

| Constructor | Path | Effect |
|---|---|---|
| \`buildCoachAgents\` (Gemini fixed) | uses \`makeCoachAgentConfig\` | marker is a no-op (Gemini ignores \`anthropic.*\` namespace) |
| \`buildCoachAgentsForProvider\` (Claude/Gemini/OpenAI/OpenRouter) | uses \`makeCoachAgentConfig\` | caching active for Claude; inert for others |
| \`buildCoachAgentForStorageOnly\` | no LLM call | irrelevant |

## Telemetry (no changes needed)

\`coach.ts:140-164\` already records \`usage.inputTokenDetails.cacheReadTokens\` / \`cacheWriteTokens\` into the \`aiUsage\` table (\`schema.ts:394-395\`) and PostHog (\`lib/posthog.ts:30-33\`, mapping to \`\$ai_cache_read_input_tokens\` / \`\$ai_cache_creation_input_tokens\`). Cache savings will appear in both immediately after deploy.

## Risks

| Risk | Mitigation |
|---|---|
| First message of a 5-min window pays a 25% cache-write premium | Net positive starting at message #2; one-shot users see ~2% cost increase, worth it |
| \`STATIC_INSTRUCTIONS\` ever made dynamic by accident | Module-scoped const; \`buildInstructions()\` is pure and parameterless |
| Tool defs change between deploys | Cache invalidates once per deploy — acceptable |
| 4-breakpoint limit | Using 1 of 4 |

## Verification

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm run lint\` passes
- [x] \`npx vitest run\` — 1027 tests pass (1024 prior + 3 new)
- [x] \`npx knip\` clean
- [ ] **Post-deploy manual smoke** (to do after merge): on a Claude-backed thread, send \"hello\" twice within 5 minutes. The first \`aiUsage\` row should show \`cacheWriteTokens\` ≈ 8500. The second should show \`cacheReadTokens\` ≈ 8500 (and \`cacheWriteTokens\` ≈ 0–300 depending on snapshot drift).

## Test Plan

- [ ] Local: send a message on a Claude key, confirm typecheck + tests still pass — done
- [ ] Post-deploy: verify \`aiUsage.cacheReadTokens\` populates for Claude requests via Convex dashboard or \`npx convex run aiUsage:list\`
- [ ] Post-deploy: spot-check PostHog AI Generation events for \`\$ai_cache_read_input_tokens\` > 0 on Claude