### PR TITLE
fix: suppress Sentry noise from control-flow sentinels and Tonal credential errors

### DIFF
--- a/convex/tonal/auth.ts
+++ b/convex/tonal/auth.ts
@@ -30,8 +30,6 @@ export async function obtainTonalToken(email: string, password: string): Promise
   if (!res.ok) {
     const error = await res.json().catch(() => ({ error_description: "Unknown error" }));
     const description = error.error_description || "Invalid Tonal credentials";
-    // Invalid credentials is user input, not a system failure. Surface as a
-    // typed sentinel the action layer converts to a structured response.
     if (/wrong email or password|invalid_grant/i.test(description)) {
       throw new Error("tonal_invalid_credentials");
     }

--- a/convex/tonal/auth.ts
+++ b/convex/tonal/auth.ts
@@ -29,7 +29,13 @@ export async function obtainTonalToken(email: string, password: string): Promise
 
   if (!res.ok) {
     const error = await res.json().catch(() => ({ error_description: "Unknown error" }));
-    throw new Error(error.error_description || "Invalid Tonal credentials");
+    const description = error.error_description || "Invalid Tonal credentials";
+    // Invalid credentials is user input, not a system failure. Surface as a
+    // typed sentinel the action layer converts to a structured response.
+    if (/wrong email or password|invalid_grant/i.test(description)) {
+      throw new Error("tonal_invalid_credentials");
+    }
+    throw new Error(description);
   }
 
   const data = await res.json();

--- a/convex/tonal/connect.ts
+++ b/convex/tonal/connect.ts
@@ -7,15 +7,28 @@ import { CACHE_TTLS } from "./cache";
 import { toUserProfileData } from "./profileData";
 import type { TonalUser } from "./types";
 
+export type ConnectTonalResult =
+  | { success: true; tonalUserId: string }
+  | { success: false; error: "invalid_credentials" };
+
 export const connectTonal = internalAction({
   args: {
     userId: v.id("users"),
     tonalEmail: v.string(),
     tonalPassword: v.string(),
   },
-  handler: async (ctx, { userId, tonalEmail, tonalPassword }) => {
-    // 1. Obtain token from Auth0
-    const { idToken, refreshToken, expiresAt } = await obtainTonalToken(tonalEmail, tonalPassword);
+  handler: async (ctx, { userId, tonalEmail, tonalPassword }): Promise<ConnectTonalResult> => {
+    let idToken: string;
+    let refreshToken: string | undefined;
+    let expiresAt: number;
+    try {
+      ({ idToken, refreshToken, expiresAt } = await obtainTonalToken(tonalEmail, tonalPassword));
+    } catch (err) {
+      if (err instanceof Error && err.message === "tonal_invalid_credentials") {
+        return { success: false, error: "invalid_credentials" };
+      }
+      throw err;
+    }
 
     // 2. Get Tonal user info (returns full profile)
     const profile = await tonalFetch<TonalUser>(idToken, "/v6/users/userinfo");
@@ -68,6 +81,6 @@ export const connectTonal = internalAction({
       userId,
     });
 
-    return { success: true, tonalUserId };
+    return { success: true, tonalUserId } satisfies ConnectTonalResult;
   },
 });

--- a/convex/tonal/connectPublic.ts
+++ b/convex/tonal/connectPublic.ts
@@ -1,16 +1,14 @@
 import { v } from "convex/values";
 import { action } from "../_generated/server";
 import { internal } from "../_generated/api";
+import type { ConnectTonalResult } from "./connect";
 
 export const connectTonal = action({
   args: {
     tonalEmail: v.string(),
     tonalPassword: v.string(),
   },
-  handler: async (
-    ctx,
-    { tonalEmail, tonalPassword },
-  ): Promise<{ success: boolean; tonalUserId: string }> => {
+  handler: async (ctx, { tonalEmail, tonalPassword }): Promise<ConnectTonalResult> => {
     const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,6 +5,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { getSentryRuntimeConfig } from "./src/lib/deployment";
+import { sentryBeforeSend } from "./src/lib/sentryBeforeSend";
 
 const sentryConfig = getSentryRuntimeConfig({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -16,5 +17,6 @@ if (sentryConfig) {
     ...sentryConfig,
     enableLogs: false,
     sendDefaultPii: false,
+    beforeSend: sentryBeforeSend,
   });
 }

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,6 +4,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { getSentryRuntimeConfig } from "./src/lib/deployment";
+import { sentryBeforeSend } from "./src/lib/sentryBeforeSend";
 
 const sentryConfig = getSentryRuntimeConfig({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -15,5 +16,6 @@ if (sentryConfig) {
     ...sentryConfig,
     enableLogs: false,
     sendDefaultPii: false,
+    beforeSend: sentryBeforeSend,
   });
 }

--- a/src/app/connect-tonal/page.tsx
+++ b/src/app/connect-tonal/page.tsx
@@ -51,8 +51,14 @@ export default function ConnectTonalPage() {
 
     try {
       const phaseTimer = setTimeout(() => setPhase("syncing"), 1500);
-      await connectTonal({ tonalEmail, tonalPassword });
+      const result = await connectTonal({ tonalEmail, tonalPassword });
       clearTimeout(phaseTimer);
+      if (!result.success) {
+        track("tonal_connection_failed", { error: result.error });
+        setPhase("idle");
+        setError("Wrong email or password. Please check your Tonal credentials and try again.");
+        return;
+      }
       track("tonal_connected");
       setPhase("done");
       const destination = isReconnecting ? "/dashboard" : "/onboarding";

--- a/src/app/onboarding/ConnectStep.tsx
+++ b/src/app/onboarding/ConnectStep.tsx
@@ -38,8 +38,13 @@ export function ConnectStep({ onComplete }: { readonly onComplete: () => void })
     const fetchTimer = setTimeout(() => setPhase("fetching"), 1200);
 
     try {
-      await connectTonal({ tonalEmail, tonalPassword });
+      const result = await connectTonal({ tonalEmail, tonalPassword });
       clearTimeout(fetchTimer);
+      if (!result.success) {
+        setPhase("idle");
+        setError("Wrong email or password. Please check your Tonal credentials and try again.");
+        return;
+      }
       track("tonal_connected");
       setPhase("done");
       setTimeout(onComplete, 800);

--- a/src/components/ReconnectModal.tsx
+++ b/src/components/ReconnectModal.tsx
@@ -57,12 +57,19 @@ export function ReconnectModal({ tonalEmail, open, onDismiss }: ReconnectModalPr
     setPhase("submitting");
 
     try {
-      await connectTonal({ tonalEmail, tonalPassword: password });
+      const result = await connectTonal({ tonalEmail, tonalPassword: password });
+      if (!result.success) {
+        track("tonal_reconnect_failed", { error: result.error });
+        setError("Wrong password. Please try again.");
+        setPhase("idle");
+        passwordRef.current?.focus();
+        return;
+      }
       track("tonal_reconnected");
       setPhase("success");
     } catch {
-      track("tonal_reconnect_failed", { error: "Wrong password" });
-      setError("Wrong password. Please try again.");
+      track("tonal_reconnect_failed", { error: "Connection failed" });
+      setError("Something went wrong. Please try again.");
       setPhase("idle");
       passwordRef.current?.focus();
     }

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,6 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 import posthog from "posthog-js";
 import { getSentryRuntimeConfig } from "@/lib/deployment";
+import { sentryBeforeSend } from "@/lib/sentryBeforeSend";
 
 if (process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN, {
@@ -39,6 +40,7 @@ if (sentryConfig) {
         : [],
     enableLogs: false,
     sendDefaultPii: false,
+    beforeSend: sentryBeforeSend,
   });
 }
 

--- a/src/lib/sentryBeforeSend.test.ts
+++ b/src/lib/sentryBeforeSend.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorEvent, EventHint } from "@sentry/nextjs";
+import { sentryBeforeSend, shouldDropSentryEvent } from "./sentryBeforeSend";
+
+function eventWithValue(value: string): ErrorEvent {
+  return { exception: { values: [{ value }] } } as unknown as ErrorEvent;
+}
+
+function hintWithError(message: string): EventHint {
+  return { originalException: new Error(message) };
+}
+
+describe("shouldDropSentryEvent", () => {
+  it.each([
+    "byok_key_missing",
+    "byok_model_missing",
+    "byok_key_invalid",
+    "byok_quota_exceeded",
+    "byok_safety_blocked",
+    "byok_unknown_error",
+    "house_key_quota_exhausted",
+    "tonal_invalid_credentials",
+  ])("drops sentinel code %s", (code) => {
+    const event = eventWithValue(`Uncaught Error: ${code}`);
+    const hint = hintWithError(code);
+    expect(shouldDropSentryEvent(event, hint)).toBe(true);
+  });
+
+  it("drops Convex RateLimited errors", () => {
+    const payload = 'ConvexError: {"kind":"RateLimited","name":"dailyMessages"}';
+    expect(shouldDropSentryEvent(eventWithValue(payload), hintWithError(payload))).toBe(true);
+  });
+
+  it("drops Not authenticated auth-guard races", () => {
+    expect(
+      shouldDropSentryEvent(
+        eventWithValue("Uncaught Error: Not authenticated"),
+        hintWithError("Not authenticated"),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops wrong-email-or-password legacy messages", () => {
+    expect(
+      shouldDropSentryEvent(
+        eventWithValue("Uncaught Error: Wrong email or password."),
+        hintWithError("Wrong email or password."),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps real errors", () => {
+    const event = eventWithValue("TypeError: Cannot read properties of undefined");
+    const hint = hintWithError("TypeError: Cannot read properties of undefined");
+    expect(shouldDropSentryEvent(event, hint)).toBe(false);
+  });
+
+  it("falls back to event.exception value when originalException is missing", () => {
+    const event = eventWithValue("Uncaught Error: byok_quota_exceeded");
+    expect(shouldDropSentryEvent(event, {})).toBe(true);
+  });
+});
+
+describe("sentryBeforeSend", () => {
+  it("returns null for dropped events", () => {
+    const event = eventWithValue("Uncaught Error: byok_key_missing");
+    expect(sentryBeforeSend(event, hintWithError("byok_key_missing"))).toBeNull();
+  });
+
+  it("returns the event unchanged for real errors", () => {
+    const event = eventWithValue("ReferenceError: foo is not defined");
+    const hint = hintWithError("foo is not defined");
+    expect(sentryBeforeSend(event, hint)).toBe(event);
+  });
+});

--- a/src/lib/sentryBeforeSend.ts
+++ b/src/lib/sentryBeforeSend.ts
@@ -1,11 +1,6 @@
 import type { ErrorEvent, EventHint } from "@sentry/nextjs";
 
-/**
- * Messages that are intentional control-flow signals, not system failures.
- * Dropping them here keeps Sentry focused on real bugs.
- */
 const SUPPRESSED_MESSAGE_SUBSTRINGS: readonly string[] = [
-  // BYOK sentinels rethrown by withByokErrorSanitization / resolveProviderKey
   "byok_key_missing",
   "byok_model_missing",
   "byok_key_invalid",
@@ -13,12 +8,9 @@ const SUPPRESSED_MESSAGE_SUBSTRINGS: readonly string[] = [
   "byok_safety_blocked",
   "byok_unknown_error",
   "house_key_quota_exhausted",
-  // User input, not a bug
   "tonal_invalid_credentials",
   "Wrong email or password",
-  // Convex rate limiter — expected user-facing cap
   '"kind":"RateLimited"',
-  // Auth guards firing from race conditions between session + navigation
   "Not authenticated",
 ];
 

--- a/src/lib/sentryBeforeSend.ts
+++ b/src/lib/sentryBeforeSend.ts
@@ -1,0 +1,50 @@
+import type { ErrorEvent, EventHint } from "@sentry/nextjs";
+
+/**
+ * Messages that are intentional control-flow signals, not system failures.
+ * Dropping them here keeps Sentry focused on real bugs.
+ */
+const SUPPRESSED_MESSAGE_SUBSTRINGS: readonly string[] = [
+  // BYOK sentinels rethrown by withByokErrorSanitization / resolveProviderKey
+  "byok_key_missing",
+  "byok_model_missing",
+  "byok_key_invalid",
+  "byok_quota_exceeded",
+  "byok_safety_blocked",
+  "byok_unknown_error",
+  "house_key_quota_exhausted",
+  // User input, not a bug
+  "tonal_invalid_credentials",
+  "Wrong email or password",
+  // Convex rate limiter — expected user-facing cap
+  '"kind":"RateLimited"',
+  // Auth guards firing from race conditions between session + navigation
+  "Not authenticated",
+];
+
+function errorMessage(event: ErrorEvent, hint: EventHint): string | null {
+  const hintError = hint.originalException;
+  if (hintError instanceof Error && typeof hintError.message === "string") {
+    return hintError.message;
+  }
+  if (typeof hintError === "string") return hintError;
+
+  const values = event.exception?.values;
+  if (values && values.length > 0) {
+    const last = values[values.length - 1]?.value;
+    if (typeof last === "string") return last;
+  }
+
+  if (typeof event.message === "string") return event.message;
+  return null;
+}
+
+export function shouldDropSentryEvent(event: ErrorEvent, hint: EventHint): boolean {
+  const message = errorMessage(event, hint);
+  if (!message) return false;
+  return SUPPRESSED_MESSAGE_SUBSTRINGS.some((needle) => message.includes(needle));
+}
+
+export function sentryBeforeSend(event: ErrorEvent, hint: EventHint): ErrorEvent | null {
+  return shouldDropSentryEvent(event, hint) ? null : event;
+}


### PR DESCRIPTION
## Summary

- Stop treating intentional control-flow signals (BYOK sentinels, Convex rate limits, auth guards) as Sentry errors — they're expected user state, not bugs. Drops ~900 events/day.
- Convert Tonal "wrong email or password" (TONALCOACH-8/9, 312 events/day, 83 users) from a thrown error to a typed \`{ success: false, error: "invalid_credentials" }\` result with cleaner UX and no Sentry capture.

## Changes

### Tonal credentials → typed result
- \`convex/tonal/auth.ts\`: \`obtainTonalToken\` now throws a typed \`tonal_invalid_credentials\` sentinel on 4xx credential failures (only matches Auth0's \`invalid_grant\` / "wrong email or password" responses). Other failures still throw with the original description.
- \`convex/tonal/connect.ts\`: \`connectTonal\` catches the sentinel and returns \`{ success: false, error: "invalid_credentials" }\`. Exported \`ConnectTonalResult\` type.
- \`convex/tonal/connectPublic.ts\`: propagates the typed result.
- \`src/app/connect-tonal/page.tsx\`, \`src/app/onboarding/ConnectStep.tsx\`, \`src/components/ReconnectModal.tsx\`: check \`result.success\` and render the specific error without swallowing unrelated failures.

### Sentry \`beforeSend\` filter
- \`src/lib/sentryBeforeSend.ts\`: shared helper that drops events whose message contains any known sentinel (\`byok_*\` codes, \`house_key_quota_exhausted\`, \`tonal_invalid_credentials\`, \`Wrong email or password\`, Convex \`RateLimited\`, \`Not authenticated\`).
- \`src/lib/sentryBeforeSend.test.ts\`: 15 tests covering each sentinel + happy path.
- Wired into \`sentry.server.config.ts\`, \`sentry.edge.config.ts\`, and \`src/instrumentation-client.ts\`.

### Housekeeping (already applied via API)
- Sentry: resolved 6 stale issues that hadn't recurred (\`systemHealth\` OCC cluster TONALCOACH-2P/2Q/1E/2R/2T, stale \`admin:getImpersonationStatus\` TONALCOACH-21).
- PostHog: archived browser-extension noise (\`window.ethereum\`, \`__firefox__\`, \`Script error.\`).

## Checklist

- [x] \`npx tsc --noEmit\` passes
- [x] \`npx tsc --noEmit -p convex/tsconfig.json\` passes
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (1039 + 15 new = 1054)
- [x] New logic has tests (happy path + sentinel matrix + fallback branches)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new \`any\` types (enforced by ESLint); \`as\` casts only at deserialization boundaries
- [ ] Tested in browser (if UI changes) - error paths exercised by unit tests; manual verification after deploy
- [x] Commits follow conventional format (\`type: description\`)
- [x] No unused exports or dead code introduced

## Test Plan

- Unit tests cover the \`sentryBeforeSend\` matrix (each sentinel, Convex RateLimited payloads, fallback to \`event.exception\`, real errors kept).
- Existing Tonal connect tests still pass — \`obtainTonalToken\` behavior only changed for the 4xx credential branch.
- After deploy, verify TONALCOACH-8/9 stop recurring and the three BYOK/RateLimited issues drop to zero new events.

## Out of scope (for follow-up PRs)

- Batch 2: \`fetchWorkoutDetail\` >8192 items and oversized cache writes (TONALCOACH-1R, 2S, 29)
- Batch 3: Workflow orphan investigation (TONALCOACH-35)
- Batch 4: Function timeout 600s (TONALCOACH-17)