### PR TITLE
fix(auth): return existingUserId on update path

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -11,20 +11,21 @@ export const { auth, signIn, signOut, store } = convexAuth({
   ],
   callbacks: {
     async createOrUpdateUser(ctx, args) {
-      // Blunt abuse deterrent. Only run on actual account creation, not on
-      // updates to an existing user. If the global bucket is empty, the
-      // caller sees a clear rate-limit error and the auth library rolls
-      // back the half-created auth account (which is why we throw before
-      // inserting the users row).
-      if (args.existingUserId === null) {
-        await rateLimiter.limit(ctx, "newSignup", { throws: true });
+      // Update path: auth library is linking an existing user (email
+      // verification, password reset). Return the existing ID so the
+      // authAccount stays pointed at the original user row.
+      if (args.existingUserId !== null) {
+        return args.existingUserId;
       }
 
-      const userId = await ctx.db.insert("users", {
+      // Create path: rate-limit before inserting so the auth library
+      // rolls back the half-created auth account if the bucket is empty.
+      await rateLimiter.limit(ctx, "newSignup", { throws: true });
+
+      return await ctx.db.insert("users", {
         ...(args.profile.email ? { email: args.profile.email } : {}),
         ...(args.profile.name ? { name: args.profile.name as string } : {}),
       });
-      return userId;
     },
   },
 });


### PR DESCRIPTION
## Summary
- `createOrUpdateUser` unconditionally inserted a new `users` row on every call, including when the auth library was linking an existing account (email verification, password reset).
- Each reset-send AND reset-verify therefore: created a duplicate user row, repointed `authAccounts.userId` at that new empty row, and broke `Password.ts` reset-verification's `resetAccount.userId === userId` check — every reset flow threw "Invalid code."
- Fix returns `args.existingUserId` early on the update path; rate-limit + insert only on the create path. Matches the library's default `createOrUpdateUser` semantics.

## Impact on prod
Cross-checked prod via two signals (duplicate `users` rows by email + `authAccounts.userId` pointing at non-oldest user). Both converge on the same 6 affected emails / 15 orphan user rows:

| email | dupes |
|---|---|
| otano.jeffrey@gmail.com | 8 |
| chris24mansfield@gmail.com | 3 |
| ken.adler@gmail.com | 3 |
| ricardovasq@gmail.com | 3 |
| arianna.ratner@gmail.com | 2 |
| mike.byron@outlook.com | 2 |

This PR stops new damage. A follow-up PR will ship a one-shot cleanup action that repoints each affected `authAccounts` row back to its oldest user and deletes the orphans.

Also required separately: `SITE_URL` env var on prod Convex (set earlier this session — the missing env was the first bug uncovered in this investigation, masking this one).

## Test plan
- [ ] Merge + Vercel redeploy (auto `npx convex deploy` via `vercel.json`)
- [ ] Verify an affected user's password reset no longer produces new `users` rows
- [ ] Follow-up PR: cleanup action + verification scan shows 0 affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)