### PR TITLE
fix: recover scheduled chat failures

### DIFF
--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -199,11 +199,11 @@ export const continueAfterApproval = action({
     await assertThreadOwnership(ctx, threadId, userId);
 
     let provider: ProviderId | undefined;
+    const startTime = Date.now();
     try {
       const providerConfig = await resolveUserProviderConfig(ctx, userId);
       provider = providerConfig.provider;
 
-      const startTime = Date.now();
       const { primary, fallback } = buildCoachAgentsForProvider({
         ...providerConfig,
         userTimezone,
@@ -219,15 +219,23 @@ export const continueAfterApproval = action({
           provider: providerConfig.provider,
         }),
       );
-
-      analytics.capture(userId, "coach_response_received", {
-        response_time_ms: Date.now() - startTime,
-        after_approval: true,
-      });
-      await analytics.flush();
     } catch (error) {
-      await persistScheduledFailure({ ctx, threadId, userId, error, provider });
+      await persistScheduledFailure({
+        ctx,
+        threadId,
+        userId,
+        error,
+        provider,
+        source: "chat.continueAfterApproval",
+      });
+      return;
     }
+
+    analytics.capture(userId, "coach_response_received", {
+      response_time_ms: Date.now() - startTime,
+      after_approval: true,
+    });
+    await analytics.flush();
   },
 });
 
@@ -291,13 +299,13 @@ export const processMessage = internalAction({
     });
 
     let provider: ProviderId | undefined;
+    const startTime = Date.now();
     try {
       const providerConfig = await resolveUserProviderConfig(ctx, userId);
       provider = providerConfig.provider;
 
-      const resolvedPrompt = await buildPrompt(ctx, prompt, imageStorageIds ?? undefined);
+      const resolvedPrompt = await buildPrompt(ctx, prompt, imageStorageIds);
 
-      const startTime = Date.now();
       const { primary, fallback } = buildCoachAgentsForProvider({
         ...providerConfig,
         userTimezone,
@@ -314,14 +322,22 @@ export const processMessage = internalAction({
           provider: providerConfig.provider,
         }),
       );
-
-      analytics.capture(userId, "coach_response_received", {
-        response_time_ms: Date.now() - startTime,
-        has_images: (imageStorageIds?.length ?? 0) > 0,
-      });
-      await analytics.flush();
     } catch (error) {
-      await persistScheduledFailure({ ctx, threadId, userId, error, provider });
+      await persistScheduledFailure({
+        ctx,
+        threadId,
+        userId,
+        error,
+        provider,
+        source: "chat.processMessage",
+      });
+      return;
     }
+
+    analytics.capture(userId, "coach_response_received", {
+      response_time_ms: Date.now() - startTime,
+      has_images: (imageStorageIds?.length ?? 0) > 0,
+    });
+    await analytics.flush();
   },
 });

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -7,17 +7,11 @@ import {
   syncStreams,
   vStreamArgs,
 } from "@convex-dev/agent";
-import { action, type ActionCtx, internalAction, mutation, query } from "./_generated/server";
+import { action, internalAction, mutation, query } from "./_generated/server";
 import { components, internal } from "./_generated/api";
 import { getEffectiveUserId } from "./lib/auth";
 import { buildCoachAgentForStorageOnly, buildCoachAgentsForProvider } from "./ai/coach";
-import {
-  buildByokErrorMessage,
-  type ByokErrorCode,
-  checkDailyBudget,
-  classifyByokError,
-  streamWithRetry,
-} from "./ai/resilience";
+import { checkDailyBudget, streamWithRetry } from "./ai/resilience";
 import { rateLimiter } from "./rateLimits";
 import { sanitizeTimezone } from "./ai/timeDecay";
 import type { ProviderId } from "./ai/providers";
@@ -25,62 +19,11 @@ import * as analytics from "./lib/posthog";
 import {
   assertThreadOwnership,
   buildPrompt,
+  persistScheduledFailure,
   resolveUserProviderConfig,
   validateUserProviderKey,
   withByokErrorSanitization,
 } from "./chatHelpers";
