### PR TITLE
refactor(tonal): tighten cache size budget and project workout meta payloads

### DIFF
--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -6,6 +6,7 @@ import type { Id } from "../_generated/dataModel";
 import { decrypt } from "./encryption";
 import { TonalApiError, tonalFetch } from "./client";
 import { CACHE_TTLS } from "./cache";
+import { isCacheValueWithinLimit, isConvexSizeError } from "./proxyCacheLimits";
 import { withTokenRetry } from "./tokenRetry";
 import type {
   Activity,
@@ -41,15 +42,7 @@ export async function withTonalToken(
   return { token, tonalUserId: profile.tonalUserId };
 }
 
-const MAX_CACHE_VALUE_BYTES = 8 * 1024 * 1024;
-
-const CONVEX_SIZE_ERROR_PATTERN =
-  /\b(is|are) too (long|large)\b|\bmaximum (size|length)\b|\bexceeds? the maximum\b/i;
-
-export function isConvexSizeError(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  return CONVEX_SIZE_ERROR_PATTERN.test(msg);
-}
+const MAX_CACHE_ARRAY_LENGTH = 500;
 
 /** Generic cache-check-then-fetch helper with stale-while-revalidate. */
 export async function cachedFetch<T>(
@@ -88,20 +81,12 @@ export async function cachedFetch<T>(
     const data = await fetcher();
     const now = Date.now();
 
-    const MAX_CACHE_ARRAY_LENGTH = 500;
     const cacheData =
       Array.isArray(data) && data.length > MAX_CACHE_ARRAY_LENGTH
         ? data.slice(0, MAX_CACHE_ARRAY_LENGTH)
         : data;
 
-    let serializedBytes = Number.POSITIVE_INFINITY;
-    try {
-      serializedBytes = Buffer.byteLength(JSON.stringify(cacheData), "utf8");
-    } catch {
-      // Unserializable payloads (circular refs, bigints) fall through as oversized.
-    }
-
-    if (serializedBytes > MAX_CACHE_VALUE_BYTES) {
+    if (!isCacheValueWithinLimit(cacheData)) {
       console.warn(`cachedFetch(${dataType}): payload too large to cache, skipping write`);
     } else {
       try {
@@ -224,6 +209,18 @@ export interface WorkoutMeta {
   targetArea?: string;
 }
 
+export function projectWorkoutMeta(raw: unknown): WorkoutMeta {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+
+  const candidate = raw as { title?: unknown; targetArea?: unknown };
+  return {
+    title: typeof candidate.title === "string" ? candidate.title : undefined,
+    targetArea: typeof candidate.targetArea === "string" ? candidate.targetArea : undefined,
+  };
+}
+
 const WORKOUT_META_BATCH_SIZE = 10;
 
 /** Batch-fetch workout metadata for unique workoutIds. Failures are silently skipped. */
@@ -240,7 +237,13 @@ export async function fetchWorkoutMetaBatch(
         const data = await cachedFetch<WorkoutMeta>(ctx, {
           dataType: `workoutMeta:${id}`,
           ttl: CACHE_TTLS.profile,
-          fetcher: () => tonalFetch<WorkoutMeta>(token, `/v6/workouts/${id}`),
+          fetcher: async () => {
+            const raw = await tonalFetch<{ title?: unknown; targetArea?: unknown }>(
+              token,
+              `/v6/workouts/${id}`,
+            );
+            return projectWorkoutMeta(raw);
+          },
         });
         return { id, data };
       }),

--- a/convex/tonal/proxyCacheBehavior.test.ts
+++ b/convex/tonal/proxyCacheBehavior.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActionCtx } from "../_generated/server";
+import { cachedFetch, fetchWorkoutMetaBatch } from "./proxy";
+import { MAX_CACHE_VALUE_BYTES } from "./proxyCacheLimits";
+
+type CacheRow = {
+  data: unknown;
+  fetchedAt: number;
+  expiresAt: number;
+};
+
+function makeCacheKey(userId: unknown, dataType: string) {
+  return `${String(userId ?? "global")}:${dataType}`;
+}
+
+function makeMockCtx() {
+  const cache = new Map<string, CacheRow>();
+
+  const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+    if ("dataType" in args) {
+      return cache.get(makeCacheKey(args.userId, String(args.dataType))) ?? null;
+    }
+    if ("service" in args) {
+      return false;
+    }
+    return null;
+  });
+
+  const runMutation = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+    if ("dataType" in args && "data" in args) {
+      cache.set(makeCacheKey(args.userId, String(args.dataType)), {
+        data: args.data,
+        fetchedAt: Number(args.fetchedAt),
+        expiresAt: Number(args.expiresAt),
+      });
+      return undefined;
+    }
+    if ("dataType" in args) {
+      cache.delete(makeCacheKey(args.userId, String(args.dataType)));
+      return true;
+    }
+    return undefined;
+  });
+
+  return {
+    cache,
+    runQuery,
+    runMutation,
+    ctx: {
+      runQuery,
+      runMutation,
+    } as unknown as ActionCtx,
+  };
+}
+
+function makeJsonResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: () => null,
+    },
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("cachedFetch", () => {
+  it("skips doomed cache writes before calling the cache mutation", async () => {
+    const { ctx, runMutation } = makeMockCtx();
+    const fetcher = vi.fn().mockResolvedValue({ payload: "x".repeat(MAX_CACHE_VALUE_BYTES + 1) });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await cachedFetch(ctx, {
+      dataType: "oversized",
+      ttl: 60_000,
+      fetcher,
+    });
+
+    await cachedFetch(ctx, {
+      dataType: "oversized",
+      ttl: 60_000,
+      fetcher,
+    });
+
+    const cacheWriteCalls = runMutation.mock.calls.filter(
+      ([, args]) => args && typeof args === "object" && "dataType" in args && "data" in args,
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(cacheWriteCalls).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "cachedFetch(oversized): payload too large to cache, skipping write",
+    );
+  });
+});
+
+describe("fetchWorkoutMetaBatch", () => {
+  it("projects large workout responses before caching and reuses the cached metadata", async () => {
+    const { ctx, cache } = makeMockCtx();
+    const fetchMock = vi.fn(async () =>
+      makeJsonResponse({
+        title: "Push Day",
+        targetArea: "Upper Body",
+        blocks: "x".repeat(MAX_CACHE_VALUE_BYTES + 50_000),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await fetchWorkoutMetaBatch(ctx, "token", ["workout-1"]);
+    const second = await fetchWorkoutMetaBatch(ctx, "token", ["workout-1"]);
+
+    expect(first.get("workout-1")).toEqual({
+      title: "Push Day",
+      targetArea: "Upper Body",
+    });
+    expect(second.get("workout-1")).toEqual({
+      title: "Push Day",
+      targetArea: "Upper Body",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(cache.get("global:workoutMeta:workout-1")?.data).toEqual({
+      title: "Push Day",
+      targetArea: "Upper Body",
+    });
+  });
+});

--- a/convex/tonal/proxyCacheLimits.ts
+++ b/convex/tonal/proxyCacheLimits.ts
@@ -1,0 +1,24 @@
+const CONVEX_DOC_LIMIT_BYTES = 1024 * 1024;
+const CACHE_SIZE_HEADROOM_BYTES = 64 * 1024;
+export const MAX_CACHE_VALUE_BYTES = CONVEX_DOC_LIMIT_BYTES - CACHE_SIZE_HEADROOM_BYTES;
+
+const CONVEX_SIZE_ERROR_PATTERN =
+  /\b(is|are) too (long|large)\b|\bmaximum (size|length)\b|\bexceeds? the maximum\b/i;
+
+export function isConvexSizeError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return CONVEX_SIZE_ERROR_PATTERN.test(msg);
+}
+
+export function estimateCacheValueBytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    // Unserializable payloads (circular refs, bigints) should never be cached.
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+export function isCacheValueWithinLimit(value: unknown): boolean {
+  return estimateCacheValueBytes(value) <= MAX_CACHE_VALUE_BYTES;
+}

--- a/convex/tonal/proxyTruncation.test.ts
+++ b/convex/tonal/proxyTruncation.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { isConvexSizeError, truncateWorkoutDetail } from "./proxy";
+import { projectWorkoutMeta, toActivity, truncateWorkoutDetail } from "./proxy";
+import {
+  estimateCacheValueBytes,
+  isCacheValueWithinLimit,
+  isConvexSizeError,
+  MAX_CACHE_VALUE_BYTES,
+} from "./proxyCacheLimits";
 import type { SetActivity, WorkoutActivityDetail } from "./types";
 
 function makeSet(id: string): SetActivity {
@@ -57,6 +63,79 @@ describe("truncateWorkoutDetail", () => {
     const detail = makeDetail(9000);
     const result = truncateWorkoutDetail(detail);
     expect(result?.workoutSetActivity?.length).toBe(4000);
+  });
+});
+
+describe("projectWorkoutMeta", () => {
+  it("keeps only title and targetArea string fields", () => {
+    const result = projectWorkoutMeta({
+      title: "Push Day",
+      targetArea: "Upper Body",
+      description: "ignored",
+      blocks: [{ id: "b1" }],
+    });
+
+    expect(result).toEqual({
+      title: "Push Day",
+      targetArea: "Upper Body",
+    });
+  });
+
+  it("drops non-string metadata values", () => {
+    const result = projectWorkoutMeta({
+      title: 42,
+      targetArea: ["Upper Body"],
+    });
+
+    expect(result).toEqual({
+      title: undefined,
+      targetArea: undefined,
+    });
+  });
+
+  it("returns empty metadata for null and non-object payloads", () => {
+    expect(projectWorkoutMeta(null)).toEqual({});
+    expect(projectWorkoutMeta("Push Day")).toEqual({});
+    expect(projectWorkoutMeta(["Push Day"])).toEqual({});
+  });
+});
+
+describe("cache size helpers", () => {
+  it("measures serializable values", () => {
+    expect(estimateCacheValueBytes({ title: "Push Day" })).toBeGreaterThan(0);
+  });
+
+  it("treats unserializable values as oversized", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(estimateCacheValueBytes(circular)).toBe(Number.POSITIVE_INFINITY);
+    expect(isCacheValueWithinLimit(circular)).toBe(false);
+  });
+
+  it("rejects payloads above the safe cache threshold", () => {
+    const oversized = { data: "x".repeat(MAX_CACHE_VALUE_BYTES + 1) };
+
+    expect(isCacheValueWithinLimit(oversized)).toBe(false);
+  });
+});
+
+describe("toActivity", () => {
+  it("fills default title and target area when metadata is missing", () => {
+    const result = toActivity(makeDetail(1));
+
+    expect(result.workoutPreview.workoutTitle).toBe("Tonal Workout");
+    expect(result.workoutPreview.targetArea).toBe("Full Body");
+  });
+
+  it("uses projected metadata when available", () => {
+    const result = toActivity(makeDetail(1), {
+      title: "Leg Day",
+      targetArea: "Lower Body",
+    });
+
+    expect(result.workoutPreview.workoutTitle).toBe("Leg Day");
+    expect(result.workoutPreview.targetArea).toBe("Lower Body");
   });
 });
 

--- a/convex/workflows.ts
+++ b/convex/workflows.ts
@@ -3,6 +3,7 @@ import { components } from "./_generated/api";
 
 export const workflow = new WorkflowManager(components.workflow, {
   workpoolOptions: {
+    logLevel: "WARN",
     defaultRetryBehavior: {
       maxAttempts: 3,
       initialBackoffMs: 1000,


### PR DESCRIPTION
## Summary
- Move the cache size helpers (`MAX_CACHE_VALUE_BYTES`, `isConvexSizeError`, `estimateCacheValueBytes`, `isCacheValueWithinLimit`) into a new `convex/tonal/proxyCacheLimits.ts` so `proxy.ts` stays under the 400-line hard cap and the helpers can be unit-tested in isolation.
- Derive `MAX_CACHE_VALUE_BYTES` from `CONVEX_DOC_LIMIT_BYTES` (1 MiB) minus a 64 KiB headroom budget instead of the old arbitrary 8 MiB constant, so the cache write budget actually tracks the Convex document cap.
- Project `/v6/workouts/:id` responses to just `{ title, targetArea }` via the new `projectWorkoutMeta` helper before the cache write — the upstream payload contains a full `blocks` array that can blow past the cache budget by itself, leaving us with a poisoned cache row that can't be read back.
- Drop the workflow workpool log floor to `WARN` so retries and failures stay visible without the per-step bookkeeping noise.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run convex/tonal/proxyCacheBehavior.test.ts convex/tonal/proxyTruncation.test.ts` (21 tests pass)
- [ ] `npm test` on CI
- [ ] Spot-check a Tonal-connected account in preview to confirm `fetchWorkoutMetaBatch` still hydrates workout titles after the projection narrowing
- [ ] Confirm Convex logs in preview no longer show per-step workpool chatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)