### PR TITLE
fix: evict oversized cache reads and guard oversized writes in tonal proxy

### DIFF
--- a/convex/tonal/cache.ts
+++ b/convex/tonal/cache.ts
@@ -93,6 +93,22 @@ export const setCacheEntry = internalMutation({
   },
 });
 
+export const deleteCacheEntryByType = internalMutation({
+  args: {
+    userId: v.optional(v.id("users")),
+    dataType: v.string(),
+  },
+  handler: async (ctx, { userId, dataType }) => {
+    const existing = await ctx.db
+      .query("tonalCache")
+      .withIndex("by_userId_dataType", (q) => q.eq("userId", userId).eq("dataType", dataType))
+      .unique();
+    if (!existing) return false;
+    await ctx.db.delete(existing._id);
+    return true;
+  },
+});
+
 export const deleteUserCacheEntries = internalMutation({
   args: {
     userId: v.id("users"),

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -43,14 +43,6 @@ export async function withTonalToken(
 
 const MAX_CACHE_VALUE_BYTES = 8 * 1024 * 1024;
 
-async function readCacheEntry(
-  ctx: ActionCtx,
-  userId: Id<"users"> | undefined,
-  dataType: string,
-): Promise<{ data: unknown; expiresAt: number } | null> {
-  return ctx.runQuery(internal.tonal.cache.getCacheEntry, { userId, dataType });
-}
-
 export function isConvexSizeError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return (
@@ -59,14 +51,6 @@ export function isConvexSizeError(err: unknown): boolean {
     msg.includes("maximum size") ||
     msg.includes("maximum length")
   );
-}
-
-function estimatedBytes(value: unknown): number {
-  try {
-    return JSON.stringify(value).length;
-  } catch {
-    return Number.POSITIVE_INFINITY;
-  }
 }
 
 /** Generic cache-check-then-fetch helper with stale-while-revalidate. */
@@ -81,18 +65,15 @@ export async function cachedFetch<T>(
 ): Promise<T> {
   const { userId, dataType, ttl, fetcher } = opts;
 
-  let cached: Awaited<ReturnType<typeof readCacheEntry>> = null;
+  let cached: { data: unknown; expiresAt: number } | null = null;
   try {
-    cached = await readCacheEntry(ctx, userId, dataType);
+    cached = await ctx.runQuery(internal.tonal.cache.getCacheEntry, { userId, dataType });
   } catch (readErr) {
-    if (isConvexSizeError(readErr)) {
-      console.warn(`cachedFetch(${dataType}): cached entry invalid on read, evicting`, readErr);
-      await ctx
-        .runMutation(internal.tonal.cache.deleteCacheEntryByType, { userId, dataType })
-        .catch((err: unknown) => console.warn(`cachedFetch(${dataType}): eviction failed`, err));
-    } else {
-      throw readErr;
-    }
+    if (!isConvexSizeError(readErr)) throw readErr;
+    console.warn(`cachedFetch(${dataType}): cached entry invalid on read, evicting`, readErr);
+    await ctx
+      .runMutation(internal.tonal.cache.deleteCacheEntryByType, { userId, dataType })
+      .catch((err: unknown) => console.warn(`cachedFetch(${dataType}): eviction failed`, err));
   }
 
   if (cached && cached.expiresAt > Date.now()) {
@@ -115,7 +96,16 @@ export async function cachedFetch<T>(
         ? data.slice(0, MAX_CACHE_ARRAY_LENGTH)
         : data;
 
-    if (estimatedBytes(cacheData) <= MAX_CACHE_VALUE_BYTES) {
+    let serializedBytes = Number.POSITIVE_INFINITY;
+    try {
+      serializedBytes = JSON.stringify(cacheData).length;
+    } catch {
+      // Unserializable payloads (circular refs, bigints) fall through as oversized.
+    }
+
+    if (serializedBytes > MAX_CACHE_VALUE_BYTES) {
+      console.warn(`cachedFetch(${dataType}): payload too large to cache, skipping write`);
+    } else {
       try {
         await ctx.runMutation(internal.tonal.cache.setCacheEntry, {
           userId,
@@ -130,8 +120,6 @@ export async function cachedFetch<T>(
           cacheErr,
         );
       }
-    } else {
-      console.warn(`cachedFetch(${dataType}): payload too large to cache, skipping write`);
     }
 
     await ctx
@@ -304,14 +292,10 @@ const MAX_SETS_RETURN = 4000;
 export function truncateWorkoutDetail(
   detail: WorkoutActivityDetail | null,
 ): WorkoutActivityDetail | null {
-  if (!detail) return detail;
-  const out: Record<string, unknown> = { ...detail };
-  for (const [key, value] of Object.entries(out)) {
-    if (Array.isArray(value) && value.length > MAX_SETS_RETURN) {
-      out[key] = value.slice(0, MAX_SETS_RETURN);
-    }
+  if (!detail?.workoutSetActivity || detail.workoutSetActivity.length <= MAX_SETS_RETURN) {
+    return detail;
   }
-  return out as unknown as WorkoutActivityDetail;
+  return { ...detail, workoutSetActivity: detail.workoutSetActivity.slice(0, MAX_SETS_RETURN) };
 }
 
 export const fetchWorkoutDetail = internalAction({

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -41,6 +41,34 @@ export async function withTonalToken(
   return { token, tonalUserId: profile.tonalUserId };
 }
 
+const MAX_CACHE_VALUE_BYTES = 8 * 1024 * 1024;
+
+async function readCacheEntry(
+  ctx: ActionCtx,
+  userId: Id<"users"> | undefined,
+  dataType: string,
+): Promise<{ data: unknown; expiresAt: number } | null> {
+  return ctx.runQuery(internal.tonal.cache.getCacheEntry, { userId, dataType });
+}
+
+export function isConvexSizeError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    msg.includes("too long") ||
+    msg.includes("too large") ||
+    msg.includes("maximum size") ||
+    msg.includes("maximum length")
+  );
+}
+
+function estimatedBytes(value: unknown): number {
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
 /** Generic cache-check-then-fetch helper with stale-while-revalidate. */
 export async function cachedFetch<T>(
   ctx: ActionCtx,
@@ -53,46 +81,57 @@ export async function cachedFetch<T>(
 ): Promise<T> {
   const { userId, dataType, ttl, fetcher } = opts;
 
-  const cached = await ctx.runQuery(internal.tonal.cache.getCacheEntry, {
-    userId,
-    dataType,
-  });
+  let cached: Awaited<ReturnType<typeof readCacheEntry>> = null;
+  try {
+    cached = await readCacheEntry(ctx, userId, dataType);
+  } catch (readErr) {
+    if (isConvexSizeError(readErr)) {
+      console.warn(`cachedFetch(${dataType}): cached entry invalid on read, evicting`, readErr);
+      await ctx
+        .runMutation(internal.tonal.cache.deleteCacheEntryByType, { userId, dataType })
+        .catch((err: unknown) => console.warn(`cachedFetch(${dataType}): eviction failed`, err));
+    } else {
+      throw readErr;
+    }
+  }
 
   if (cached && cached.expiresAt > Date.now()) {
     return cached.data as T;
   }
 
-  // Circuit breaker: if Tonal is unhealthy, serve stale data without attempting fetch
   const circuitOpen = await ctx.runQuery(internal.systemHealth.isCircuitOpen, { service: "tonal" });
   if (circuitOpen && cached) {
     console.warn(`cachedFetch(${dataType}): circuit open, serving stale data`);
     return cached.data as T;
   }
 
-  // Stale-while-revalidate: try to refresh, fall back to stale data
   try {
     const data = await fetcher();
     const now = Date.now();
 
-    // Truncate large arrays before caching to stay within Convex's
-    // 8192 element limit per array field. The full data is still
-    // returned to the caller; only the cached copy is truncated.
     const MAX_CACHE_ARRAY_LENGTH = 500;
     const cacheData =
       Array.isArray(data) && data.length > MAX_CACHE_ARRAY_LENGTH
         ? data.slice(0, MAX_CACHE_ARRAY_LENGTH)
         : data;
 
-    try {
-      await ctx.runMutation(internal.tonal.cache.setCacheEntry, {
-        userId,
-        dataType,
-        data: cacheData,
-        fetchedAt: now,
-        expiresAt: now + ttl,
-      });
-    } catch (cacheErr) {
-      console.warn(`cachedFetch(${dataType}): cache write failed, returning fresh data`, cacheErr);
+    if (estimatedBytes(cacheData) <= MAX_CACHE_VALUE_BYTES) {
+      try {
+        await ctx.runMutation(internal.tonal.cache.setCacheEntry, {
+          userId,
+          dataType,
+          data: cacheData,
+          fetchedAt: now,
+          expiresAt: now + ttl,
+        });
+      } catch (cacheErr) {
+        console.warn(
+          `cachedFetch(${dataType}): cache write failed, returning fresh data`,
+          cacheErr,
+        );
+      }
+    } else {
+      console.warn(`cachedFetch(${dataType}): payload too large to cache, skipping write`);
     }
 
     await ctx
@@ -262,10 +301,17 @@ export function toActivity(wa: WorkoutActivityDetail, meta?: WorkoutMeta): Activ
 // Convex caps array fields at 8192 elements. Tonal can return thousands of
 // set entries for some activities. Apply after every return path (fresh + cached).
 const MAX_SETS_RETURN = 4000;
-function truncateWorkoutDetail(detail: WorkoutActivityDetail | null): WorkoutActivityDetail | null {
-  if (!detail?.workoutSetActivity || detail.workoutSetActivity.length <= MAX_SETS_RETURN)
-    return detail;
-  return { ...detail, workoutSetActivity: detail.workoutSetActivity.slice(0, MAX_SETS_RETURN) };
+export function truncateWorkoutDetail(
+  detail: WorkoutActivityDetail | null,
+): WorkoutActivityDetail | null {
+  if (!detail) return detail;
+  const out: Record<string, unknown> = { ...detail };
+  for (const [key, value] of Object.entries(out)) {
+    if (Array.isArray(value) && value.length > MAX_SETS_RETURN) {
+      out[key] = value.slice(0, MAX_SETS_RETURN);
+    }
+  }
+  return out as unknown as WorkoutActivityDetail;
 }
 
 export const fetchWorkoutDetail = internalAction({

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -43,14 +43,12 @@ export async function withTonalToken(
 
 const MAX_CACHE_VALUE_BYTES = 8 * 1024 * 1024;
 
+const CONVEX_SIZE_ERROR_PATTERN =
+  /\b(is|are) too (long|large)\b|\bmaximum (size|length)\b|\bexceeds? the maximum\b/i;
+
 export function isConvexSizeError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return (
-    msg.includes("too long") ||
-    msg.includes("too large") ||
-    msg.includes("maximum size") ||
-    msg.includes("maximum length")
-  );
+  return CONVEX_SIZE_ERROR_PATTERN.test(msg);
 }
 
 /** Generic cache-check-then-fetch helper with stale-while-revalidate. */
@@ -98,7 +96,7 @@ export async function cachedFetch<T>(
 
     let serializedBytes = Number.POSITIVE_INFINITY;
     try {
-      serializedBytes = JSON.stringify(cacheData).length;
+      serializedBytes = Buffer.byteLength(JSON.stringify(cacheData), "utf8");
     } catch {
       // Unserializable payloads (circular refs, bigints) fall through as oversized.
     }
@@ -292,10 +290,12 @@ const MAX_SETS_RETURN = 4000;
 export function truncateWorkoutDetail(
   detail: WorkoutActivityDetail | null,
 ): WorkoutActivityDetail | null {
-  if (!detail?.workoutSetActivity || detail.workoutSetActivity.length <= MAX_SETS_RETURN) {
-    return detail;
-  }
-  return { ...detail, workoutSetActivity: detail.workoutSetActivity.slice(0, MAX_SETS_RETURN) };
+  const sets = detail?.workoutSetActivity;
+  if (!sets || sets.length <= MAX_SETS_RETURN) return detail;
+  console.warn(
+    `truncateWorkoutDetail: capped workoutSetActivity (${sets.length} -> ${MAX_SETS_RETURN}) for activity ${detail.id}`,
+  );
+  return { ...detail, workoutSetActivity: sets.slice(0, MAX_SETS_RETURN) };
 }
 
 export const fetchWorkoutDetail = internalAction({

--- a/convex/tonal/proxyTruncation.test.ts
+++ b/convex/tonal/proxyTruncation.test.ts
@@ -58,20 +58,6 @@ describe("truncateWorkoutDetail", () => {
     const result = truncateWorkoutDetail(detail);
     expect(result?.workoutSetActivity?.length).toBe(4000);
   });
-
-  it("truncates arbitrary oversized top-level array fields from upstream payloads", () => {
-    const detail = {
-      ...makeDetail(10),
-      extraTimeline: Array.from({ length: 9000 }, (_, i) => i),
-    } as WorkoutActivityDetail & { extraTimeline: number[] };
-
-    const result = truncateWorkoutDetail(detail) as unknown as {
-      extraTimeline: number[];
-      workoutSetActivity: SetActivity[];
-    };
-    expect(result.extraTimeline.length).toBe(4000);
-    expect(result.workoutSetActivity.length).toBe(10);
-  });
 });
 
 describe("isConvexSizeError", () => {

--- a/convex/tonal/proxyTruncation.test.ts
+++ b/convex/tonal/proxyTruncation.test.ts
@@ -65,16 +65,21 @@ describe("isConvexSizeError", () => {
     "Array length is too long (8988 > maximum length 8192)",
     "Value is too large (1.26 MiB > maximum size 1 MiB)",
     "Arguments for setCacheEntry are too large (17.96 MiB, limit: 16 MiB)",
-  ])("detects %s", (msg) => {
+  ])("detects Convex size error: %s", (msg) => {
     expect(isConvexSizeError(new Error(msg))).toBe(true);
   });
 
-  it("ignores unrelated errors", () => {
-    expect(isConvexSizeError(new Error("Not authenticated"))).toBe(false);
+  it.each([
+    "Not authenticated",
+    "Request took too long",
+    "Query took too long to complete",
+    "too large a change to apply at once",
+  ])("ignores unrelated message: %s", (msg) => {
+    expect(isConvexSizeError(new Error(msg))).toBe(false);
   });
 
-  it("tolerates non-Error values", () => {
-    expect(isConvexSizeError("too large: plain string")).toBe(true);
+  it("reads size errors from plain string inputs", () => {
+    expect(isConvexSizeError("Value is too large (1 MiB)")).toBe(true);
     expect(isConvexSizeError({})).toBe(false);
   });
 });

--- a/convex/tonal/proxyTruncation.test.ts
+++ b/convex/tonal/proxyTruncation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { isConvexSizeError, truncateWorkoutDetail } from "./proxy";
+import type { SetActivity, WorkoutActivityDetail } from "./types";
+
+function makeSet(id: string): SetActivity {
+  return {
+    id,
+    movementId: "m",
+    prescribedReps: 1,
+    repetition: 1,
+    repetitionTotal: 1,
+    blockNumber: 1,
+    spotter: false,
+    eccentric: false,
+    chains: false,
+    flex: false,
+    warmUp: false,
+    beginTime: "2026-04-17T00:00:00Z",
+    sideNumber: 0,
+  };
+}
+
+function makeDetail(setCount: number): WorkoutActivityDetail {
+  return {
+    id: "a",
+    userId: "u",
+    workoutId: "w",
+    workoutType: "guided",
+    timezone: "UTC",
+    beginTime: "2026-04-17T00:00:00Z",
+    endTime: "2026-04-17T01:00:00Z",
+    totalDuration: 3600,
+    activeDuration: 3000,
+    restDuration: 600,
+    totalMovements: 10,
+    totalSets: setCount,
+    totalReps: setCount,
+    totalVolume: 0,
+    totalConcentricWork: 0,
+    percentCompleted: 100,
+    workoutSetActivity: Array.from({ length: setCount }, (_, i) => makeSet(String(i))),
+  };
+}
+
+describe("truncateWorkoutDetail", () => {
+  it("returns null unchanged", () => {
+    expect(truncateWorkoutDetail(null)).toBeNull();
+  });
+
+  it("passes through details under the cap", () => {
+    const detail = makeDetail(100);
+    const result = truncateWorkoutDetail(detail);
+    expect(result?.workoutSetActivity?.length).toBe(100);
+  });
+
+  it("truncates workoutSetActivity arrays above the cap", () => {
+    const detail = makeDetail(9000);
+    const result = truncateWorkoutDetail(detail);
+    expect(result?.workoutSetActivity?.length).toBe(4000);
+  });
+
+  it("truncates arbitrary oversized top-level array fields from upstream payloads", () => {
+    const detail = {
+      ...makeDetail(10),
+      extraTimeline: Array.from({ length: 9000 }, (_, i) => i),
+    } as WorkoutActivityDetail & { extraTimeline: number[] };
+
+    const result = truncateWorkoutDetail(detail) as unknown as {
+      extraTimeline: number[];
+      workoutSetActivity: SetActivity[];
+    };
+    expect(result.extraTimeline.length).toBe(4000);
+    expect(result.workoutSetActivity.length).toBe(10);
+  });
+});
+
+describe("isConvexSizeError", () => {
+  it.each([
+    "Array length is too long (8988 > maximum length 8192)",
+    "Value is too large (1.26 MiB > maximum size 1 MiB)",
+    "Arguments for setCacheEntry are too large (17.96 MiB, limit: 16 MiB)",
+  ])("detects %s", (msg) => {
+    expect(isConvexSizeError(new Error(msg))).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(isConvexSizeError(new Error("Not authenticated"))).toBe(false);
+  });
+
+  it("tolerates non-Error values", () => {
+    expect(isConvexSizeError("too large: plain string")).toBe(true);
+    expect(isConvexSizeError({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Cache reads that hit Convex's array/size validators (pre-truncation rows) now evict the offending entry and fall through to a fresh fetch instead of failing the whole action (TONALCOACH-1R, 209 events / 6 users).
- Cache writes skip gracefully when the serialized payload would exceed Convex's 16 MiB mutation-argument limit (TONALCOACH-2S / -29, 244 events).
- \`truncateWorkoutDetail\` now caps every oversized top-level array on the detail object, not just \`workoutSetActivity\`. Defensive against upstream Tonal payloads that include additional list fields we don't model.

## Changes

- \`convex/tonal/proxy.ts\`:
  - \`cachedFetch\` wraps the cache read in try/catch. On \`isConvexSizeError\`, warns, deletes the bad entry via \`deleteCacheEntryByType\`, and proceeds to fetch fresh.
  - Before \`setCacheEntry\`, \`estimatedBytes\` checks the serialized payload against an 8 MiB budget (half of Convex's 16 MiB arg limit to leave headroom for other fields). Oversized payloads skip the write.
  - \`truncateWorkoutDetail\` iterates all top-level array properties and caps each at \`MAX_SETS_RETURN = 4000\`.
  - Exported \`isConvexSizeError\` and \`truncateWorkoutDetail\` for focused unit tests.
- \`convex/tonal/cache.ts\`: new \`deleteCacheEntryByType\` internal mutation for the eviction path.
- \`convex/tonal/proxyTruncation.test.ts\`: 9 tests — null/small/oversized detail paths, extra oversized array fields, and the size-error string matrix.

## Checklist

- [x] \`npx tsc --noEmit\` passes
- [x] \`npx tsc --noEmit -p convex/tsconfig.json\` passes
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (1063 passing, +9 new)
- [x] New logic has tests (truncation matrix + size-error detector)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new \`any\` types (enforced by ESLint); \`as\` casts only at deserialization boundaries
- [ ] Tested in browser (if UI changes) - N/A, backend only
- [x] Commits follow conventional format (\`type: description\`)
- [x] No unused exports or dead code introduced

## Test Plan

- Unit tests cover the truncation and size-error matrix.
- After deploy, expect TONALCOACH-1R to stop recurring: first oversized cache read evicts itself, subsequent reads fall through to fresh fetches.
- TONALCOACH-2S is 1-user and last recurred Apr 15; the pre-flight size check prevents reoccurrence.

## Out of scope

- Batch 3: Workflow orphan (TONALCOACH-35) — investigation, likely a single stuck row
- Batch 4: Function execution timed out 600s (TONALCOACH-17) — probably historySync, needs profiling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache robustness: automatically evicts problematic entries when size-related errors occur.
  * Prevents storing oversized payloads and logs/skips large writes while still returning fresh data when caching fails.
  * Applies consistent truncation to oversized activity details to avoid storage/transfer issues.

* **Tests**
  * Added tests for truncation behavior and size-error detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->