-
-const CHAT_ERROR_MESSAGE = "I'm having trouble right now. Please try again in a moment.";
-const HOUSE_KEY_EXHAUSTED_MESSAGE =
-  "You've used your 500 free AI messages this month. Add your own API key in Settings to keep going.";
-const KEY_MISSING_MESSAGE = "You need to add an API key in Settings before chat can run.";
-const MODEL_MISSING_MESSAGE =
-  "The selected provider needs a model name before chat can start. Add one in Settings and try again.";
-const BYOK_FALLBACK_MESSAGES: Record<ByokErrorCode, string> = {
-  byok_key_invalid: "Your API key isn't working anymore. Check it in Settings and try again.",
-  byok_quota_exceeded:
-    "Your AI provider quota or credits are exhausted. Check billing or switch providers in Settings.",
-  byok_safety_blocked: "The AI provider declined to answer this one. Try rephrasing.",
-  byok_unknown_error: "Something went wrong with the AI provider. Try again in a moment.",
-};
-
-function getScheduledFailureContent(error: unknown, provider?: ProviderId): string {
-  if (provider) {
-    const classified = classifyByokError(error);
-    if (classified) return buildByokErrorMessage(classified, provider);
-  }
-
-  const code = error instanceof Error ? error.message : String(error);
-  if (code === "house_key_quota_exhausted") return HOUSE_KEY_EXHAUSTED_MESSAGE;
-  if (code === "byok_key_missing") return KEY_MISSING_MESSAGE;
-  if (code === "byok_model_missing") return MODEL_MISSING_MESSAGE;
-  if (Object.hasOwn(BYOK_FALLBACK_MESSAGES, code)) {
-    return BYOK_FALLBACK_MESSAGES[code as ByokErrorCode];
-  }
-  return CHAT_ERROR_MESSAGE;
-}
-
-async function persistScheduledFailure(args: {
-  ctx: ActionCtx;
-  threadId: string;
-  userId: string;
-  error: unknown;
-  provider?: ProviderId;
-}): Promise<void> {
-  const content = getScheduledFailureContent(args.error, args.provider);
-  await saveMessage(args.ctx, components.agent, {
-    threadId: args.threadId,
-    userId: args.userId,
-    message: { role: "assistant", content },
-  });
-
-  const reason = args.error instanceof Error ? args.error.message : String(args.error);
-  await args.ctx.runAction(internal.discord.notifyError, {
-    source: "chat.processMessage",
-    message: reason,
-    userId: args.userId,
-  });
-}
 
 export const generateImageUploadUrl = mutation({
   args: {},

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -7,13 +7,20 @@ import {
   syncStreams,
   vStreamArgs,
 } from "@convex-dev/agent";
-import { action, internalAction, mutation, query } from "./_generated/server";
+import { action, type ActionCtx, internalAction, mutation, query } from "./_generated/server";
 import { components, internal } from "./_generated/api";
 import { getEffectiveUserId } from "./lib/auth";
 import { buildCoachAgentForStorageOnly, buildCoachAgentsForProvider } from "./ai/coach";
-import { checkDailyBudget, streamWithRetry } from "./ai/resilience";
+import {
+  buildByokErrorMessage,
+  type ByokErrorCode,
+  checkDailyBudget,
+  classifyByokError,
+  streamWithRetry,
+} from "./ai/resilience";
 import { rateLimiter } from "./rateLimits";
 import { sanitizeTimezone } from "./ai/timeDecay";
+import type { ProviderId } from "./ai/providers";
 import * as analytics from "./lib/posthog";
 import {
   assertThreadOwnership,
@@ -22,6 +29,58 @@ import {
   validateUserProviderKey,
   withByokErrorSanitization,
 } from "./chatHelpers";
+
+const CHAT_ERROR_MESSAGE = "I'm having trouble right now. Please try again in a moment.";
+const HOUSE_KEY_EXHAUSTED_MESSAGE =
+  "You've used your 500 free AI messages this month. Add your own API key in Settings to keep going.";
+const KEY_MISSING_MESSAGE = "You need to add an API key in Settings before chat can run.";
+const MODEL_MISSING_MESSAGE =
+  "The selected provider needs a model name before chat can start. Add one in Settings and try again.";
+const BYOK_FALLBACK_MESSAGES: Record<ByokErrorCode, string> = {
+  byok_key_invalid: "Your API key isn't working anymore. Check it in Settings and try again.",
+  byok_quota_exceeded:
+    "Your AI provider quota or credits are exhausted. Check billing or switch providers in Settings.",
+  byok_safety_blocked: "The AI provider declined to answer this one. Try rephrasing.",
+  byok_unknown_error: "Something went wrong with the AI provider. Try again in a moment.",
+};
+
+function getScheduledFailureContent(error: unknown, provider?: ProviderId): string {
+  if (provider) {
+    const classified = classifyByokError(error);
+    if (classified) return buildByokErrorMessage(classified, provider);
+  }
+
+  const code = error instanceof Error ? error.message : String(error);
+  if (code === "house_key_quota_exhausted") return HOUSE_KEY_EXHAUSTED_MESSAGE;
+  if (code === "byok_key_missing") return KEY_MISSING_MESSAGE;
+  if (code === "byok_model_missing") return MODEL_MISSING_MESSAGE;
+  if (Object.hasOwn(BYOK_FALLBACK_MESSAGES, code)) {
+    return BYOK_FALLBACK_MESSAGES[code as ByokErrorCode];
+  }
+  return CHAT_ERROR_MESSAGE;
+}
+
+async function persistScheduledFailure(args: {
+  ctx: ActionCtx;
+  threadId: string;
+  userId: string;
+  error: unknown;
+  provider?: ProviderId;
+}): Promise<void> {
+  const content = getScheduledFailureContent(args.error, args.provider);
+  await saveMessage(args.ctx, components.agent, {
+    threadId: args.threadId,
+    userId: args.userId,
+    message: { role: "assistant", content },
+  });
+
+  const reason = args.error instanceof Error ? args.error.message : String(args.error);
+  await args.ctx.runAction(internal.discord.notifyError, {
+    source: "chat.processMessage",
+    message: reason,
+    userId: args.userId,
+  });
+}
 
 export const generateImageUploadUrl = mutation({
   args: {},
@@ -196,30 +255,36 @@ export const continueAfterApproval = action({
     if (!userId) throw new Error("Not authenticated");
     await assertThreadOwnership(ctx, threadId, userId);
 
-    const providerConfig = await resolveUserProviderConfig(ctx, userId);
+    let provider: ProviderId | undefined;
+    try {
+      const providerConfig = await resolveUserProviderConfig(ctx, userId);
+      provider = providerConfig.provider;
 
-    const startTime = Date.now();
-    const { primary, fallback } = buildCoachAgentsForProvider({
-      ...providerConfig,
-      userTimezone,
-    });
-    await withByokErrorSanitization(() =>
-      streamWithRetry(ctx, {
-        primaryAgent: primary,
-        fallbackAgent: fallback,
-        threadId,
-        userId,
-        promptMessageId: messageId,
-        isByok: !providerConfig.isHouseKey,
-        provider: providerConfig.provider,
-      }),
-    );
+      const startTime = Date.now();
+      const { primary, fallback } = buildCoachAgentsForProvider({
+        ...providerConfig,
+        userTimezone,
+      });
+      await withByokErrorSanitization(() =>
+        streamWithRetry(ctx, {
+          primaryAgent: primary,
+          fallbackAgent: fallback,
+          threadId,
+          userId,
+          promptMessageId: messageId,
+          isByok: !providerConfig.isHouseKey,
+          provider: providerConfig.provider,
+        }),
+      );
 
-    analytics.capture(userId, "coach_response_received", {
-      response_time_ms: Date.now() - startTime,
-      after_approval: true,
-    });
-    await analytics.flush();
+      analytics.capture(userId, "coach_response_received", {
+        response_time_ms: Date.now() - startTime,
+        after_approval: true,
+      });
+      await analytics.flush();
+    } catch (error) {
+      await persistScheduledFailure({ ctx, threadId, userId, error, provider });
+    }
   },
 });
 
@@ -274,10 +339,6 @@ export const processMessage = internalAction({
     const budgetExceeded = await checkDailyBudget(ctx, userId, threadId);
     if (budgetExceeded) return;
 
-    const providerConfig = await resolveUserProviderConfig(ctx, userId);
-
-    const resolvedPrompt = await buildPrompt(ctx, prompt, imageStorageIds ?? undefined);
-
     // Pre-save the user message once so retries use promptMessageId
     // instead of re-saving, re-embedding, and duplicating the message.
     const { messageId } = await saveMessage(ctx, components.agent, {
@@ -286,28 +347,38 @@ export const processMessage = internalAction({
       message: { role: "user" as const, content: prompt },
     });
 
-    const startTime = Date.now();
-    const { primary, fallback } = buildCoachAgentsForProvider({
-      ...providerConfig,
-      userTimezone,
-    });
-    await withByokErrorSanitization(() =>
-      streamWithRetry(ctx, {
-        primaryAgent: primary,
-        fallbackAgent: fallback,
-        threadId,
-        userId,
-        promptMessageId: messageId,
-        prompt: typeof resolvedPrompt === "string" ? undefined : resolvedPrompt,
-        isByok: !providerConfig.isHouseKey,
-        provider: providerConfig.provider,
-      }),
-    );
+    let provider: ProviderId | undefined;
+    try {
+      const providerConfig = await resolveUserProviderConfig(ctx, userId);
+      provider = providerConfig.provider;
 
-    analytics.capture(userId, "coach_response_received", {
-      response_time_ms: Date.now() - startTime,
-      has_images: (imageStorageIds?.length ?? 0) > 0,
-    });
-    await analytics.flush();
+      const resolvedPrompt = await buildPrompt(ctx, prompt, imageStorageIds ?? undefined);
+
+      const startTime = Date.now();
+      const { primary, fallback } = buildCoachAgentsForProvider({
+        ...providerConfig,
+        userTimezone,
+      });
+      await withByokErrorSanitization(() =>
+        streamWithRetry(ctx, {
+          primaryAgent: primary,
+          fallbackAgent: fallback,
+          threadId,
+          userId,
+          promptMessageId: messageId,
+          prompt: typeof resolvedPrompt === "string" ? undefined : resolvedPrompt,
+          isByok: !providerConfig.isHouseKey,
+          provider: providerConfig.provider,
+        }),
+      );
+
+      analytics.capture(userId, "coach_response_received", {
+        response_time_ms: Date.now() - startTime,
+        has_images: (imageStorageIds?.length ?? 0) > 0,
+      });
+      await analytics.flush();
+    } catch (error) {
+      await persistScheduledFailure({ ctx, threadId, userId, error, provider });
+    }
   },
 });

--- a/convex/chatHelpers.test.ts
+++ b/convex/chatHelpers.test.ts
@@ -45,6 +45,12 @@ describe("getScheduledFailureContent", () => {
       "I'm having trouble right now. Please try again in a moment.",
     );
   });
+
+  it("falls back to the generic chat error for classifiable errors without a known provider", () => {
+    expect(
+      getScheduledFailureContent(new Error("You exceeded your current quota: insufficient_quota.")),
+    ).toBe("I'm having trouble right now. Please try again in a moment.");
+  });
 });
 
 describe("shouldNotifyScheduledFailure", () => {

--- a/convex/chatHelpers.test.ts
+++ b/convex/chatHelpers.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { getScheduledFailureContent, shouldNotifyScheduledFailure } from "./chatHelpers";
+
+describe("getScheduledFailureContent", () => {
+  it("returns the missing-key message for BYOK-required users", () => {
+    expect(getScheduledFailureContent(new Error("byok_key_missing"), "claude")).toBe(
+      "You need to add an API key in Settings before chat can run.",
+    );
+  });
+
+  it("returns the model-missing message before provider classification", () => {
+    expect(getScheduledFailureContent(new Error("byok_model_missing"), "openrouter")).toBe(
+      "The selected provider needs a model name before chat can start. Add one in Settings and try again.",
+    );
+  });
+
+  it("returns the house-key cap message for grandfathered users", () => {
+    expect(getScheduledFailureContent(new Error("house_key_quota_exhausted"), "gemini")).toBe(
+      "You've used your 500 free AI messages this month. Add your own API key in Settings to keep going.",
+    );
+  });
+
+  it("uses the provider-specific BYOK message for sanitized error codes", () => {
+    const message = getScheduledFailureContent(new Error("byok_quota_exceeded"), "openai");
+    expect(message).toContain("OpenAI is rejecting requests");
+    expect(message).toContain("billing");
+  });
+
+  it("uses the generic fallback when no provider is known", () => {
+    expect(getScheduledFailureContent(new Error("byok_key_invalid"))).toBe(
+      "Your API key isn't working anymore. Check it in Settings and try again.",
+    );
+  });
+
+  it("classifies raw provider errors when a provider is known", () => {
+    const message = getScheduledFailureContent(
+      new Error("You exceeded your current quota: insufficient_quota."),
+      "openai",
+    );
+    expect(message).toContain("OpenAI is rejecting requests");
+  });
+
+  it("falls back to the generic chat error for unexpected failures", () => {
+    expect(getScheduledFailureContent(new Error("database blew up"), "claude")).toBe(
+      "I'm having trouble right now. Please try again in a moment.",
+    );
+  });
+});
+
+describe("shouldNotifyScheduledFailure", () => {
+  it("does not notify on expected sentinel errors", () => {
+    expect(shouldNotifyScheduledFailure(new Error("byok_key_missing"))).toBe(false);
+    expect(shouldNotifyScheduledFailure(new Error("byok_model_missing"))).toBe(false);
+    expect(shouldNotifyScheduledFailure(new Error("house_key_quota_exhausted"))).toBe(false);
+  });
+
+  it("does not notify on classified provider-state errors", () => {
+    expect(
+      shouldNotifyScheduledFailure(
+        new Error("You exceeded your current quota: insufficient_quota."),
+      ),
+    ).toBe(false);
+  });
+
+  it("notifies on unexpected failures", () => {
+    expect(shouldNotifyScheduledFailure(new Error("database blew up"))).toBe(true);
+  });
+});

--- a/convex/chatHelpers.ts
+++ b/convex/chatHelpers.ts
@@ -1,9 +1,11 @@
+import { saveMessage } from "@convex-dev/agent";
 import type { ModelMessage } from "@ai-sdk/provider-utils";
 import { components, internal } from "./_generated/api";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { type ProviderKeyResult, resolveProviderKey } from "./byok";
-import { classifyByokError } from "./ai/resilience";
+import { buildByokErrorMessage, type ByokErrorCode, classifyByokError } from "./ai/resilience";
+import type { ProviderId } from "./ai/providers";
 
 export const MAX_IMAGES_PER_MESSAGE = 4;
 
@@ -72,6 +74,80 @@ export async function withByokErrorSanitization<T>(fn: () => Promise<T>): Promis
     }
     throw err;
   }
+}
+
+const CHAT_ERROR_MESSAGE = "I'm having trouble right now. Please try again in a moment.";
+const HOUSE_KEY_EXHAUSTED_MESSAGE =
+  "You've used your 500 free AI messages this month. Add your own API key in Settings to keep going.";
+const KEY_MISSING_MESSAGE = "You need to add an API key in Settings before chat can run.";
+const MODEL_MISSING_MESSAGE =
+  "The selected provider needs a model name before chat can start. Add one in Settings and try again.";
+
+const BYOK_FALLBACK_MESSAGES: Record<ByokErrorCode, string> = {
+  byok_key_invalid: "Your API key isn't working anymore. Check it in Settings and try again.",
+  byok_quota_exceeded:
+    "Your AI provider quota or credits are exhausted. Check billing or switch providers in Settings.",
+  byok_safety_blocked: "The AI provider declined to answer this one. Try rephrasing.",
+  byok_unknown_error: "Something went wrong with the AI provider. Try again in a moment.",
+};
+
+const EXPECTED_SCHEDULED_FAILURE_CODES = new Set<string>([
+  "house_key_quota_exhausted",
+  "byok_key_missing",
+  "byok_model_missing",
+  ...Object.keys(BYOK_FALLBACK_MESSAGES),
+]);
+
+export function getScheduledFailureContent(error: unknown, provider?: ProviderId): string {
+  const code = error instanceof Error ? error.message : String(error);
+
+  // Check explicit sentinel codes first so internal control-flow errors do not
+  // get reinterpreted later by substring-based BYOK classification.
+  if (code === "house_key_quota_exhausted") return HOUSE_KEY_EXHAUSTED_MESSAGE;
+  if (code === "byok_key_missing") return KEY_MISSING_MESSAGE;
+  if (code === "byok_model_missing") return MODEL_MISSING_MESSAGE;
+
+  if (Object.hasOwn(BYOK_FALLBACK_MESSAGES, code)) {
+    return provider
+      ? buildByokErrorMessage(code as ByokErrorCode, provider)
+      : BYOK_FALLBACK_MESSAGES[code as ByokErrorCode];
+  }
+
+  if (provider) {
+    const classified = classifyByokError(error);
+    if (classified) return buildByokErrorMessage(classified, provider);
+  }
+
+  return CHAT_ERROR_MESSAGE;
+}
+
+export function shouldNotifyScheduledFailure(error: unknown): boolean {
+  const code = error instanceof Error ? error.message : String(error);
+  if (EXPECTED_SCHEDULED_FAILURE_CODES.has(code)) return false;
+  return classifyByokError(error) === null;
+}
+
+export async function persistScheduledFailure(args: {
+  ctx: ActionCtx;
+  threadId: string;
+  userId: string;
+  error: unknown;
+  provider?: ProviderId;
+}): Promise<void> {
+  await saveMessage(args.ctx, components.agent, {
+    threadId: args.threadId,
+    userId: args.userId,
+    message: { role: "assistant", content: getScheduledFailureContent(args.error, args.provider) },
+  });
+
+  if (!shouldNotifyScheduledFailure(args.error)) return;
+
+  const reason = args.error instanceof Error ? args.error.message : String(args.error);
+  await args.ctx.runAction(internal.discord.notifyError, {
+    source: "chat.processMessage",
+    message: reason,
+    userId: args.userId,
+  });
 }
 
 export async function buildPrompt(

--- a/convex/chatHelpers.ts
+++ b/convex/chatHelpers.ts
@@ -133,6 +133,7 @@ export async function persistScheduledFailure(args: {
   userId: string;
   error: unknown;
   provider?: ProviderId;
+  source: string;
 }): Promise<void> {
   await saveMessage(args.ctx, components.agent, {
     threadId: args.threadId,
@@ -144,7 +145,7 @@ export async function persistScheduledFailure(args: {
 
   const reason = args.error instanceof Error ? args.error.message : String(args.error);
   await args.ctx.runAction(internal.discord.notifyError, {
-    source: "chat.processMessage",
+    source: args.source,
     message: reason,
     userId: args.userId,
   });


### PR DESCRIPTION
## Summary

- Wrap scheduled chat actions (`processMessage`, `continueAfterApproval`) in try/catch so pre-stream failures (provider resolution, prompt build, sanitized BYOK errors) persist as assistant messages instead of dying silently on the scheduler.
- Extract helpers to `chatHelpers.ts` and gate Discord notifications so expected user-state errors (missing key, missing model, house-key cap, classified provider errors) do not page ops.

## Changes

- `convex/chat.ts`: wrap both actions in try/catch; on error route through `persistScheduledFailure`. User message is still pre-saved before the guarded region so retries keep `promptMessageId`.
- `convex/chatHelpers.ts`: new `getScheduledFailureContent`, `shouldNotifyScheduledFailure`, `persistScheduledFailure`. Sentinel codes (`house_key_quota_exhausted`, `byok_key_missing`, `byok_model_missing`) are checked before BYOK classification to avoid substring collisions. Discord notification suppressed for expected error codes and classified provider errors.
- `convex/chatHelpers.test.ts`: unit tests covering error-code → user message mapping (sentinels, sanitized BYOK codes with/without provider, raw provider errors, generic fallback) and notification gating.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [x] New logic has tests (happy path + at least one error/edge case)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [ ] Tested in browser (if UI changes) — N/A, backend only
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- Unit tests in `convex/chatHelpers.test.ts` cover each error-code branch and the notification gate.
- Manual verification relied on existing `npm test` and typecheck; not exercised against live scheduler in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and recovery in chat operations to persist failures and provide meaningful error messages to users
  * Improved error messaging for provider configuration issues and quota exhaustion scenarios
  * Refined error notification system to suppress unnecessary alerts for expected failures

* **Tests**
  * Added comprehensive test suite for error message generation and notification logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->