### PR TITLE
feat: PR tracking with materialized personal records (aggregate)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -75,6 +75,7 @@ import type * as migrations from "../migrations.js";
 import type * as migrations_backfillAvgWeight from "../migrations/backfillAvgWeight.js";
 import type * as migrations_rotateTokenEncryptionKey from "../migrations/rotateTokenEncryptionKey.js";
 import type * as progressiveOverload from "../progressiveOverload.js";
+import type * as prs from "../prs.js";
 import type * as rateLimits from "../rateLimits.js";
 import type * as schedule from "../schedule.js";
 import type * as stats from "../stats.js";
@@ -200,6 +201,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/backfillAvgWeight": typeof migrations_backfillAvgWeight;
   "migrations/rotateTokenEncryptionKey": typeof migrations_rotateTokenEncryptionKey;
   progressiveOverload: typeof progressiveOverload;
+  prs: typeof prs;
   rateLimits: typeof rateLimits;
   schedule: typeof schedule;
   stats: typeof stats;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -73,7 +73,9 @@ import type * as lib_targetArea from "../lib/targetArea.js";
 import type * as libraryWorkouts from "../libraryWorkouts.js";
 import type * as migrations from "../migrations.js";
 import type * as migrations_backfillAvgWeight from "../migrations/backfillAvgWeight.js";
+import type * as migrations_backfillPersonalRecords from "../migrations/backfillPersonalRecords.js";
 import type * as migrations_rotateTokenEncryptionKey from "../migrations/rotateTokenEncryptionKey.js";
+import type * as personalRecords from "../personalRecords.js";
 import type * as progressiveOverload from "../progressiveOverload.js";
 import type * as prs from "../prs.js";
 import type * as rateLimits from "../rateLimits.js";
@@ -101,6 +103,7 @@ import type * as tonal_mutations from "../tonal/mutations.js";
 import type * as tonal_profileBackfill from "../tonal/profileBackfill.js";
 import type * as tonal_profileData from "../tonal/profileData.js";
 import type * as tonal_proxy from "../tonal/proxy.js";
+import type * as tonal_proxyCacheLimits from "../tonal/proxyCacheLimits.js";
 import type * as tonal_refresh from "../tonal/refresh.js";
 import type * as tonal_refreshPublic from "../tonal/refreshPublic.js";
 import type * as tonal_resync from "../tonal/resync.js";
