### PR TITLE
fix: route workflow PostHog capture through action step

### DIFF
--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -68,6 +68,24 @@ export const doFetchAndPersistNewActivities = internalAction({
   },
 });
 
+/**
+ * Send a PostHog event from inside a workflow. Workflow handlers run in a
+ * sandbox that deletes `process` from globals, so `analytics.capture` can't
+ * read POSTHOG_PROJECT_TOKEN directly. Routing through an action gives the
+ * capture call a normal V8 runtime with `process.env` available.
+ */
+export const doCaptureEvent = internalAction({
+  args: {
+    userId: v.id("users"),
+    event: v.string(),
+    properties: v.optional(v.any()),
+  },
+  handler: async (_ctx, { userId, event, properties }) => {
+    analytics.capture(userId, event, properties);
+    await analytics.flush();
+  },
+});
+
 /** Fetch one page of history, diff, process new activities, persist. */
 export const doBackfillPage = internalAction({
   args: {
@@ -140,8 +158,11 @@ export const syncUserHistoryWorkflow = workflow.define({
       console.log(`[historySync] Synced ${synced} new workouts for user ${userId}`);
     }
 
-    analytics.capture(userId, "history_sync_completed", { new_workouts: synced });
-    await analytics.flush();
+    await step.runAction(internal.tonal.historySync.doCaptureEvent, {
+      userId,
+      event: "history_sync_completed",
+      properties: { new_workouts: synced },
+    });
 
     return null;
   },
@@ -210,8 +231,11 @@ export const backfillUserHistoryWorkflow = workflow.define({
       syncStatus: "complete",
     });
 
-    analytics.capture(userId, "history_sync_completed", { backfill: true });
-    await analytics.flush();
+    await step.runAction(internal.tonal.historySync.doCaptureEvent, {
+      userId,
+      event: "history_sync_completed",
+      properties: { backfill: true },
+    });
 
     return null;
   },


### PR DESCRIPTION
## Summary

- Fixes `ReferenceError: process is not defined` crash in `syncUserHistoryWorkflow` and `backfillUserHistoryWorkflow`.
- `@convex-dev/workflow` deletes `process` from globals inside workflow handlers for deterministic replay, which broke `analytics.capture`/`analytics.flush` reading `POSTHOG_PROJECT_TOKEN`.
- Routing the capture through an `internalAction` invoked via `step.runAction` gives it a normal V8 runtime where `process.env` is available.

## Changes

- `convex/tonal/historySync.ts`
  - Added `doCaptureEvent` internal action that wraps `analytics.capture` + `analytics.flush`.
  - Replaced the two direct `analytics.capture(...)` + `analytics.flush()` call pairs inside `syncUserHistoryWorkflow.handler` and `backfillUserHistoryWorkflow.handler` with `step.runAction(internal.tonal.historySync.doCaptureEvent, ...)`.

Other workflow handlers in the repo (`workoutPlans.retryPushWorkflow`, `workoutCatalogSync.syncWorkoutCatalogWorkflow`, `movementSync.syncMovementCatalogWorkflow`) already follow this pattern; only `historySync` had drifted.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [ ] New logic has tests (happy path + at least one error/edge case) — the wrapper action is a thin pass-through around analytics helpers; no new branching logic to cover.
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [ ] Tested in browser (if UI changes) — N/A, backend-only
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- `npx tsc --noEmit` clean.
- `npx eslint convex/tonal/historySync.ts --max-warnings=0` clean.
- `npx vitest run convex/tonal/historySync` — 8/8 passing.
- Manual verification: triggering `syncUserHistoryWorkflow` no longer throws; PostHog `history_sync_completed` events emit from the `doCaptureEvent` action step.