### PR TITLE
fix: use hasOwnProperty.call for ES2021 compat

### DIFF
--- a/convex/chatHelpers.ts
+++ b/convex/chatHelpers.ts
@@ -107,7 +107,7 @@ export function getScheduledFailureContent(error: unknown, provider?: ProviderId
   if (code === "byok_key_missing") return KEY_MISSING_MESSAGE;
   if (code === "byok_model_missing") return MODEL_MISSING_MESSAGE;
 
-  if (Object.hasOwn(BYOK_FALLBACK_MESSAGES, code)) {
+  if (Object.prototype.hasOwnProperty.call(BYOK_FALLBACK_MESSAGES, code)) {
     return provider
       ? buildByokErrorMessage(code as ByokErrorCode, provider)
       : BYOK_FALLBACK_MESSAGES[code as ByokErrorCode];


### PR DESCRIPTION
## Summary

- Replace `Object.hasOwn` (ES2022) with `Object.prototype.hasOwnProperty.call` so Convex's typecheck (`lib: ["ES2021", "dom"]` per `convex/tsconfig.json`) passes.
- Unblocks Vercel + Convex deploy on main after #217 merged.

## Changes

- `convex/chatHelpers.ts:110`: `Object.hasOwn(BYOK_FALLBACK_MESSAGES, code)` -> `Object.prototype.hasOwnProperty.call(BYOK_FALLBACK_MESSAGES, code)`. Semantically equivalent, ES5-safe.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npx tsc --noEmit -p convex/tsconfig.json` passes (the one that caught this)
- [x] `npm run lint` passes
- [x] `npm test` passes (11/11 in chatHelpers.test.ts)
- [x] New logic has tests (no new logic, behavior-preserving)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [ ] Tested in browser (if UI changes) - N/A, backend only
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- Existing `convex/chatHelpers.test.ts` still passes (11/11).
- Verified Vercel failure reproduces pre-fix: Convex deploy step runs `tsc` with `lib: ["ES2021", "dom"]` which rejects `Object.hasOwn`.
- Post-fix: local `npx tsc --noEmit -p convex/tsconfig.json` clean.