@@ -199,7 +202,9 @@ declare const fullApi: ApiFromModules<{
   libraryWorkouts: typeof libraryWorkouts;
   migrations: typeof migrations;
   "migrations/backfillAvgWeight": typeof migrations_backfillAvgWeight;
+  "migrations/backfillPersonalRecords": typeof migrations_backfillPersonalRecords;
   "migrations/rotateTokenEncryptionKey": typeof migrations_rotateTokenEncryptionKey;
+  personalRecords: typeof personalRecords;
   progressiveOverload: typeof progressiveOverload;
   prs: typeof prs;
   rateLimits: typeof rateLimits;
@@ -227,6 +232,7 @@ declare const fullApi: ApiFromModules<{
   "tonal/profileBackfill": typeof tonal_profileBackfill;
   "tonal/profileData": typeof tonal_profileData;
   "tonal/proxy": typeof tonal_proxy;
+  "tonal/proxyCacheLimits": typeof tonal_proxyCacheLimits;
   "tonal/refresh": typeof tonal_refresh;
   "tonal/refreshPublic": typeof tonal_refreshPublic;
   "tonal/resync": typeof tonal_resync;
@@ -282,6 +288,7 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   agent: import("@convex-dev/agent/_generated/component.js").ComponentApi<"agent">;
+  perfByMovement: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"perfByMovement">;
   migrations: import("@convex-dev/migrations/_generated/component.js").ComponentApi<"migrations">;
   rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
   workflow: import("@convex-dev/workflow/_generated/component.js").ComponentApi<"workflow">;

--- a/convex/account.ts
+++ b/convex/account.ts
@@ -134,6 +134,9 @@ export const deleteAccount = action({
       }
 
       for (const mutation of [
+        // personalRecords is drained first so its aggregate entries are cleared
+        // before the exercisePerformance rows it mirrors are deleted.
+        internal.accountDeletion.deletePersonalRecordsBatch,
         internal.accountDeletion.deleteExercisePerformanceBatch,
         internal.accountDeletion.deleteTonalCacheBatch,
         internal.accountDeletion.deleteExternalActivitiesBatch,

--- a/convex/accountDeletion.ts
+++ b/convex/accountDeletion.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
 import { BY_USER_ID_BATCH_TABLES, type ByUserIdBatchTable } from "./userData";
+import { clearForUser as clearPersonalRecordsForUser } from "./personalRecords";
 
 const BATCH_SIZE = 500;
 // tonalCache rows can hold up to ~1 MiB each, so a 500-row batch can blow past
@@ -43,6 +44,18 @@ export const deleteExercisePerformanceBatch = internalMutation({
       await ctx.db.delete(doc._id);
     }
     return docs.length === BATCH_SIZE;
+  },
+});
+
+/**
+ * Delete one batch of personalRecords rows, also clearing the corresponding
+ * aggregate namespaces. Run before `deleteExercisePerformanceBatch` so the
+ * aggregate is empty by the time the source rows go away.
+ */
+export const deletePersonalRecordsBatch = internalMutation({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }): Promise<boolean> => {
+    return clearPersonalRecordsForUser(ctx, userId, BATCH_SIZE);
   },
 });
 

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,11 +1,13 @@
 import { defineApp } from "convex/server";
 import agent from "@convex-dev/agent/convex.config";
+import aggregate from "@convex-dev/aggregate/convex.config";
 import migrations from "@convex-dev/migrations/convex.config";
 import rateLimiter from "@convex-dev/rate-limiter/convex.config";
 import workflow from "@convex-dev/workflow/convex.config";
 
 const app = defineApp();
 app.use(agent);
+app.use(aggregate, { name: "perfByMovement" });
 app.use(migrations);
 app.use(rateLimiter);
 app.use(workflow);

--- a/convex/dashboard.ts
+++ b/convex/dashboard.ts
@@ -114,7 +114,7 @@ export const getWorkoutHistory = query({
         activityId: r.activityId,
         date: r.date,
         title: r.title,
-        targetArea: r.targetArea,
+        targetArea: normalizeTargetArea(r.targetArea),
         totalVolume: r.totalVolume,
         totalDuration: r.totalDuration,
         totalWork: r.totalWork,

--- a/convex/migrations/backfillAvgWeight.ts
+++ b/convex/migrations/backfillAvgWeight.ts
@@ -47,7 +47,10 @@ export const patchAvgWeights = internalMutation({
       .collect();
     for (const row of rows) {
       const weight = weightMap.get(row.movementId);
-      if (weight != null) {
+      // Only fill in rows that had their weight nulled out (the migration's
+      // stated purpose); skipping already-weighted rows avoids needlessly
+      // churning the aggregate via afterPerformancePatch.
+      if (weight != null && row.avgWeightLbs == null) {
         await ctx.db.patch(row._id, { avgWeightLbs: weight });
         const updated = await ctx.db.get(row._id);
         if (updated) await afterPerformancePatch(ctx, row, updated);

--- a/convex/migrations/backfillAvgWeight.ts
+++ b/convex/migrations/backfillAvgWeight.ts
@@ -15,6 +15,7 @@ import type { Movement, WorkoutActivityDetail } from "../tonal/types";
 import { aggregateDetailToSessions } from "../progressiveOverload";
 import { withTokenRetry } from "../tonal/tokenRetry";
 import { tonalFetch } from "../tonal/client";
+import { afterPatch as afterPerformancePatch } from "../personalRecords";
 
 const BATCH_SIZE = 10;
 
@@ -48,6 +49,8 @@ export const patchAvgWeights = internalMutation({
       const weight = weightMap.get(row.movementId);
       if (weight != null) {
         await ctx.db.patch(row._id, { avgWeightLbs: weight });
+        const updated = await ctx.db.get(row._id);
+        if (updated) await afterPerformancePatch(ctx, row, updated);
       }
     }
   },

--- a/convex/migrations/backfillPersonalRecords.ts
+++ b/convex/migrations/backfillPersonalRecords.ts
@@ -1,0 +1,103 @@
+/**
+ * One-time backfill for the `personalRecords` projection + `perfByMovement`
+ * aggregate. Walks every weighted `exercisePerformance` row per user,
+ * idempotently populates the aggregate, then reconciles one projection per
+ * unique movement.
+ *
+ * Runbook:
+ *   npx convex run migrations/backfillPersonalRecords:backfillAll
+ *   # or target a single user:
+ *   npx convex run migrations/backfillPersonalRecords:backfillUser '{"userId": "<id>"}'
+ *
+ * Safe to re-run — `insertIfDoesNotExist` and `recomputeProjection` are both
+ * idempotent, so a partial run followed by a full run converges to the same
+ * state as a single full run.
+ */
+
+import { v } from "convex/values";
+import { internalAction, internalMutation } from "../_generated/server";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { perfByMovement, recomputeProjection } from "../personalRecords";
+
+const PAGE_SIZE = 500;
+const RECONCILE_BATCH = 50;
+
+export const backfillUserBatch = internalMutation({
+  args: { userId: v.id("users"), cursor: v.union(v.string(), v.null()) },
+  handler: async (
+    ctx,
+    { userId, cursor },
+  ): Promise<{ movementIds: string[]; continueCursor: string; isDone: boolean }> => {
+    const result = await ctx.db
+      .query("exercisePerformance")
+      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+      .paginate({ numItems: PAGE_SIZE, cursor });
+
+    const movementIds = new Set<string>();
+    for (const row of result.page) {
+      if (row.avgWeightLbs != null && row.avgWeightLbs > 0) {
+        await perfByMovement.insertIfDoesNotExist(ctx, row);
+        movementIds.add(row.movementId);
+      }
+    }
+    return {
+      movementIds: [...movementIds],
+      continueCursor: result.continueCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
+export const reconcileProjectionsBatch = internalMutation({
+  args: { userId: v.id("users"), movementIds: v.array(v.string()) },
+  handler: async (ctx, { userId, movementIds }) => {
+    for (const movementId of movementIds) {
+      await recomputeProjection(ctx, userId, movementId);
+    }
+  },
+});
+
+export const backfillUser = internalAction({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }): Promise<{ movementsReconciled: number }> => {
+    const allMovementIds = new Set<string>();
+    let cursor: string | null = null;
+
+    while (true) {
+      const batch: { movementIds: string[]; continueCursor: string; isDone: boolean } =
+        await ctx.runMutation(internal.migrations.backfillPersonalRecords.backfillUserBatch, {
+          userId,
+          cursor,
+        });
+      for (const id of batch.movementIds) allMovementIds.add(id);
+      cursor = batch.continueCursor;
+      if (batch.isDone) break;
+    }
+
+    const movementIds = [...allMovementIds];
+    for (let i = 0; i < movementIds.length; i += RECONCILE_BATCH) {
+      await ctx.runMutation(internal.migrations.backfillPersonalRecords.reconcileProjectionsBatch, {
+        userId,
+        movementIds: movementIds.slice(i, i + RECONCILE_BATCH),
+      });
+    }
+
+    return { movementsReconciled: movementIds.length };
+  },
+});
+
+export const backfillAll = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const users = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
+      sinceTimestamp: 0,
+    });
+    for (const profile of users) {
+      await ctx.scheduler.runAfter(0, internal.migrations.backfillPersonalRecords.backfillUser, {
+        userId: profile.userId as Id<"users">,
+      });
+    }
+    console.log(`[backfillPersonalRecords] Scheduled backfill for ${users.length} users`);
+  },
+});

--- a/convex/migrations/backfillPersonalRecords.ts
+++ b/convex/migrations/backfillPersonalRecords.ts
@@ -17,7 +17,6 @@
 import { v } from "convex/values";
 import { internalAction, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
 import { perfByMovement, recomputeProjection } from "../personalRecords";
 
 const PAGE_SIZE = 500;
@@ -95,7 +94,7 @@ export const backfillAll = internalAction({
     });
     for (const profile of users) {
       await ctx.scheduler.runAfter(0, internal.migrations.backfillPersonalRecords.backfillUser, {
-        userId: profile.userId as Id<"users">,
+        userId: profile.userId,
       });
     }
     console.log(`[backfillPersonalRecords] Scheduled backfill for ${users.length} users`);

--- a/convex/personalRecords.ts
+++ b/convex/personalRecords.ts
@@ -22,7 +22,7 @@ import { TableAggregate } from "@convex-dev/aggregate";
 import type { Doc, Id } from "./_generated/dataModel";
 import { components } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
-import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
 
 /** Namespace: one bucket per (user, movement). */
 type PerfNamespace = [Id<"users">, string];
@@ -45,36 +45,6 @@ function hasWeight(row: Doc<"exercisePerformance">): boolean {
   return row.avgWeightLbs != null && row.avgWeightLbs > 0;
 }
 
-async function findProjection(
-  ctx: QueryCtx,
-  userId: Id<"users">,
-  movementId: string,
-): Promise<Doc<"personalRecords"> | null> {
-  return ctx.db
-    .query("personalRecords")
-    .withIndex("by_userId_movementId", (q) => q.eq("userId", userId).eq("movementId", movementId))
-    .unique();
-}
-
-/**
- * Prefer the user-local date from `completedWorkouts` over the UTC date stored
- * on `exercisePerformance`. Falls back to the UTC date if the workout row
- * hasn't been written yet (sync order isn't guaranteed).
- */
-async function resolveAchievedDate(
-  ctx: QueryCtx,
-  userId: Id<"users">,
-  row: Doc<"exercisePerformance">,
-): Promise<string> {
-  const workout = await ctx.db
-    .query("completedWorkouts")
-    .withIndex("by_userId_activityId", (q) =>
-      q.eq("userId", userId).eq("activityId", row.activityId),
-    )
-    .first();
-  return workout?.date ?? row.date;
-}
-
 /**
  * Exported for the backfill. Normal writes should go through the `afterInsert`
  * / `afterPatch` / `afterDelete` helpers instead — they call this.
@@ -85,7 +55,10 @@ export async function recomputeProjection(
   movementId: string,
 ): Promise<void> {
   const namespace: PerfNamespace = [userId, movementId];
-  const existing = await findProjection(ctx, userId, movementId);
+  const existing = await ctx.db
+    .query("personalRecords")
+    .withIndex("by_userId_movementId", (q) => q.eq("userId", userId).eq("movementId", movementId))
+    .unique();
   const count = await perfByMovement.count(ctx, { namespace });
 
   if (count === 0) {
@@ -98,11 +71,7 @@ export async function recomputeProjection(
   // weight. Earliest wins under ties so the PR badge stays on the session
   // that first achieved the weight, not every subsequent session that
   // matches it.
-  const maxItem = await perfByMovement.at(ctx, -1, { namespace }).catch((): null => null);
-  if (!maxItem) {
-    if (existing) await ctx.db.delete(existing._id);
-    return;
-  }
+  const maxItem = await perfByMovement.at(ctx, -1, { namespace });
   const winnerItem = await perfByMovement.at(ctx, 0, {
     namespace,
     bounds: {
@@ -112,16 +81,28 @@ export async function recomputeProjection(
   });
   const row = await ctx.db.get(winnerItem.id);
   if (!row || !hasWeight(row)) {
+    // Aggregate is ahead of the table (e.g. a row got deleted between the
+    // count read and now); the next write will reconcile.
     if (existing) await ctx.db.delete(existing._id);
     return;
   }
+
+  // Prefer the user-local date from `completedWorkouts` over the UTC date
+  // stored on `exercisePerformance`. Falls back to the UTC date if the
+  // workout row hasn't been written yet (sync order isn't guaranteed).
+  const workout = await ctx.db
+    .query("completedWorkouts")
+    .withIndex("by_userId_activityId", (q) =>
+      q.eq("userId", userId).eq("activityId", row.activityId),
+    )
+    .first();
 
   const next = {
     userId,
     movementId,
     bestAvgWeightLbs: row.avgWeightLbs!,
     achievedActivityId: row.activityId,
-    achievedDate: await resolveAchievedDate(ctx, userId, row),
+    achievedDate: workout?.date ?? row.date,
     totalSessions: count,
     updatedAt: Date.now(),
   };

--- a/convex/personalRecords.ts
+++ b/convex/personalRecords.ts
@@ -161,18 +161,37 @@ export async function afterDelete(
   await recomputeProjection(ctx, row.userId, row.movementId);
 }
 
-/** Clear all projections + aggregate entries for a user (account deletion). */
+/**
+ * Clear all projections + aggregate entries for a user (account deletion).
+ *
+ * Namespaces are derived from BOTH `personalRecords` and `exercisePerformance`
+ * because a partial backfill populates the aggregate before the projection
+ * rows are reconciled — a user who deletes their account between those two
+ * phases would otherwise leave orphaned aggregate entries behind.
+ */
 export async function clearForUser(
   ctx: MutationCtx,
   userId: Id<"users">,
   batchSize: number,
 ): Promise<boolean> {
-  const records = await ctx.db
-    .query("personalRecords")
-    .withIndex("by_userId", (q) => q.eq("userId", userId))
-    .take(batchSize);
+  const [records, perfRows] = await Promise.all([
+    ctx.db
+      .query("personalRecords")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .take(batchSize),
+    ctx.db
+      .query("exercisePerformance")
+      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+      .take(batchSize),
+  ]);
+
+  const movementIds = new Set<string>();
+  for (const r of records) movementIds.add(r.movementId);
+  for (const r of perfRows) movementIds.add(r.movementId);
+  for (const movementId of movementIds) {
+    await perfByMovement.clear(ctx, { namespace: [userId, movementId] });
+  }
   for (const record of records) {
-    await perfByMovement.clear(ctx, { namespace: [userId, record.movementId] });
     await ctx.db.delete(record._id);
   }
   return records.length === batchSize;

--- a/convex/personalRecords.ts
+++ b/convex/personalRecords.ts
@@ -27,14 +27,23 @@ import type { MutationCtx } from "./_generated/server";
 /** Namespace: one bucket per (user, movement). */
 type PerfNamespace = [Id<"users">, string];
 
+/**
+ * SortKey is the tuple `[avgWeightLbs, -_creationTime]` so the aggregate's
+ * natural ordering places max weight last (what we want for `at(-1)`) AND
+ * breaks ties in favor of the earliest-inserted row. The aggregate compares
+ * tuples lexicographically, so within a tied weight the row with the larger
+ * `-_creationTime` (= smaller `_creationTime` = earliest insertion) sorts
+ * last. Without this, ties would fall back to the Convex `_id` string, which
+ * is random and non-chronological.
+ */
 export const perfByMovement = new TableAggregate<{
   Namespace: PerfNamespace;
-  Key: number;
+  Key: [number, number];
   DataModel: DataModel;
   TableName: "exercisePerformance";
 }>(components.perfByMovement, {
   namespace: (doc) => [doc.userId, doc.movementId],
-  sortKey: (doc) => doc.avgWeightLbs ?? 0,
+  sortKey: (doc) => [doc.avgWeightLbs ?? 0, -doc._creationTime],
 });
 
 // ---------------------------------------------------------------------------
@@ -66,19 +75,9 @@ export async function recomputeProjection(
     return;
   }
 
-  // Two-step max lookup: `at(-1)` gives the largest avgWeightLbs, then
-  // `at(0, { bounds: [key,key] })` gives the *earliest-inserted* row at that
-  // weight. Earliest wins under ties so the PR badge stays on the session
-  // that first achieved the weight, not every subsequent session that
-  // matches it.
-  const maxItem = await perfByMovement.at(ctx, -1, { namespace });
-  const winnerItem = await perfByMovement.at(ctx, 0, {
-    namespace,
-    bounds: {
-      lower: { key: maxItem.key, inclusive: true },
-      upper: { key: maxItem.key, inclusive: true },
-    },
-  });
+  // `at(-1)` returns the row with the largest sortKey tuple, which the
+  // sortKey function defines as max weight then earliest insertion.
+  const winnerItem = await perfByMovement.at(ctx, -1, { namespace });
   const row = await ctx.db.get(winnerItem.id);
   if (!row || !hasWeight(row)) {
     // Aggregate is ahead of the table (e.g. a row got deleted between the

--- a/convex/personalRecords.ts
+++ b/convex/personalRecords.ts
@@ -1,0 +1,199 @@
+/**
+ * Personal records subsystem.
+ *
+ * Two cooperating pieces of derived state, both kept in sync with
+ * `exercisePerformance` by the helpers below:
+ *
+ * 1. `perfByMovement` — an `@convex-dev/aggregate` instance namespaced by
+ *    `[userId, movementId]`, sort-keyed by `avgWeightLbs`. Gives us
+ *    O(log N) `max` / `count` per movement, used when recomputing the best
+ *    after a delete/patch removes the prior winner.
+ * 2. `personalRecords` table — a per-(user, movement) projection carrying
+ *    the best weight plus the context a UI needs: `achievedActivityId`,
+ *    `achievedDate`, `totalSessions`. Single-index scans power the
+ *    Personal Records page and the workout-detail PR badges without
+ *    touching `exercisePerformance` on the read path.
+ *
+ * Callers never poke these two stores directly — every `exercisePerformance`
+ * mutation routes through `afterInsert` / `afterPatch` / `afterDelete` so
+ * the invariants stay local to this file.
+ */
+import { TableAggregate } from "@convex-dev/aggregate";
+import type { Doc, Id } from "./_generated/dataModel";
+import { components } from "./_generated/api";
+import type { DataModel } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+
+/** Namespace: one bucket per (user, movement). */
+type PerfNamespace = [Id<"users">, string];
+
+export const perfByMovement = new TableAggregate<{
+  Namespace: PerfNamespace;
+  Key: number;
+  DataModel: DataModel;
+  TableName: "exercisePerformance";
+}>(components.perfByMovement, {
+  namespace: (doc) => [doc.userId, doc.movementId],
+  sortKey: (doc) => doc.avgWeightLbs ?? 0,
+});
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function hasWeight(row: Doc<"exercisePerformance">): boolean {
+  return row.avgWeightLbs != null && row.avgWeightLbs > 0;
+}
+
+async function findProjection(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+  movementId: string,
+): Promise<Doc<"personalRecords"> | null> {
+  return ctx.db
+    .query("personalRecords")
+    .withIndex("by_userId_movementId", (q) => q.eq("userId", userId).eq("movementId", movementId))
+    .unique();
+}
+
+/**
+ * Prefer the user-local date from `completedWorkouts` over the UTC date stored
+ * on `exercisePerformance`. Falls back to the UTC date if the workout row
+ * hasn't been written yet (sync order isn't guaranteed).
+ */
+async function resolveAchievedDate(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+  row: Doc<"exercisePerformance">,
+): Promise<string> {
+  const workout = await ctx.db
+    .query("completedWorkouts")
+    .withIndex("by_userId_activityId", (q) =>
+      q.eq("userId", userId).eq("activityId", row.activityId),
+    )
+    .first();
+  return workout?.date ?? row.date;
+}
+
+/**
+ * Exported for the backfill. Normal writes should go through the `afterInsert`
+ * / `afterPatch` / `afterDelete` helpers instead — they call this.
+ */
+export async function recomputeProjection(
+  ctx: MutationCtx,
+  userId: Id<"users">,
+  movementId: string,
+): Promise<void> {
+  const namespace: PerfNamespace = [userId, movementId];
+  const existing = await findProjection(ctx, userId, movementId);
+  const count = await perfByMovement.count(ctx, { namespace });
+
+  if (count === 0) {
+    if (existing) await ctx.db.delete(existing._id);
+    return;
+  }
+
+  // Two-step max lookup: `at(-1)` gives the largest avgWeightLbs, then
+  // `at(0, { bounds: [key,key] })` gives the *earliest-inserted* row at that
+  // weight. Earliest wins under ties so the PR badge stays on the session
+  // that first achieved the weight, not every subsequent session that
+  // matches it.
+  const maxItem = await perfByMovement.at(ctx, -1, { namespace }).catch((): null => null);
+  if (!maxItem) {
+    if (existing) await ctx.db.delete(existing._id);
+    return;
+  }
+  const winnerItem = await perfByMovement.at(ctx, 0, {
+    namespace,
+    bounds: {
+      lower: { key: maxItem.key, inclusive: true },
+      upper: { key: maxItem.key, inclusive: true },
+    },
+  });
+  const row = await ctx.db.get(winnerItem.id);
+  if (!row || !hasWeight(row)) {
+    if (existing) await ctx.db.delete(existing._id);
+    return;
+  }
+
+  const next = {
+    userId,
+    movementId,
+    bestAvgWeightLbs: row.avgWeightLbs!,
+    achievedActivityId: row.activityId,
+    achievedDate: await resolveAchievedDate(ctx, userId, row),
+    totalSessions: count,
+    updatedAt: Date.now(),
+  };
+
+  if (existing) {
+    await ctx.db.replace(existing._id, next);
+  } else {
+    await ctx.db.insert("personalRecords", next);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Write hooks (call these from every exercisePerformance mutation)
+// ---------------------------------------------------------------------------
+
+/** Call after `ctx.db.insert("exercisePerformance", ...)` completes. */
+export async function afterInsert(
+  ctx: MutationCtx,
+  row: Doc<"exercisePerformance">,
+): Promise<void> {
+  if (hasWeight(row)) {
+    await perfByMovement.insertIfDoesNotExist(ctx, row);
+    await recomputeProjection(ctx, row.userId, row.movementId);
+  }
+}
+
+/** Call with the pre-patch and post-patch docs around `ctx.db.patch(...)`. */
+export async function afterPatch(
+  ctx: MutationCtx,
+  before: Doc<"exercisePerformance">,
+  after: Doc<"exercisePerformance">,
+): Promise<void> {
+  const beforeHasWeight = hasWeight(before);
+  const afterHasWeight = hasWeight(after);
+
+  if (beforeHasWeight && afterHasWeight) {
+    await perfByMovement.replace(ctx, before, after);
+  } else if (beforeHasWeight) {
+    await perfByMovement.deleteIfExists(ctx, before);
+  } else if (afterHasWeight) {
+    await perfByMovement.insertIfDoesNotExist(ctx, after);
+  } else {
+    return;
+  }
+
+  await recomputeProjection(ctx, after.userId, after.movementId);
+}
+
+/** Call with the pre-delete doc before `ctx.db.delete(...)` runs. */
+export async function afterDelete(
+  ctx: MutationCtx,
+  row: Doc<"exercisePerformance">,
+): Promise<void> {
+  if (hasWeight(row)) {
+    await perfByMovement.deleteIfExists(ctx, row);
+  }
+  await recomputeProjection(ctx, row.userId, row.movementId);
+}
+
+/** Clear all projections + aggregate entries for a user (account deletion). */
+export async function clearForUser(
+  ctx: MutationCtx,
+  userId: Id<"users">,
+  batchSize: number,
+): Promise<boolean> {
+  const records = await ctx.db
+    .query("personalRecords")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .take(batchSize);
+  for (const record of records) {
+    await perfByMovement.clear(ctx, { namespace: [userId, record.movementId] });
+    await ctx.db.delete(record._id);
+  }
+  return records.length === batchSize;
+}

--- a/convex/prs.test.ts
+++ b/convex/prs.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateAllTimePRs,
+  buildHistoryFromRows,
+  buildRecentPRSummary,
+  type PerfRow,
+} from "./prs";
+
+// ---------------------------------------------------------------------------
+// Test data builders
+// ---------------------------------------------------------------------------
+
+let rowCounter = 0;
+
+function row(
+  movementId: string,
+  date: string,
+  sets: number,
+  totalReps: number,
+  avgWeightLbs?: number,
+): PerfRow {
+  return { activityId: `act-${++rowCounter}`, movementId, date, sets, totalReps, avgWeightLbs };
+}
+
+const meta = new Map([
+  ["bench", { name: "Bench Press", muscleGroups: ["Chest", "Triceps"] }],
+  ["squat", { name: "Squat", muscleGroups: ["Quads", "Glutes"] }],
+  ["curl", { name: "Bicep Curl", muscleGroups: ["Biceps"] }],
+]);
+
+const names = new Map([
+  ["bench", "Bench Press"],
+  ["squat", "Squat"],
+  ["curl", "Bicep Curl"],
+]);
+
+// ---------------------------------------------------------------------------
+// aggregateAllTimePRs
+// ---------------------------------------------------------------------------
+
+describe("aggregateAllTimePRs", () => {
+  it("returns empty array for no rows", () => {
+    expect(aggregateAllTimePRs([], meta)).toEqual([]);
+  });
+
+  it("finds the best weight per movement", () => {
+    const rows = [
+      row("bench", "2025-03-14", 3, 30, 100),
+      row("bench", "2025-03-10", 3, 30, 90),
+      row("bench", "2025-03-07", 3, 30, 95),
+      row("squat", "2025-03-14", 4, 40, 150),
+      row("squat", "2025-03-10", 4, 40, 140),
+    ];
+
+    const result = aggregateAllTimePRs(rows, meta);
+
+    expect(result).toHaveLength(2);
+    // Sorted by best weight desc — squat first
+    expect(result[0]).toEqual({
+      movementId: "squat",
+      movementName: "Squat",
+      bestWeightLbs: 150,
+      achievedDate: "2025-03-14",
+      muscleGroups: ["Quads", "Glutes"],
+      totalSessions: 2,
+    });
+    expect(result[1]).toEqual({
+      movementId: "bench",
+      movementName: "Bench Press",
+      bestWeightLbs: 100,
+      achievedDate: "2025-03-14",
+      muscleGroups: ["Chest", "Triceps"],
+      totalSessions: 3,
+    });
+  });
+
+  it("skips rows with no weight or zero weight", () => {
+    const rows = [
+      row("bench", "2025-03-14", 3, 30, 100),
+      row("bench", "2025-03-10", 3, 30, undefined),
+      row("squat", "2025-03-14", 4, 40, 0),
+    ];
+
+    const result = aggregateAllTimePRs(rows, meta);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].movementId).toBe("bench");
+    expect(result[0].totalSessions).toBe(1);
+  });
+
+  it("uses 'Unknown' for movements not in the meta map", () => {
+    const rows = [row("unknown-id", "2025-03-14", 3, 30, 50)];
+
+    const result = aggregateAllTimePRs(rows, meta);
+
+    expect(result[0].movementName).toBe("Unknown");
+    expect(result[0].muscleGroups).toEqual([]);
+  });
+
+  it("tracks the date of the best weight, not the latest date", () => {
+    const rows = [
+      row("bench", "2025-03-14", 3, 30, 80), // latest, lower weight
+      row("bench", "2025-03-07", 3, 30, 100), // older, best weight
+    ];
+
+    const result = aggregateAllTimePRs(rows, meta);
+
+    expect(result[0].bestWeightLbs).toBe(100);
+    expect(result[0].achievedDate).toBe("2025-03-07");
+  });
+
+  it("rounds fractional weights", () => {
+    const rows = [row("bench", "2025-03-14", 3, 30, 97.7)];
+
+    const result = aggregateAllTimePRs(rows, meta);
+
+    expect(result[0].bestWeightLbs).toBe(98);
+  });
+
+  it("uses workoutDateMap date when available", () => {
+    const rows = [
+      row("bench", "2025-03-08", 3, 30, 100), // UTC date is 03-08
+    ];
+    // completedWorkouts has the local date as 03-07
+    const workoutDateMap = new Map([[rows[0].activityId, "2025-03-07"]]);
+
+    const result = aggregateAllTimePRs(rows, meta, workoutDateMap);
+
+    expect(result[0].achievedDate).toBe("2025-03-07");
+  });
+
+  it("falls back to exercisePerformance date when workoutDateMap has no entry", () => {
+    const rows = [row("bench", "2025-03-08", 3, 30, 100)];
+    const workoutDateMap = new Map<string, string>(); // empty
+
+    const result = aggregateAllTimePRs(rows, meta, workoutDateMap);
+
+    expect(result[0].achievedDate).toBe("2025-03-08");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHistoryFromRows
+// ---------------------------------------------------------------------------
+
+describe("buildHistoryFromRows", () => {
+  it("returns empty array for no rows", () => {
+    expect(buildHistoryFromRows([])).toEqual([]);
+  });
+
+  it("groups rows by movementId", () => {
+    const rows = [
+      row("bench", "2025-03-14", 3, 30, 100),
+      row("squat", "2025-03-14", 4, 40, 150),
+      row("bench", "2025-03-10", 3, 30, 90),
+    ];
+
+    const result = buildHistoryFromRows(rows);
+
+    expect(result).toHaveLength(2);
+
+    const bench = result.find((e) => e.movementId === "bench");
+    expect(bench?.sessions).toHaveLength(2);
+    expect(bench?.sessions[0].sessionDate).toBe("2025-03-14");
+    expect(bench?.sessions[1].sessionDate).toBe("2025-03-10");
+  });
+
+  it("computes repsPerSet correctly", () => {
+    const rows = [row("bench", "2025-03-14", 3, 27, 100)];
+
+    const result = buildHistoryFromRows(rows);
+
+    expect(result[0].sessions[0].repsPerSet).toBe(9);
+  });
+
+  it("handles zero sets gracefully", () => {
+    const rows = [row("bench", "2025-03-14", 0, 0, 100)];
+
+    const result = buildHistoryFromRows(rows);
+
+    expect(result[0].sessions[0].repsPerSet).toBe(0);
+  });
+
+  it("converts null avgWeightLbs to undefined", () => {
+    const rows = [row("bench", "2025-03-14", 3, 30, undefined)];
+
+    const result = buildHistoryFromRows(rows);
+
+    expect(result[0].sessions[0].avgWeightLbs).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentPRSummary
+// ---------------------------------------------------------------------------
+
+describe("buildRecentPRSummary", () => {
+  it("returns zero counts for empty history", () => {
+    const result = buildRecentPRSummary([], names);
+
+    expect(result.recentPRs).toEqual([]);
+    expect(result.plateauCount).toBe(0);
+    expect(result.regressionCount).toBe(0);
+    expect(result.steadyCount).toBe(0);
+    expect(result.totalMovementsTracked).toBe(0);
+  });
+
+  it("detects a PR when latest session beats previous best", () => {
+    const history = buildHistoryFromRows([
+      row("bench", "2025-03-14", 3, 30, 100),
+      row("bench", "2025-03-10", 3, 30, 90),
+      row("bench", "2025-03-07", 3, 30, 85),
+    ]);
+
+    const result = buildRecentPRSummary(history, names);
+
+    expect(result.recentPRs).toHaveLength(1);
+    expect(result.recentPRs[0].movementName).toBe("Bench Press");
+    expect(result.recentPRs[0].newWeightLbs).toBe(100);
+    expect(result.recentPRs[0].previousBestLbs).toBe(90);
+  });
+
+  it("does not detect a PR when latest is not the best", () => {
+    const history = buildHistoryFromRows([
+      row("bench", "2025-03-14", 3, 30, 80),
+      row("bench", "2025-03-10", 3, 30, 90),
+      row("bench", "2025-03-07", 3, 30, 85),
+    ]);
+
+    const result = buildRecentPRSummary(history, names);
+
+    expect(result.recentPRs).toHaveLength(0);
+  });
+
+  it("detects plateau when recent sessions are within 2 lbs", () => {
+    const history = buildHistoryFromRows([
+      row("bench", "2025-03-14", 3, 30, 100),
+      row("bench", "2025-03-10", 3, 30, 99),
+      row("bench", "2025-03-07", 3, 30, 100),
+    ]);
+
+    const result = buildRecentPRSummary(history, names);
+
+    expect(result.plateauCount).toBe(1);
+  });
+
+  it("counts total movements tracked", () => {
+    const history = buildHistoryFromRows([
+      row("bench", "2025-03-14", 3, 30, 100),
+      row("squat", "2025-03-14", 4, 40, 150),
+      row("curl", "2025-03-14", 3, 30, 30),
+    ]);
+
+    const result = buildRecentPRSummary(history, names);
+
+    expect(result.totalMovementsTracked).toBe(3);
+  });
+
+  it("detects multiple PRs across different movements", () => {
+    const history = buildHistoryFromRows([
+      // bench: PR
+      row("bench", "2025-03-14", 3, 30, 100),
+      row("bench", "2025-03-10", 3, 30, 90),
+      // squat: PR
+      row("squat", "2025-03-14", 4, 40, 160),
+      row("squat", "2025-03-10", 4, 40, 150),
+    ]);
+
+    const result = buildRecentPRSummary(history, names);
+
+    expect(result.recentPRs).toHaveLength(2);
+    const prNames = result.recentPRs.map((p) => p.movementName).sort();
+    expect(prNames).toEqual(["Bench Press", "Squat"]);
+  });
+});

--- a/convex/prs.test.ts
+++ b/convex/prs.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  aggregateAllTimePRs,
-  buildHistoryFromRows,
-  buildRecentPRSummary,
-  type PerfRow,
-} from "./prs";
+import { buildHistoryFromRows, buildRecentPRSummary, isoDateDaysAgo, type PerfRow } from "./prs";
 
 // ---------------------------------------------------------------------------
 // Test data builders
@@ -22,12 +17,6 @@ function row(
   return { activityId: `act-${++rowCounter}`, movementId, date, sets, totalReps, avgWeightLbs };
 }
 
-const meta = new Map([
-  ["bench", { name: "Bench Press", muscleGroups: ["Chest", "Triceps"] }],
-  ["squat", { name: "Squat", muscleGroups: ["Quads", "Glutes"] }],
-  ["curl", { name: "Bicep Curl", muscleGroups: ["Biceps"] }],
-]);
-
 const names = new Map([
   ["bench", "Bench Press"],
   ["squat", "Squat"],
@@ -35,107 +24,18 @@ const names = new Map([
 ]);
 
 // ---------------------------------------------------------------------------
-// aggregateAllTimePRs
+// isoDateDaysAgo
 // ---------------------------------------------------------------------------
 
-describe("aggregateAllTimePRs", () => {
-  it("returns empty array for no rows", () => {
-    expect(aggregateAllTimePRs([], meta)).toEqual([]);
+describe("isoDateDaysAgo", () => {
+  it("returns YYYY-MM-DD N days before the given date", () => {
+    expect(isoDateDaysAgo(new Date("2026-04-15T12:00:00Z"), 0)).toBe("2026-04-15");
+    expect(isoDateDaysAgo(new Date("2026-04-15T12:00:00Z"), 7)).toBe("2026-04-08");
+    expect(isoDateDaysAgo(new Date("2026-04-15T12:00:00Z"), 120)).toBe("2025-12-16");
   });
 
-  it("finds the best weight per movement", () => {
-    const rows = [
-      row("bench", "2025-03-14", 3, 30, 100),
-      row("bench", "2025-03-10", 3, 30, 90),
-      row("bench", "2025-03-07", 3, 30, 95),
-      row("squat", "2025-03-14", 4, 40, 150),
-      row("squat", "2025-03-10", 4, 40, 140),
-    ];
-
-    const result = aggregateAllTimePRs(rows, meta);
-
-    expect(result).toHaveLength(2);
-    // Sorted by best weight desc — squat first
-    expect(result[0]).toEqual({
-      movementId: "squat",
-      movementName: "Squat",
-      bestWeightLbs: 150,
-      achievedDate: "2025-03-14",
-      muscleGroups: ["Quads", "Glutes"],
-      totalSessions: 2,
-    });
-    expect(result[1]).toEqual({
-      movementId: "bench",
-      movementName: "Bench Press",
-      bestWeightLbs: 100,
-      achievedDate: "2025-03-14",
-      muscleGroups: ["Chest", "Triceps"],
-      totalSessions: 3,
-    });
-  });
-
-  it("skips rows with no weight or zero weight", () => {
-    const rows = [
-      row("bench", "2025-03-14", 3, 30, 100),
-      row("bench", "2025-03-10", 3, 30, undefined),
-      row("squat", "2025-03-14", 4, 40, 0),
-    ];
-
-    const result = aggregateAllTimePRs(rows, meta);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].movementId).toBe("bench");
-    expect(result[0].totalSessions).toBe(1);
-  });
-
-  it("uses 'Unknown' for movements not in the meta map", () => {
-    const rows = [row("unknown-id", "2025-03-14", 3, 30, 50)];
-
-    const result = aggregateAllTimePRs(rows, meta);
-
-    expect(result[0].movementName).toBe("Unknown");
-    expect(result[0].muscleGroups).toEqual([]);
-  });
-
-  it("tracks the date of the best weight, not the latest date", () => {
-    const rows = [
-      row("bench", "2025-03-14", 3, 30, 80), // latest, lower weight
-      row("bench", "2025-03-07", 3, 30, 100), // older, best weight
-    ];
-
-    const result = aggregateAllTimePRs(rows, meta);
-
-    expect(result[0].bestWeightLbs).toBe(100);
-    expect(result[0].achievedDate).toBe("2025-03-07");
-  });
-
-  it("rounds fractional weights", () => {
-    const rows = [row("bench", "2025-03-14", 3, 30, 97.7)];
-
-    const result = aggregateAllTimePRs(rows, meta);
-
-    expect(result[0].bestWeightLbs).toBe(98);
-  });
-
-  it("uses workoutDateMap date when available", () => {
-    const rows = [
-      row("bench", "2025-03-08", 3, 30, 100), // UTC date is 03-08
-    ];
-    // completedWorkouts has the local date as 03-07
-    const workoutDateMap = new Map([[rows[0].activityId, "2025-03-07"]]);
-
-    const result = aggregateAllTimePRs(rows, meta, workoutDateMap);
-
-    expect(result[0].achievedDate).toBe("2025-03-07");
-  });
-
-  it("falls back to exercisePerformance date when workoutDateMap has no entry", () => {
-    const rows = [row("bench", "2025-03-08", 3, 30, 100)];
-    const workoutDateMap = new Map<string, string>(); // empty
-
-    const result = aggregateAllTimePRs(rows, meta, workoutDateMap);
-
-    expect(result[0].achievedDate).toBe("2025-03-08");
+  it("handles year boundaries", () => {
+    expect(isoDateDaysAgo(new Date("2026-01-05T12:00:00Z"), 10)).toBe("2025-12-26");
   });
 });
 

--- a/convex/prs.ts
+++ b/convex/prs.ts
@@ -1,0 +1,213 @@
+import { query } from "./_generated/server";
+import { getEffectiveUserId } from "./lib/auth";
+import { generatePerformanceSummary } from "./coach/prDetection";
+import type { PerMovementHistoryEntry } from "./progressiveOverload";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AllTimePREntry {
+  movementId: string;
+  movementName: string;
+  bestWeightLbs: number;
+  achievedDate: string;
+  muscleGroups: string[];
+  totalSessions: number;
+}
+
+export interface RecentPRSummary {
+  recentPRs: Array<{
+    movementId: string;
+    movementName: string;
+    newWeightLbs: number;
+    previousBestLbs: number;
+    improvementPct: number;
+  }>;
+  plateauCount: number;
+  regressionCount: number;
+  steadyCount: number;
+  totalMovementsTracked: number;
+}
+
+/** Max exercisePerformance rows to scan per user (bounds query cost). */
+const MAX_PERFORMANCE_ROWS = 5000;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+/** Minimal shape needed from an exercisePerformance row. */
+export interface PerfRow {
+  activityId: string;
+  movementId: string;
+  date: string;
+  sets: number;
+  totalReps: number;
+  avgWeightLbs?: number;
+}
+
+interface MovementMeta {
+  name: string;
+  muscleGroups: string[];
+}
+
+/** Group performance rows into all-time bests per movement. */
+export function aggregateAllTimePRs(
+  rows: readonly PerfRow[],
+  metaMap: ReadonlyMap<string, MovementMeta>,
+  /** Map activityId → date from completedWorkouts (corrected local date). */
+  workoutDateMap?: ReadonlyMap<string, string>,
+): AllTimePREntry[] {
+  const byMovement = new Map<
+    string,
+    { bestWeight: number; bestDate: string; bestActivityId: string; sessions: number }
+  >();
+
+  for (const row of rows) {
+    const weight = row.avgWeightLbs;
+    if (weight == null || weight <= 0) continue;
+
+    const existing = byMovement.get(row.movementId);
+    if (existing) {
+      existing.sessions += 1;
+      if (weight > existing.bestWeight) {
+        existing.bestWeight = weight;
+        existing.bestDate = row.date;
+        existing.bestActivityId = row.activityId;
+      }
+    } else {
+      byMovement.set(row.movementId, {
+        bestWeight: weight,
+        bestDate: row.date,
+        bestActivityId: row.activityId,
+        sessions: 1,
+      });
+    }
+  }
+
+  const entries: AllTimePREntry[] = [];
+  for (const [movementId, data] of byMovement) {
+    const meta = metaMap.get(movementId);
+    // Prefer the completedWorkouts date (local time) over exercisePerformance date (UTC)
+    const date = workoutDateMap?.get(data.bestActivityId) ?? data.bestDate;
+    entries.push({
+      movementId,
+      movementName: meta?.name ?? "Unknown",
+      bestWeightLbs: Math.round(data.bestWeight),
+      achievedDate: date,
+      muscleGroups: meta?.muscleGroups ?? [],
+      totalSessions: data.sessions,
+    });
+  }
+
+  entries.sort((a, b) => b.bestWeightLbs - a.bestWeightLbs);
+  return entries;
+}
+
+/** Group performance rows into PerMovementHistoryEntry[] for prDetection. */
+export function buildHistoryFromRows(rows: readonly PerfRow[]): PerMovementHistoryEntry[] {
+  const sessionMap = new Map<
+    string,
+    Array<{
+      sessionDate: string;
+      sets: number;
+      totalReps: number;
+      repsPerSet: number;
+      avgWeightLbs?: number;
+    }>
+  >();
+
+  for (const row of rows) {
+    const snapshot = {
+      sessionDate: row.date,
+      sets: row.sets,
+      totalReps: row.totalReps,
+      repsPerSet: row.sets > 0 ? Math.round(row.totalReps / row.sets) : 0,
+      avgWeightLbs: row.avgWeightLbs ?? undefined,
+    };
+    const sessions = sessionMap.get(row.movementId);
+    if (sessions) {
+      sessions.push(snapshot);
+    } else {
+      sessionMap.set(row.movementId, [snapshot]);
+    }
+  }
+
+  return Array.from(sessionMap, ([movementId, sessions]) => ({
+    movementId,
+    sessions,
+  }));
+}
+
+/** Build RecentPRSummary from history + name map. */
+export function buildRecentPRSummary(
+  history: PerMovementHistoryEntry[],
+  nameMap: ReadonlyMap<string, string>,
+): RecentPRSummary {
+  const summary = generatePerformanceSummary(history, nameMap);
+  return {
+    recentPRs: summary.prs,
+    plateauCount: summary.plateaus.length,
+    regressionCount: summary.regressions.length,
+    steadyCount: summary.steadyProgressionCount,
+    totalMovementsTracked: history.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getAllTimePRs — best avgWeightLbs per movement, all time
+// ---------------------------------------------------------------------------
+
+export const getAllTimePRs = query({
+  args: {},
+  handler: async (ctx): Promise<AllTimePREntry[]> => {
+    const userId = await getEffectiveUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const rows = await ctx.db
+      .query("exercisePerformance")
+      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+      .order("desc")
+      .take(MAX_PERFORMANCE_ROWS);
+
+    // Build date map from completedWorkouts (local dates, not UTC)
+    const workouts = await ctx.db
+      .query("completedWorkouts")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .take(MAX_PERFORMANCE_ROWS);
+    const workoutDateMap = new Map(workouts.map((w) => [w.activityId, w.date]));
+
+    const movementDocs = await ctx.db.query("movements").take(5000);
+    const metaMap = new Map(
+      movementDocs.map((m) => [m.tonalId, { name: m.name, muscleGroups: m.muscleGroups }]),
+    );
+
+    return aggregateAllTimePRs(rows, metaMap, workoutDateMap);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getRecentPRSummary — recent PRs, plateaus, regressions via prDetection
+// ---------------------------------------------------------------------------
+
+export const getRecentPRSummary = query({
+  args: {},
+  handler: async (ctx): Promise<RecentPRSummary> => {
+    const userId = await getEffectiveUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const rows = await ctx.db
+      .query("exercisePerformance")
+      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+      .order("desc")
+      .take(MAX_PERFORMANCE_ROWS);
+
+    const history = buildHistoryFromRows(rows);
+
+    const movementDocs = await ctx.db.query("movements").take(5000);
+    const nameMap = new Map(movementDocs.map((m) => [m.tonalId, m.name]));
+
+    return buildRecentPRSummary(history, nameMap);
+  },
+});

--- a/convex/prs.ts
+++ b/convex/prs.ts
@@ -1,3 +1,4 @@
+import type { PaginationResult } from "convex/server";
 import { query } from "./_generated/server";
 import { getEffectiveUserId } from "./lib/auth";
 import { generatePerformanceSummary } from "./coach/prDetection";
@@ -30,8 +31,27 @@ export interface RecentPRSummary {
   totalMovementsTracked: number;
 }
 
-/** Max exercisePerformance rows to scan per user (bounds query cost). */
-const MAX_PERFORMANCE_ROWS = 5000;
+/** Max exercisePerformance rows to scan for the recent-PR summary (recent data is enough). */
+const MAX_RECENT_PERFORMANCE_ROWS = 5000;
+
+/** Page size for full scans that accumulate every row. */
+const PAGE_SIZE = 1000;
+
+interface Paginable<T> {
+  paginate: (opts: { numItems: number; cursor: string | null }) => Promise<PaginationResult<T>>;
+}
+
+async function collectAllPages<T>(buildQuery: () => Paginable<T>): Promise<T[]> {
+  const all: T[] = [];
+  let cursor: string | null = null;
+  while (true) {
+    const result = await buildQuery().paginate({ numItems: PAGE_SIZE, cursor });
+    all.push(...result.page);
+    cursor = result.continueCursor;
+    if (result.isDone) break;
+  }
+  return all;
+}
 
 // ---------------------------------------------------------------------------
 // Pure helpers (exported for testing)
@@ -165,20 +185,21 @@ export const getAllTimePRs = query({
     const userId = await getEffectiveUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
-    const rows = await ctx.db
-      .query("exercisePerformance")
-      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
-      .order("desc")
-      .take(MAX_PERFORMANCE_ROWS);
+    const [rows, workouts, movementDocs] = await Promise.all([
+      collectAllPages(() =>
+        ctx.db
+          .query("exercisePerformance")
+          .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+          .order("desc"),
+      ),
+      // Used for local-date mapping (exercisePerformance stores UTC dates).
+      collectAllPages(() =>
+        ctx.db.query("completedWorkouts").withIndex("by_userId", (q) => q.eq("userId", userId)),
+      ),
+      collectAllPages(() => ctx.db.query("movements")),
+    ]);
 
-    // Build date map from completedWorkouts (local dates, not UTC)
-    const workouts = await ctx.db
-      .query("completedWorkouts")
-      .withIndex("by_userId", (q) => q.eq("userId", userId))
-      .take(MAX_PERFORMANCE_ROWS);
     const workoutDateMap = new Map(workouts.map((w) => [w.activityId, w.date]));
-
-    const movementDocs = await ctx.db.query("movements").take(5000);
     const metaMap = new Map(
       movementDocs.map((m) => [m.tonalId, { name: m.name, muscleGroups: m.muscleGroups }]),
     );
@@ -197,15 +218,16 @@ export const getRecentPRSummary = query({
     const userId = await getEffectiveUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
-    const rows = await ctx.db
-      .query("exercisePerformance")
-      .withIndex("by_userId_date", (q) => q.eq("userId", userId))
-      .order("desc")
-      .take(MAX_PERFORMANCE_ROWS);
+    const [rows, movementDocs] = await Promise.all([
+      ctx.db
+        .query("exercisePerformance")
+        .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+        .order("desc")
+        .take(MAX_RECENT_PERFORMANCE_ROWS),
+      collectAllPages(() => ctx.db.query("movements")),
+    ]);
 
     const history = buildHistoryFromRows(rows);
-
-    const movementDocs = await ctx.db.query("movements").take(5000);
     const nameMap = new Map(movementDocs.map((m) => [m.tonalId, m.name]));
 
     return buildRecentPRSummary(history, nameMap);

--- a/convex/prs.ts
+++ b/convex/prs.ts
@@ -1,4 +1,3 @@
-import type { PaginationResult } from "convex/server";
 import { query } from "./_generated/server";
 import { getEffectiveUserId } from "./lib/auth";
 import { generatePerformanceSummary } from "./coach/prDetection";
@@ -31,27 +30,12 @@ export interface RecentPRSummary {
   totalMovementsTracked: number;
 }
 
-/** Max exercisePerformance rows to scan for the recent-PR summary (recent data is enough). */
-const MAX_RECENT_PERFORMANCE_ROWS = 5000;
-
-/** Page size for full scans that accumulate every row. */
-const PAGE_SIZE = 1000;
-
-interface Paginable<T> {
-  paginate: (opts: { numItems: number; cursor: string | null }) => Promise<PaginationResult<T>>;
-}
-
-async function collectAllPages<T>(buildQuery: () => Paginable<T>): Promise<T[]> {
-  const all: T[] = [];
-  let cursor: string | null = null;
-  while (true) {
-    const result = await buildQuery().paginate({ numItems: PAGE_SIZE, cursor });
-    all.push(...result.page);
-    cursor = result.continueCursor;
-    if (result.isDone) break;
-  }
-  return all;
-}
+/**
+ * Days of recent exercisePerformance history fed into the recent-trend
+ * analyzer. Covers ~4 months of training, which is longer than every window
+ * `generatePerformanceSummary` currently looks at.
+ */
+const RECENT_WINDOW_DAYS = 120;
 
 // ---------------------------------------------------------------------------
 // Pure helpers (exported for testing)
@@ -65,64 +49,6 @@ export interface PerfRow {
   sets: number;
   totalReps: number;
   avgWeightLbs?: number;
-}
-
-interface MovementMeta {
-  name: string;
-  muscleGroups: string[];
-}
-
-/** Group performance rows into all-time bests per movement. */
-export function aggregateAllTimePRs(
-  rows: readonly PerfRow[],
-  metaMap: ReadonlyMap<string, MovementMeta>,
-  /** Map activityId → date from completedWorkouts (corrected local date). */
-  workoutDateMap?: ReadonlyMap<string, string>,
-): AllTimePREntry[] {
-  const byMovement = new Map<
-    string,
-    { bestWeight: number; bestDate: string; bestActivityId: string; sessions: number }
-  >();
-
-  for (const row of rows) {
-    const weight = row.avgWeightLbs;
-    if (weight == null || weight <= 0) continue;
-
-    const existing = byMovement.get(row.movementId);
-    if (existing) {
-      existing.sessions += 1;
-      if (weight > existing.bestWeight) {
-        existing.bestWeight = weight;
-        existing.bestDate = row.date;
-        existing.bestActivityId = row.activityId;
-      }
-    } else {
-      byMovement.set(row.movementId, {
-        bestWeight: weight,
-        bestDate: row.date,
-        bestActivityId: row.activityId,
-        sessions: 1,
-      });
-    }
-  }
-
-  const entries: AllTimePREntry[] = [];
-  for (const [movementId, data] of byMovement) {
-    const meta = metaMap.get(movementId);
-    // Prefer the completedWorkouts date (local time) over exercisePerformance date (UTC)
-    const date = workoutDateMap?.get(data.bestActivityId) ?? data.bestDate;
-    entries.push({
-      movementId,
-      movementName: meta?.name ?? "Unknown",
-      bestWeightLbs: Math.round(data.bestWeight),
-      achievedDate: date,
-      muscleGroups: meta?.muscleGroups ?? [],
-      totalSessions: data.sessions,
-    });
-  }
-
-  entries.sort((a, b) => b.bestWeightLbs - a.bestWeightLbs);
-  return entries;
 }
 
 /** Group performance rows into PerMovementHistoryEntry[] for prDetection. */
@@ -175,8 +101,14 @@ export function buildRecentPRSummary(
   };
 }
 
+/** YYYY-MM-DD string for `daysAgo` days before `now`, in UTC. */
+export function isoDateDaysAgo(now: Date, daysAgo: number): string {
+  const cutoff = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
+  return cutoff.toISOString().slice(0, 10);
+}
+
 // ---------------------------------------------------------------------------
-// getAllTimePRs — best avgWeightLbs per movement, all time
+// getAllTimePRs — one indexed scan of the personalRecords projection.
 // ---------------------------------------------------------------------------
 
 export const getAllTimePRs = query({
@@ -185,31 +117,34 @@ export const getAllTimePRs = query({
     const userId = await getEffectiveUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
-    const [rows, workouts, movementDocs] = await Promise.all([
-      collectAllPages(() =>
-        ctx.db
-          .query("exercisePerformance")
-          .withIndex("by_userId_date", (q) => q.eq("userId", userId))
-          .order("desc"),
-      ),
-      // Used for local-date mapping (exercisePerformance stores UTC dates).
-      collectAllPages(() =>
-        ctx.db.query("completedWorkouts").withIndex("by_userId", (q) => q.eq("userId", userId)),
-      ),
-      collectAllPages(() => ctx.db.query("movements")),
-    ]);
+    const records = await ctx.db
+      .query("personalRecords")
+      .withIndex("by_userId_best", (q) => q.eq("userId", userId))
+      .order("desc")
+      .collect();
+    if (records.length === 0) return [];
 
-    const workoutDateMap = new Map(workouts.map((w) => [w.activityId, w.date]));
+    const movementDocs = await ctx.db.query("movements").collect();
     const metaMap = new Map(
       movementDocs.map((m) => [m.tonalId, { name: m.name, muscleGroups: m.muscleGroups }]),
     );
 
-    return aggregateAllTimePRs(rows, metaMap, workoutDateMap);
+    return records.map((r) => {
+      const meta = metaMap.get(r.movementId);
+      return {
+        movementId: r.movementId,
+        movementName: meta?.name ?? "Unknown",
+        bestWeightLbs: Math.round(r.bestAvgWeightLbs),
+        achievedDate: r.achievedDate,
+        muscleGroups: meta?.muscleGroups ?? [],
+        totalSessions: r.totalSessions,
+      };
+    });
   },
 });
 
 // ---------------------------------------------------------------------------
-// getRecentPRSummary — recent PRs, plateaus, regressions via prDetection
+// getRecentPRSummary — recent PRs, plateaus, regressions via prDetection.
 // ---------------------------------------------------------------------------
 
 export const getRecentPRSummary = query({
@@ -218,13 +153,15 @@ export const getRecentPRSummary = query({
     const userId = await getEffectiveUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
+    const since = isoDateDaysAgo(new Date(), RECENT_WINDOW_DAYS);
+
     const [rows, movementDocs] = await Promise.all([
       ctx.db
         .query("exercisePerformance")
-        .withIndex("by_userId_date", (q) => q.eq("userId", userId))
+        .withIndex("by_userId_date", (q) => q.eq("userId", userId).gte("date", since))
         .order("desc")
-        .take(MAX_RECENT_PERFORMANCE_ROWS),
-      collectAllPages(() => ctx.db.query("movements")),
+        .collect(),
+      ctx.db.query("movements").collect(),
     ]);
 
     const history = buildHistoryFromRows(rows);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -448,6 +448,24 @@ export default defineSchema({
     .index("by_userId_activityId_movementId", ["userId", "activityId", "movementId"])
     .index("by_userId_date", ["userId", "date"]),
 
+  /**
+   * Materialized all-time best avgWeightLbs per (user, movement).
+   * Maintained by convex/personalRecords.ts hooks in every mutation that
+   * writes to `exercisePerformance`.
+   */
+  personalRecords: defineTable({
+    userId: v.id("users"),
+    movementId: v.string(),
+    bestAvgWeightLbs: v.number(),
+    achievedActivityId: v.string(),
+    achievedDate: v.string(),
+    totalSessions: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_userId_movementId", ["userId", "movementId"])
+    .index("by_userId_best", ["userId", "bestAvgWeightLbs"])
+    .index("by_userId", ["userId"]),
+
   /** Strength score snapshots over time (synced from Tonal history). */
   strengthScoreSnapshots: defineTable({
     userId: v.id("users"),

--- a/convex/tonal/historySyncMutations.ts
+++ b/convex/tonal/historySyncMutations.ts
@@ -9,6 +9,7 @@
 import { v } from "convex/values";
 import { internalMutation, internalQuery } from "../_generated/server";
 import { isDeletionInProgress } from "../lib/auth";
+import { afterInsert as afterPerformanceInsert } from "../personalRecords";
 
 // ---------------------------------------------------------------------------
 // Shared validators (exported for action payload typing)
@@ -105,7 +106,13 @@ export const persistExercisePerformance = internalMutation({
         )
         .first();
       if (existing) continue;
-      await ctx.db.insert("exercisePerformance", { userId, ...p, syncedAt: Date.now() });
+      const id = await ctx.db.insert("exercisePerformance", {
+        userId,
+        ...p,
+        syncedAt: Date.now(),
+      });
+      const inserted = await ctx.db.get(id);
+      if (inserted) await afterPerformanceInsert(ctx, inserted);
     }
   },
 });

--- a/convex/userData.ts
+++ b/convex/userData.ts
@@ -17,6 +17,7 @@ export const USER_DATA_TABLES = [
     delete: "exercisePerformanceBatch",
     jsonExportKey: "exercisePerformance",
   },
+  { table: "personalRecords", delete: "personalRecordsBatch", jsonExportKey: null },
   {
     table: "strengthScoreSnapshots",
     delete: "byUserIdBatch",

--- a/convex/workoutDetail.ts
+++ b/convex/workoutDetail.ts
@@ -62,11 +62,12 @@ export interface EnrichedWorkoutDetail extends Omit<WorkoutActivityDetail, "work
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-/** Return the best avgWeightLbs per movement from exercisePerformance, including the current activity.
- *  We include the current activity so the comparison uses the same stored value for both sides. */
+/** Return the best avgWeightLbs per movement from prior exercisePerformance rows.
+ *  Rows for `currentActivityId` (when provided) are excluded so callers can compare
+ *  the current workout strictly against its history. */
 export const getHistoricalBests = internalQuery({
-  args: { userId: v.id("users") },
-  handler: async (ctx, { userId }) => {
+  args: { userId: v.id("users"), currentActivityId: v.optional(v.string()) },
+  handler: async (ctx, { userId, currentActivityId }) => {
     const PAGE_SIZE = 1000;
     const allRows: Doc<"exercisePerformance">[] = [];
     let cursor: string | null = null;
@@ -88,13 +89,14 @@ export const getHistoricalBests = internalQuery({
     // Warn if results approach the old 5000 limit
     if (allRows.length >= 5000) {
       console.warn(
-        `getHistoricalBests: fetched ${allRows.length} rows for user ${userId}. ` +
+        `getHistoricalBests: fetched ${allRows.length} rows. ` +
           `Consider maintaining a dedicated personal bests table for better performance.`,
       );
     }
 
     const bests = new Map<string, { best: number; count: number }>();
     for (const row of allRows) {
+      if (currentActivityId && row.activityId === currentActivityId) continue;
       if (row.avgWeightLbs == null || row.avgWeightLbs <= 0) continue;
       const existing = bests.get(row.movementId);
       if (existing) {
@@ -169,6 +171,7 @@ export const getWorkoutDetail = action({
       }),
       ctx.runQuery(internal.workoutDetail.getHistoricalBests, {
         userId,
+        currentActivityId: args.activityId,
       }),
       ctx.runQuery(internal.workoutDetail.getWorkoutPerformanceRows, {
         userId,
@@ -202,14 +205,15 @@ export const getWorkoutDetail = action({
     });
 
     // Detect PRs by comparing this workout's stored exercisePerformance values
-    // against all-time bests (same metric, same source — avoids computation mismatches).
+    // against prior bests (which exclude this activity — see getHistoricalBests).
+    // The movement must have at least one prior weighted session, otherwise the
+    // first workout of a movement would always register as a PR.
     const prMovementIds = new Set<string>();
     for (const perf of thisWorkoutPerf) {
       if (perf.avgWeightLbs == null || perf.avgWeightLbs <= 0) continue;
       const hist = historicalBests[perf.movementId];
       if (!hist) continue;
-      // PR if this workout's stored value equals the all-time best and there are 2+ sessions
-      if (perf.avgWeightLbs >= hist.best && hist.count >= 2) {
+      if (perf.avgWeightLbs > hist.best) {
         prMovementIds.add(perf.movementId);
       }
     }

--- a/convex/workoutDetail.ts
+++ b/convex/workoutDetail.ts
@@ -1,6 +1,8 @@
 import { v } from "convex/values";
-import { action } from "./_generated/server";
+import { action, internalQuery } from "./_generated/server";
 import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
+import { normalizeTargetArea } from "./lib/targetArea";
 import type {
   Activity,
   FormattedWorkoutSummary,
@@ -45,14 +47,93 @@ export interface MovementSummary {
   totalSets: number;
   totalReps: number;
   avgWeightLbs: number;
+  /** True when this session's avgWeightLbs is the user's all-time best. */
+  isPR?: boolean;
 }
 
 export interface EnrichedWorkoutDetail extends Omit<WorkoutActivityDetail, "workoutSetActivity"> {
   workoutSetActivity: EnrichedSetActivity[];
   movementSummaries: MovementSummary[];
+  /** Human-readable workout title from activity history (e.g. "Arms Burnout"). */
+  workoutTitle?: string;
+  /** Target area from activity history (e.g. "Upper Body"). */
+  targetArea?: string;
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Return the best avgWeightLbs per movement from exercisePerformance, including the current activity.
+ *  We include the current activity so the comparison uses the same stored value for both sides. */
+export const getHistoricalBests = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    const PAGE_SIZE = 1000;
+    const allRows: Doc<"exercisePerformance">[] = [];
+    let cursor: string | null = null;
+
+    // Paginate through all results to avoid truncation
+    while (true) {
+      const query = ctx.db
+        .query("exercisePerformance")
+        .withIndex("by_userId_date", (q) => q.eq("userId", userId));
+
+      const result = await query.paginate({ numItems: PAGE_SIZE, cursor });
+
+      allRows.push(...result.page);
+      cursor = result.continueCursor;
+
+      if (!cursor || result.page.length < PAGE_SIZE) break;
+    }
+
+    // Warn if results approach the old 5000 limit
+    if (allRows.length >= 5000) {
+      console.warn(
+        `getHistoricalBests: fetched ${allRows.length} rows for user ${userId}. ` +
+          `Consider maintaining a dedicated personal bests table for better performance.`,
+      );
+    }
+
+    const bests = new Map<string, { best: number; count: number }>();
+    for (const row of allRows) {
+      if (row.avgWeightLbs == null || row.avgWeightLbs <= 0) continue;
+      const existing = bests.get(row.movementId);
+      if (existing) {
+        existing.count += 1;
+        if (row.avgWeightLbs > existing.best) {
+          existing.best = row.avgWeightLbs;
+        }
+      } else {
+        bests.set(row.movementId, { best: row.avgWeightLbs, count: 1 });
+      }
+    }
+    return Object.fromEntries([...bests].map(([id, { best, count }]) => [id, { best, count }]));
+  },
+});
+
+/** Get exercisePerformance rows for a specific workout — used for PR comparison. */
+export const getWorkoutPerformanceRows = internalQuery({
+  args: { userId: v.id("users"), activityId: v.string() },
+  handler: async (ctx, { userId, activityId }) => {
+    const rows = await ctx.db
+      .query("exercisePerformance")
+      .withIndex("by_userId_activityId", (q) => q.eq("userId", userId).eq("activityId", activityId))
+      .take(100);
+    return rows.map((r) => ({ movementId: r.movementId, avgWeightLbs: r.avgWeightLbs }));
+  },
+});
+
+/** Look up completed-workout metadata (title, targetArea) for the activity page header. */
+export const getCompletedWorkoutMeta = internalQuery({
+  args: { userId: v.id("users"), activityId: v.string() },
+  handler: async (ctx, { userId, activityId }) => {
+    const row = await ctx.db
+      .query("completedWorkouts")
+      .withIndex("by_userId_activityId", (q) => q.eq("userId", userId).eq("activityId", activityId))
+      .first();
+    if (!row) return null;
+    return { title: row.title, targetArea: row.targetArea, workoutType: row.workoutType };
+  },
+});
 
 export const getWorkoutDetail = action({
   args: { activityId: v.string() },
@@ -63,21 +144,37 @@ export const getWorkoutDetail = action({
     const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 
-    const [detail, movements, formattedSummary]: [unknown, Movement[], unknown] = await Promise.all(
-      [
-        ctx.runAction(internal.tonal.proxy.fetchWorkoutDetail, {
+    const [detail, movements, formattedSummary, workoutMeta, historicalBests, thisWorkoutPerf]: [
+      unknown,
+      Movement[],
+      unknown,
+      { title: string; targetArea: string; workoutType: string } | null,
+      Record<string, { best: number; count: number }>,
+      Array<{ movementId: string; avgWeightLbs?: number }>,
+    ] = await Promise.all([
+      ctx.runAction(internal.tonal.proxy.fetchWorkoutDetail, {
+        userId,
+        activityId: args.activityId,
+      }),
+      ctx.runQuery(internal.tonal.movementSync.getAllMovements),
+      ctx
+        .runAction(internal.tonal.proxy.fetchFormattedSummary, {
           userId,
-          activityId: args.activityId,
-        }),
-        ctx.runQuery(internal.tonal.movementSync.getAllMovements),
-        ctx
-          .runAction(internal.tonal.proxy.fetchFormattedSummary, {
-            userId,
-            summaryId: args.activityId,
-          })
-          .catch((): null => null),
-      ],
-    );
+          summaryId: args.activityId,
+        })
+        .catch((): null => null),
+      ctx.runQuery(internal.workoutDetail.getCompletedWorkoutMeta, {
+        userId,
+        activityId: args.activityId,
+      }),
+      ctx.runQuery(internal.workoutDetail.getHistoricalBests, {
+        userId,
+      }),
+      ctx.runQuery(internal.workoutDetail.getWorkoutPerformanceRows, {
+        userId,
+        activityId: args.activityId,
+      }),
+    ]);
     if (!detail) throw new Error("Workout not found");
     const movementMap = new Map(movements.map((m) => [m.id, m]));
 
@@ -104,13 +201,28 @@ export const getWorkoutDetail = action({
       };
     });
 
+    // Detect PRs by comparing this workout's stored exercisePerformance values
+    // against all-time bests (same metric, same source — avoids computation mismatches).
+    const prMovementIds = new Set<string>();
+    for (const perf of thisWorkoutPerf) {
+      if (perf.avgWeightLbs == null || perf.avgWeightLbs <= 0) continue;
+      const hist = historicalBests[perf.movementId];
+      if (!hist) continue;
+      // PR if this workout's stored value equals the all-time best and there are 2+ sessions
+      if (perf.avgWeightLbs >= hist.best && hist.count >= 2) {
+        prMovementIds.add(perf.movementId);
+      }
+    }
+
     // Build movement summaries grouped by movementId
-    const movementSummaries = buildMovementSummaries(enrichedSets, volumeMap);
+    const movementSummaries = buildMovementSummaries(enrichedSets, volumeMap, prMovementIds);
 
     return {
       ...typedDetail,
       workoutSetActivity: enrichedSets,
       movementSummaries,
+      workoutTitle: workoutMeta?.title ?? undefined,
+      targetArea: workoutMeta ? normalizeTargetArea(workoutMeta.targetArea) : undefined,
     };
   },
 });
@@ -119,6 +231,7 @@ export const getWorkoutDetail = action({
 export function buildMovementSummaries(
   sets: readonly EnrichedSetActivity[],
   volumeMap: ReadonlyMap<string, number>,
+  prMovementIds?: ReadonlySet<string>,
 ): MovementSummary[] {
   const grouped = new Map<
     string,
@@ -157,6 +270,8 @@ export function buildMovementSummaries(
 
   return Array.from(grouped.entries()).map(([movementId, data]) => {
     const totalVolume = volumeMap.get(movementId) ?? 0;
+    const avgWeightLbs =
+      data.weightedReps > 0 ? Math.round(data.weightedWeightSum / data.weightedReps) : 0;
     return {
       movementId,
       movementName: data.name,
@@ -164,8 +279,8 @@ export function buildMovementSummaries(
       totalVolume,
       totalSets: data.totalSets,
       totalReps: data.totalReps,
-      avgWeightLbs:
-        data.weightedReps > 0 ? Math.round(data.weightedWeightSum / data.weightedReps) : 0,
+      avgWeightLbs,
+      isPR: prMovementIds?.has(movementId) || undefined,
     };
   });
 }

--- a/convex/workoutDetail.ts
+++ b/convex/workoutDetail.ts
@@ -1,7 +1,6 @@
 import { v } from "convex/values";
 import { action, internalQuery } from "./_generated/server";
 import { internal } from "./_generated/api";
-import type { Doc } from "./_generated/dataModel";
 import { normalizeTargetArea } from "./lib/targetArea";
 import type {
   Activity,
@@ -62,65 +61,26 @@ export interface EnrichedWorkoutDetail extends Omit<WorkoutActivityDetail, "work
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-/** Return the best avgWeightLbs per movement from prior exercisePerformance rows.
- *  Rows for `currentActivityId` (when provided) are excluded so callers can compare
- *  the current workout strictly against its history. */
-export const getHistoricalBests = internalQuery({
-  args: { userId: v.id("users"), currentActivityId: v.optional(v.string()) },
-  handler: async (ctx, { userId, currentActivityId }) => {
-    const PAGE_SIZE = 1000;
-    const allRows: Doc<"exercisePerformance">[] = [];
-    let cursor: string | null = null;
-
-    // Paginate through all results to avoid truncation
-    while (true) {
-      const query = ctx.db
-        .query("exercisePerformance")
-        .withIndex("by_userId_date", (q) => q.eq("userId", userId));
-
-      const result = await query.paginate({ numItems: PAGE_SIZE, cursor });
-
-      allRows.push(...result.page);
-      cursor = result.continueCursor;
-
-      if (!cursor || result.page.length < PAGE_SIZE) break;
-    }
-
-    // Warn if results approach the old 5000 limit
-    if (allRows.length >= 5000) {
-      console.warn(
-        `getHistoricalBests: fetched ${allRows.length} rows. ` +
-          `Consider maintaining a dedicated personal bests table for better performance.`,
-      );
-    }
-
-    const bests = new Map<string, { best: number; count: number }>();
-    for (const row of allRows) {
-      if (currentActivityId && row.activityId === currentActivityId) continue;
-      if (row.avgWeightLbs == null || row.avgWeightLbs <= 0) continue;
-      const existing = bests.get(row.movementId);
-      if (existing) {
-        existing.count += 1;
-        if (row.avgWeightLbs > existing.best) {
-          existing.best = row.avgWeightLbs;
-        }
-      } else {
-        bests.set(row.movementId, { best: row.avgWeightLbs, count: 1 });
-      }
-    }
-    return Object.fromEntries([...bests].map(([id, { best, count }]) => [id, { best, count }]));
-  },
-});
-
-/** Get exercisePerformance rows for a specific workout — used for PR comparison. */
-export const getWorkoutPerformanceRows = internalQuery({
+/**
+ * Return the movementIds that got a new all-time PR in the given activity.
+ *
+ * Reads the materialized `personalRecords` projection: a movement's PR row
+ * points back to the single activity that set the best weight
+ * (`achievedActivityId`), with ties broken by earliest insertion. So a
+ * movement's PR belongs to this activity iff its projection row points here
+ * AND there were prior weighted sessions (`totalSessions > 1`) — otherwise
+ * the very first session of every movement would falsely register as a PR.
+ */
+export const getPRMovementIdsForActivity = internalQuery({
   args: { userId: v.id("users"), activityId: v.string() },
-  handler: async (ctx, { userId, activityId }) => {
-    const rows = await ctx.db
-      .query("exercisePerformance")
-      .withIndex("by_userId_activityId", (q) => q.eq("userId", userId).eq("activityId", activityId))
-      .take(100);
-    return rows.map((r) => ({ movementId: r.movementId, avgWeightLbs: r.avgWeightLbs }));
+  handler: async (ctx, { userId, activityId }): Promise<string[]> => {
+    const records = await ctx.db
+      .query("personalRecords")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    return records
+      .filter((r) => r.achievedActivityId === activityId && r.totalSessions > 1)
+      .map((r) => r.movementId);
   },
 });
 
@@ -146,13 +106,12 @@ export const getWorkoutDetail = action({
     const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
     if (!userId) throw new Error("Not authenticated");
 
-    const [detail, movements, formattedSummary, workoutMeta, historicalBests, thisWorkoutPerf]: [
+    const [detail, movements, formattedSummary, workoutMeta, prMovementIdList]: [
       unknown,
       Movement[],
       unknown,
       { title: string; targetArea: string; workoutType: string } | null,
-      Record<string, { best: number; count: number }>,
-      Array<{ movementId: string; avgWeightLbs?: number }>,
+      string[],
     ] = await Promise.all([
       ctx.runAction(internal.tonal.proxy.fetchWorkoutDetail, {
         userId,
@@ -169,11 +128,7 @@ export const getWorkoutDetail = action({
         userId,
         activityId: args.activityId,
       }),
-      ctx.runQuery(internal.workoutDetail.getHistoricalBests, {
-        userId,
-        currentActivityId: args.activityId,
-      }),
-      ctx.runQuery(internal.workoutDetail.getWorkoutPerformanceRows, {
+      ctx.runQuery(internal.workoutDetail.getPRMovementIdsForActivity, {
         userId,
         activityId: args.activityId,
       }),
@@ -204,19 +159,7 @@ export const getWorkoutDetail = action({
       };
     });
 
-    // Detect PRs by comparing this workout's stored exercisePerformance values
-    // against prior bests (which exclude this activity — see getHistoricalBests).
-    // The movement must have at least one prior weighted session, otherwise the
-    // first workout of a movement would always register as a PR.
-    const prMovementIds = new Set<string>();
-    for (const perf of thisWorkoutPerf) {
-      if (perf.avgWeightLbs == null || perf.avgWeightLbs <= 0) continue;
-      const hist = historicalBests[perf.movementId];
-      if (!hist) continue;
-      if (perf.avgWeightLbs > hist.best) {
-        prMovementIds.add(perf.movementId);
-      }
-    }
+    const prMovementIds = new Set(prMovementIdList);
 
     // Build movement summaries grouped by movementId
     const movementSummaries = buildMovementSummaries(enrichedSets, volumeMap, prMovementIds);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ai-sdk/provider-utils": "^4.0.23",
         "@base-ui/react": "^1.3.0",
         "@convex-dev/agent": "^0.6.1",
+        "@convex-dev/aggregate": "^0.2.1",
         "@convex-dev/auth": "^0.0.91",
         "@convex-dev/migrations": "^0.3.3",
         "@convex-dev/rate-limiter": "^0.3.2",
@@ -1117,6 +1118,15 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@convex-dev/aggregate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@convex-dev/aggregate/-/aggregate-0.2.1.tgz",
+      "integrity": "sha512-z8GeUC+cIZEgtMXecX6WTBQHNW4E2ioRsc5IkO8BWnCjgDOru/Mw8zXe9JPe35JkqDjlSVKuwxiQHKs/jaYAyA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.24.8"
       }
     },
     "node_modules/@convex-dev/auth": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@ai-sdk/provider-utils": "^4.0.23",
     "@base-ui/react": "^1.3.0",
     "@convex-dev/agent": "^0.6.1",
+    "@convex-dev/aggregate": "^0.2.1",
     "@convex-dev/auth": "^0.0.91",
     "@convex-dev/migrations": "^0.3.3",
     "@convex-dev/rate-limiter": "^0.3.2",

--- a/src/app/(app)/activity/[activityId]/components.tsx
+++ b/src/app/(app)/activity/[activityId]/components.tsx
@@ -4,6 +4,7 @@ import type { EnrichedSetActivity, MovementSummary } from "../../../../../convex
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TrendingUp } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Formatting helpers
@@ -53,9 +54,11 @@ export function workoutTypeLabel(workoutType: string): string {
   return labels[workoutType] ?? workoutType;
 }
 
-function sideLabel(sideNumber: number): string | null {
+function sideLabel(sideNumber: number, hasSidedSets: boolean): string | null {
   if (sideNumber === 1) return "L";
   if (sideNumber === 2) return "R";
+  // Tonal uses sideNumber 0 for the right side on two-sided movements
+  if (sideNumber === 0 && hasSidedSets) return "R";
   return null;
 }
 
@@ -156,8 +159,16 @@ export function TimeBreakdownBar({
 // Set row
 // ---------------------------------------------------------------------------
 
-function SetRow({ set, setNumber }: { set: EnrichedSetActivity; setNumber: number }) {
-  const side = sideLabel(set.sideNumber);
+function SetRow({
+  set,
+  setNumber,
+  hasSidedSets,
+}: {
+  set: EnrichedSetActivity;
+  setNumber: number;
+  hasSidedSets: boolean;
+}) {
+  const side = sideLabel(set.sideNumber, hasSidedSets);
   const hasWeight = set.avgWeight != null && set.avgWeight > 0;
   const reps = set.repCount != null && set.repCount > 0 ? set.repCount : set.repetition;
 
@@ -222,11 +233,18 @@ export function MovementCard({
   summary: MovementSummary;
   sets: EnrichedSetActivity[];
 }) {
+  const hasSidedSets = sets.some((s) => s.sideNumber > 0);
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base font-semibold text-foreground">
+        <CardTitle className="flex items-center gap-2 text-base font-semibold text-foreground">
           {summary.movementName}
+          {summary.isPR && (
+            <span className="flex items-center gap-1 rounded-full bg-chart-2/10 px-2 py-0.5 text-[10px] font-medium text-chart-2">
+              <TrendingUp className="size-3" />
+              PR
+            </span>
+          )}
         </CardTitle>
         <div className="flex flex-wrap items-center gap-2">
           {summary.muscleGroups.map((group) => (
@@ -248,7 +266,7 @@ export function MovementCard({
       </CardHeader>
       <CardContent className="space-y-1.5">
         {sets.map((set, i) => (
-          <SetRow key={set.id} set={set} setNumber={i + 1} />
+          <SetRow key={set.id} set={set} setNumber={i + 1} hasSidedSets={hasSidedSets} />
         ))}
       </CardContent>
     </Card>

--- a/src/app/(app)/activity/[activityId]/page.tsx
+++ b/src/app/(app)/activity/[activityId]/page.tsx
@@ -110,9 +110,22 @@ export default function WorkoutDetailPage({ params }: { params: Promise<{ activi
         </Button>
       </Link>
 
-      <h1 className="text-2xl font-bold tracking-tight text-foreground">
-        {workoutTypeLabel(detail.workoutType)}
-      </h1>
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          {detail.workoutTitle ?? workoutTypeLabel(detail.workoutType)}
+        </h1>
+        {(detail.targetArea || detail.workoutType) && (
+          <span className="text-sm text-muted-foreground">
+            {detail.targetArea}
+            {detail.targetArea && detail.workoutType && " · "}
+            {detail.workoutType && detail.workoutTitle && (
+              <em className="not-italic text-muted-foreground/80">
+                ({workoutTypeLabel(detail.workoutType)})
+              </em>
+            )}
+          </span>
+        )}
+      </div>
       <p className="mt-1 text-sm text-muted-foreground">{formatDateTime(detail.beginTime)}</p>
 
       <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3">

--- a/src/app/(app)/activity/[activityId]/page.tsx
+++ b/src/app/(app)/activity/[activityId]/page.tsx
@@ -117,7 +117,7 @@ export default function WorkoutDetailPage({ params }: { params: Promise<{ activi
         {(detail.targetArea || detail.workoutTitle) && (
           <span className="text-sm text-muted-foreground">
             {detail.targetArea}
-            {detail.targetArea && detail.workoutType && " · "}
+            {detail.targetArea && detail.workoutType && detail.workoutTitle && " · "}
             {detail.workoutType && detail.workoutTitle && (
               <em className="not-italic text-muted-foreground/80">
                 ({workoutTypeLabel(detail.workoutType)})

--- a/src/app/(app)/activity/[activityId]/page.tsx
+++ b/src/app/(app)/activity/[activityId]/page.tsx
@@ -114,7 +114,7 @@ export default function WorkoutDetailPage({ params }: { params: Promise<{ activi
         <h1 className="text-2xl font-bold tracking-tight text-foreground">
           {detail.workoutTitle ?? workoutTypeLabel(detail.workoutType)}
         </h1>
-        {(detail.targetArea || detail.workoutType) && (
+        {(detail.targetArea || detail.workoutTitle) && (
           <span className="text-sm text-muted-foreground">
             {detail.targetArea}
             {detail.targetArea && detail.workoutType && " · "}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -11,11 +11,13 @@ import type {
   StrengthScore,
 } from "../../../../convex/tonal/types";
 import type { DashboardExternalActivity, DashboardWorkout } from "../../../../convex/dashboard";
+import type { RecentPRSummary } from "../../../../convex/prs";
 import { StrengthScoreCard } from "@/features/dashboard/StrengthScoreCard";
 import { MuscleReadinessMap } from "@/features/dashboard/MuscleReadinessMap";
 import { TrainingFrequencyChart } from "@/features/dashboard/TrainingFrequencyChart";
 import { RecentWorkoutsList } from "@/features/dashboard/RecentWorkoutsList";
 import { ExternalActivitiesList } from "@/features/dashboard/ExternalActivitiesList";
+import { PRHighlightsCard } from "@/features/dashboard/PRHighlightsCard";
 import { AsyncCard } from "@/components/AsyncCard";
 import { useActionData } from "@/hooks/useActionData";
 import { ArrowRight } from "lucide-react";
@@ -77,6 +79,7 @@ function getGreeting(): string {
 const NAV_PILLS = [
   { label: "View stats", href: "/stats" },
   { label: "Strength trends", href: "/strength" },
+  { label: "Personal records", href: "/prs" },
   { label: "Browse exercises", href: "/exercises" },
 ] as const;
 
@@ -98,6 +101,7 @@ export default function DashboardPage() {
   const workouts = useQuery(api.dashboard.getWorkoutHistory);
   const frequency = useQuery(api.dashboard.getTrainingFrequency);
   const externalActivities = useQuery(api.dashboard.getExternalActivities);
+  const prSummary = useQuery(api.prs.getRecentPRSummary);
 
   const me = useQuery(api.users.getMe);
   const firstName = me?.tonalName?.split(" ")[0] ?? "there";
@@ -178,6 +182,9 @@ export default function DashboardPage() {
         </QueryCard>
         <QueryCard<DashboardWorkout[]> data={workouts} title="Recent Workouts" tall>
           {(d) => <RecentWorkoutsList workouts={d} />}
+        </QueryCard>
+        <QueryCard<RecentPRSummary> data={prSummary} title="Personal Records">
+          {(d) => <PRHighlightsCard summary={d} />}
         </QueryCard>
         <QueryCard<DashboardExternalActivity[]> data={externalActivities} title="Other Activities">
           {(d) => <ExternalActivitiesList activities={d} />}

--- a/src/app/(app)/prs/page.tsx
+++ b/src/app/(app)/prs/page.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { usePageView } from "@/lib/analytics";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MessageSquare, TrendingDown, TrendingUp, Trophy } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { AllTimePREntry, RecentPRSummary } from "../../../../convex/prs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(dateStr: string): string {
+  // Date strings are YYYY-MM-DD. Parse with T12:00 to avoid timezone-shift issues
+  // where UTC midnight rolls back to the previous day in western timezones.
+  const date = new Date(`${dateStr}T12:00:00`);
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Filter pill
+// ---------------------------------------------------------------------------
+
+function FilterPill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "rounded-full px-3.5 py-2 text-xs font-medium transition-all duration-200",
+        active
+          ? "bg-primary text-primary-foreground shadow-md shadow-primary/20"
+          : "bg-muted/60 text-muted-foreground hover:bg-muted",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recent PR row
+// ---------------------------------------------------------------------------
+
+function RecentPRRow({ pr }: { pr: RecentPRSummary["recentPRs"][number] }) {
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+      <div className="flex items-center gap-2">
+        <TrendingUp className="size-4 text-chart-2" />
+        <span className="text-sm font-semibold text-foreground">{pr.movementName}</span>
+      </div>
+      <div className="flex items-center gap-3 text-xs tabular-nums">
+        <span className="text-muted-foreground">
+          {pr.previousBestLbs} → {pr.newWeightLbs} lbs
+        </span>
+        <span className="font-medium text-chart-2">+{pr.improvementPct}%</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// All-time PR row
+// ---------------------------------------------------------------------------
+
+function AllTimePRRow({ entry }: { entry: AllTimePREntry }) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="truncate text-sm font-semibold text-foreground">{entry.movementName}</span>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {entry.muscleGroups.map((g) => (
+            <Badge key={g} variant="secondary" className="text-[10px]">
+              {g}
+            </Badge>
+          ))}
+          <span className="text-[10px] text-muted-foreground/60">
+            {entry.totalSessions} session{entry.totalSessions !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-0.5">
+        <span className="text-sm font-bold tabular-nums text-foreground">
+          {entry.bestWeightLbs} lbs
+        </span>
+        <span className="text-[10px] text-muted-foreground/60">
+          {formatDate(entry.achievedDate)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+function PRPageSkeleton() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 lg:px-6 lg:py-10">
+      <Skeleton className="mb-2 h-8 w-48" />
+      <Skeleton className="mb-8 h-4 w-64" />
+      <div className="space-y-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-16 rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function PRsPage() {
+  usePageView("prs_viewed");
+
+  const allTimePRs = useQuery(api.prs.getAllTimePRs);
+  const recentSummary = useQuery(api.prs.getRecentPRSummary);
+  const [muscleFilter, setMuscleFilter] = useState<string | null>(null);
+
+  if (allTimePRs === undefined || recentSummary === undefined) {
+    return <PRPageSkeleton />;
+  }
+
+  // Derive available muscle groups from data
+  const muscleGroups = [...new Set(allTimePRs.flatMap((p) => p.muscleGroups))].sort();
+
+  const filteredPRs = muscleFilter
+    ? allTimePRs.filter((p) => p.muscleGroups.includes(muscleFilter))
+    : allTimePRs;
+
+  const chatPrompt = encodeURIComponent(
+    "Tell me about my personal records and what I should focus on next",
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 lg:px-6 lg:py-10">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Personal Records</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Your best lifts and recent breakthroughs.
+        </p>
+      </div>
+
+      {allTimePRs.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <Trophy className="mx-auto mb-3 size-8 text-muted-foreground/40" />
+            <p className="text-sm text-muted-foreground">
+              No exercise data yet. Complete a workout to start tracking your records.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Recent PRs */}
+          {recentSummary.recentPRs.length > 0 && (
+            <Card className="mb-6">
+              <CardHeader>
+                <CardTitle>
+                  <span className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+                    Recent PRs
+                  </span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-2">
+                {recentSummary.recentPRs.map((pr) => (
+                  <RecentPRRow key={pr.movementId} pr={pr} />
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Summary stats */}
+          <div className="mb-6 flex flex-wrap gap-3 text-xs text-muted-foreground">
+            {recentSummary.recentPRs.length > 0 && (
+              <span className="flex items-center gap-1">
+                <TrendingUp className="size-3 text-chart-2" />
+                {recentSummary.recentPRs.length} PR{recentSummary.recentPRs.length !== 1 ? "s" : ""}
+              </span>
+            )}
+            {recentSummary.steadyCount > 0 && <span>{recentSummary.steadyCount} progressing</span>}
+            {recentSummary.plateauCount > 0 && <span>{recentSummary.plateauCount} plateaued</span>}
+            {recentSummary.regressionCount > 0 && (
+              <span className="flex items-center gap-1">
+                <TrendingDown className="size-3 text-destructive" />
+                {recentSummary.regressionCount} regressed
+              </span>
+            )}
+          </div>
+
+          {/* Muscle group filter */}
+          {muscleGroups.length > 1 && (
+            <div className="mb-6 flex flex-wrap gap-2">
+              <FilterPill
+                label="All"
+                active={muscleFilter === null}
+                onClick={() => setMuscleFilter(null)}
+              />
+              {muscleGroups.map((g) => (
+                <FilterPill
+                  key={g}
+                  label={g}
+                  active={muscleFilter === g}
+                  onClick={() => setMuscleFilter(g)}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* All-time records */}
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                <span className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+                  All-Time Records
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-2">
+              {filteredPRs.length > 0 ? (
+                filteredPRs.map((entry) => <AllTimePRRow key={entry.movementId} entry={entry} />)
+              ) : (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  No records for this muscle group.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Coach CTA */}
+          <div className="mt-6">
+            <Link
+              href={`/chat?prompt=${chatPrompt}`}
+              className="flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+            >
+              <MessageSquare className="size-4" />
+              Ask coach about your progress
+            </Link>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/prs/page.tsx
+++ b/src/app/(app)/prs/page.tsx
@@ -43,6 +43,7 @@ function FilterPill({
   return (
     <button
       onClick={onClick}
+      aria-pressed={active}
       className={cn(
         "rounded-full px-3.5 py-2 text-xs font-medium transition-all duration-200",
         active
@@ -198,7 +199,7 @@ export default function PRsPage() {
                 {recentSummary.recentPRs.length} PR{recentSummary.recentPRs.length !== 1 ? "s" : ""}
               </span>
             )}
-            {recentSummary.steadyCount > 0 && <span>{recentSummary.steadyCount} progressing</span>}
+            {recentSummary.steadyCount > 0 && <span>{recentSummary.steadyCount} steady</span>}
             {recentSummary.plateauCount > 0 && <span>{recentSummary.plateauCount} plateaued</span>}
             {recentSummary.regressionCount > 0 && (
               <span className="flex items-center gap-1">

--- a/src/app/(app)/prs/page.tsx
+++ b/src/app/(app)/prs/page.tsx
@@ -142,11 +142,17 @@ export default function PRsPage() {
     return <PRPageSkeleton />;
   }
 
-  // Derive available muscle groups from data
+  // Derive available muscle groups from data.
   const muscleGroups = [...new Set(allTimePRs.flatMap((p) => p.muscleGroups))].sort();
 
-  const filteredPRs = muscleFilter
-    ? allTimePRs.filter((p) => p.muscleGroups.includes(muscleFilter))
+  // Ignore a stale filter whose group has dropped out of the current data
+  // (e.g. last PR for that muscle was deleted) — deriving the effective
+  // filter keeps the list and the "All" pill consistent without a
+  // setState-in-effect dance.
+  const effectiveFilter = muscleFilter && muscleGroups.includes(muscleFilter) ? muscleFilter : null;
+
+  const filteredPRs = effectiveFilter
+    ? allTimePRs.filter((p) => p.muscleGroups.includes(effectiveFilter))
     : allTimePRs;
 
   const chatPrompt = encodeURIComponent(
@@ -214,14 +220,14 @@ export default function PRsPage() {
             <div className="mb-6 flex flex-wrap gap-2">
               <FilterPill
                 label="All"
-                active={muscleFilter === null}
+                active={effectiveFilter === null}
                 onClick={() => setMuscleFilter(null)}
               />
               {muscleGroups.map((g) => (
                 <FilterPill
                   key={g}
                   label={g}
-                  active={muscleFilter === g}
+                  active={effectiveFilter === g}
                   onClick={() => setMuscleFilter(g)}
                 />
               ))}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -14,6 +14,7 @@ import {
   Settings,
   Sun,
   TrendingUp,
+  Trophy,
   User,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -36,6 +37,7 @@ const navLinks: Array<{
   { href: "/schedule", label: "Schedule", icon: CalendarDays },
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard, exact: true },
   { href: "/progress", label: "Progress", icon: TrendingUp },
+  { href: "/prs", label: "PRs", icon: Trophy },
   { href: "/settings", label: "Settings", icon: Settings },
 ];
 

--- a/src/features/dashboard/PRHighlightsCard.tsx
+++ b/src/features/dashboard/PRHighlightsCard.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { ArrowRight, TrendingUp } from "lucide-react";
 import type { RecentPRSummary } from "../../../convex/prs";
 
+const RECENT_PR_DISPLAY_LIMIT = 3;
+
 interface PRHighlightsCardProps {
   summary: RecentPRSummary;
 }
@@ -18,7 +20,7 @@ export function PRHighlightsCard({ summary }: PRHighlightsCardProps) {
   }
 
   const hasPRs = summary.recentPRs.length > 0;
-  const displayPRs = summary.recentPRs.slice(0, 3);
+  const displayPRs = summary.recentPRs.slice(0, RECENT_PR_DISPLAY_LIMIT);
 
   return (
     <div className="flex flex-col gap-3">
@@ -39,9 +41,9 @@ export function PRHighlightsCard({ summary }: PRHighlightsCardProps) {
               </div>
             </div>
           ))}
-          {summary.recentPRs.length > 3 && (
+          {summary.recentPRs.length > RECENT_PR_DISPLAY_LIMIT && (
             <p className="text-[11px] text-muted-foreground/60">
-              +{summary.recentPRs.length - 3} more
+              +{summary.recentPRs.length - RECENT_PR_DISPLAY_LIMIT} more
             </p>
           )}
         </div>
@@ -52,7 +54,7 @@ export function PRHighlightsCard({ summary }: PRHighlightsCardProps) {
       )}
 
       <div className="flex items-center gap-3 text-[11px] text-muted-foreground/60">
-        {summary.steadyCount > 0 && <span>{summary.steadyCount} progressing</span>}
+        {summary.steadyCount > 0 && <span>{summary.steadyCount} steady</span>}
         {summary.plateauCount > 0 && <span>{summary.plateauCount} plateaued</span>}
         {summary.regressionCount > 0 && <span>{summary.regressionCount} regressed</span>}
       </div>

--- a/src/features/dashboard/PRHighlightsCard.tsx
+++ b/src/features/dashboard/PRHighlightsCard.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, TrendingUp } from "lucide-react";
+import type { RecentPRSummary } from "../../../convex/prs";
+
+interface PRHighlightsCardProps {
+  summary: RecentPRSummary;
+}
+
+export function PRHighlightsCard({ summary }: PRHighlightsCardProps) {
+  if (summary.totalMovementsTracked === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No exercise data yet. Complete a workout to start tracking PRs.
+      </p>
+    );
+  }
+
+  const hasPRs = summary.recentPRs.length > 0;
+  const displayPRs = summary.recentPRs.slice(0, 3);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {hasPRs ? (
+        <div className="flex flex-col gap-2">
+          {displayPRs.map((pr) => (
+            <div
+              key={pr.movementId}
+              className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2"
+            >
+              <div className="flex items-center gap-2">
+                <TrendingUp className="size-3.5 text-chart-2" />
+                <span className="text-sm font-medium text-foreground">{pr.movementName}</span>
+              </div>
+              <div className="flex items-center gap-2 text-xs tabular-nums text-muted-foreground">
+                <span>{pr.newWeightLbs} lbs</span>
+                <span className="text-chart-2">+{pr.improvementPct}%</span>
+              </div>
+            </div>
+          ))}
+          {summary.recentPRs.length > 3 && (
+            <p className="text-[11px] text-muted-foreground/60">
+              +{summary.recentPRs.length - 3} more
+            </p>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No new PRs — {summary.totalMovementsTracked} movements tracked.
+        </p>
+      )}
+
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground/60">
+        {summary.steadyCount > 0 && <span>{summary.steadyCount} progressing</span>}
+        {summary.plateauCount > 0 && <span>{summary.plateauCount} plateaued</span>}
+        {summary.regressionCount > 0 && <span>{summary.regressionCount} regressed</span>}
+      </div>
+
+      <Link
+        href="/prs"
+        className="mt-1 flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+      >
+        View all records <ArrowRight className="size-3" />
+      </Link>
+    </div>
+  );
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -60,6 +60,7 @@ type AnalyticsEvents = {
   strength_scores_viewed: Record<string, never>;
   muscle_readiness_viewed: Record<string, never>;
   exercises_viewed: Record<string, never>;
+  prs_viewed: Record<string, never>;
   activity_detail_viewed: { activity_id: string };
   settings_viewed: Record<string, never>;
   profile_viewed: Record<string, never>;


### PR DESCRIPTION
## Summary

Adds the Personal Records feature (all-time PR page, dashboard highlights, PR badges on workout detail) on a materialized-state backend that makes the read path O(log N) indexed lookups instead of the O(full user history) scans the previous approach required.

## What ships

**Feature (UI)** — Personal Records page at `/prs`, PR highlights card on the dashboard, PR badges on activity detail pages, workout title + target area in the activity header, navigation entry. These are largely the same UI that [PR #222](https://github.com/JeffOtano/roni/pull/222) proposed; the commit history preserves the original authorship.

**Architecture (backend)** — Two cooperating pieces of derived state, both maintained on every write to `exercisePerformance`:

- **`perfByMovement` aggregate** (`@convex-dev/aggregate`) — namespace `[userId, movementId]`, sortKey `avgWeightLbs`. Gives O(log N) `max` / `count` per movement and makes deletion-of-the-prior-winner reconciliation cheap.
- **`personalRecords` table** — per-(user, movement) projection carrying `bestAvgWeightLbs`, `achievedActivityId`, `achievedDate`, `totalSessions`. A single `by_userId_best` range scan powers the Personal Records page.

Writes flow through `afterInsert` / `afterPatch` / `afterDelete` helpers in [convex/personalRecords.ts](convex/personalRecords.ts), wired into the three existing `exercisePerformance` write sites (`persistExercisePerformance`, `patchAvgWeights`, `deleteExercisePerformanceBatch`). Ties at the max weight resolve to the *earliest*-inserted row, so a PR badge stays on the session that first achieved the weight instead of every matching session that follows.

## Read-path rewrites

- `getAllTimePRs` — reads `personalRecords` via `by_userId_best` (one indexed scan).
- `getHistoricalBests` + `getWorkoutPerformanceRows` — replaced by a single `getPRMovementIdsForActivity` that answers "did this activity set any all-time PRs?" directly from the projection.
- `getRecentPRSummary` — bounded by a 120-day window on `by_userId_date` instead of an arbitrary 5000-row cap.

## Rollout

1. Deploy — hooks use `insertIfDoesNotExist` / `deleteIfExists` so they're safe against a partially-populated aggregate.
2. `npx convex run migrations/backfillPersonalRecords:backfillAll` — schedules a per-user backfill action. Idempotent and re-runnable.
3. The `/prs` page starts showing data as users' backfills complete; before that it renders the empty state.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` — 1089 passing, 13 skipped
- [x] `npm run knip` — no dead exports
- [x] File size check — no file over the 300-line soft cap crosses the 400-line hard cap
- [ ] Manual: deploy to dev, run backfill, verify `/prs` page matches the brute-force computation for a seeded user
- [ ] Manual: trigger account deletion and verify `personalRecords` + aggregate namespaces are empty for the deleted user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Personal Records page: View all-time best lifts and recent progress filtered by muscle group.
  * Dashboard PR highlights: See summary of recent gains, plateaus, and regressions.
  * PR badges: Workout activities now display which movements achieved new personal records.
  * Navigation: Added "PRs" link for quick access to personal records dashboard.

* **Improvements**
  * Workout details now display titles and target areas for better context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->