### PR TITLE
chore(migrations): repair orphaned auth accounts post-#228

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -74,6 +74,7 @@ import type * as libraryWorkouts from "../libraryWorkouts.js";
 import type * as migrations from "../migrations.js";
 import type * as migrations_backfillAvgWeight from "../migrations/backfillAvgWeight.js";
 import type * as migrations_backfillPersonalRecords from "../migrations/backfillPersonalRecords.js";
+import type * as migrations_repairOrphanedAuthAccounts from "../migrations/repairOrphanedAuthAccounts.js";
 import type * as migrations_rotateTokenEncryptionKey from "../migrations/rotateTokenEncryptionKey.js";
 import type * as personalRecords from "../personalRecords.js";
 import type * as progressiveOverload from "../progressiveOverload.js";
@@ -203,6 +204,7 @@ declare const fullApi: ApiFromModules<{
   migrations: typeof migrations;
   "migrations/backfillAvgWeight": typeof migrations_backfillAvgWeight;
   "migrations/backfillPersonalRecords": typeof migrations_backfillPersonalRecords;
+  "migrations/repairOrphanedAuthAccounts": typeof migrations_repairOrphanedAuthAccounts;
   "migrations/rotateTokenEncryptionKey": typeof migrations_rotateTokenEncryptionKey;
   personalRecords: typeof personalRecords;
   progressiveOverload: typeof progressiveOverload;

--- a/convex/migrations/repairOrphanedAuthAccounts.ts
+++ b/convex/migrations/repairOrphanedAuthAccounts.ts
@@ -4,20 +4,31 @@
  * #228). For each affected email:
  *
  * 1. Find the oldest `users` row for the email (the real one holding data).
- * 2. Verify every OTHER `users` row for that email has zero references in
- *    the 18 app tables that carry a `userId`. Abort that email if any found.
- * 3. Repoint the `authAccounts` row back to the oldest user.
- * 4. Delete orphan `authSessions` + `authRefreshTokens` for the duplicate
- *    user rows.
- * 5. Delete the duplicate user rows themselves.
+ * 2. Safety check: verify every orphan `users` row has zero references in
+ *    the 18 user-scoped app tables. Abort that email if any found — orphans
+ *    were created by an auth-only path that never completed a signed-in
+ *    session, so they should have zero app data.
+ * 3. Repoint the password `authAccounts` row at the oldest user.
+ * 4. For each orphan, run the full account-deletion sequence used by
+ *    `convex/account.ts:deleteAccount` (agent component data → by-userId
+ *    tables → specialized tables → remaining auth data → user record). This
+ *    ensures nothing user-scoped is left behind, across every current and
+ *    future table enumerated in `convex/userData.ts`.
  *
  * Dry run:  npx convex run migrations/repairOrphanedAuthAccounts:run '{"dryRun": true}' --prod
  * Execute:  npx convex run migrations/repairOrphanedAuthAccounts:run '{"dryRun": false}' --prod
  */
 
 import { v } from "convex/values";
-import { internalMutation, type MutationCtx } from "../_generated/server";
-import type { Id, TableNames } from "../_generated/dataModel";
+import {
+  type ActionCtx,
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "../_generated/server";
+import { components, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { BY_USER_ID_BATCH_TABLES } from "../userData";
 
 // Emails with duplicate user rows from the pre-fix prod scan.
 const AFFECTED_EMAILS = [
@@ -29,32 +40,104 @@ const AFFECTED_EMAILS = [
   "mike.byron@outlook.com",
 ] as const;
 
-// Tables whose `userId` index we check to confirm an orphan row has no data.
-// Index name is `by_userId` for most tables; a few use a compound index
-// whose first field is `userId`, which Convex lets us query with `eq("userId", ...)`.
-const USER_REFERENCING_TABLES: ReadonlyArray<{
-  table: TableNames;
-  index: string;
-}> = [
-  { table: "aiUsage", index: "by_userId" },
-  { table: "checkIns", index: "by_userId" },
-  { table: "completedWorkouts", index: "by_userId_activityId" },
-  { table: "currentStrengthScores", index: "by_userId" },
-  { table: "emailChangeRequests", index: "by_userId" },
-  { table: "exercisePerformance", index: "by_userId_movementId" },
-  { table: "externalActivities", index: "by_userId_externalId" },
-  { table: "goals", index: "by_userId" },
-  { table: "injuries", index: "by_userId" },
-  { table: "muscleReadiness", index: "by_userId" },
-  { table: "personalRecords", index: "by_userId_movementId" },
-  { table: "strengthScoreSnapshots", index: "by_userId_date" },
-  { table: "tonalCache", index: "by_userId_dataType" },
-  { table: "trainingBlocks", index: "by_userId" },
-  { table: "userProfiles", index: "by_userId" },
-  { table: "weekPlans", index: "by_userId" },
-  { table: "workoutFeedback", index: "by_userId" },
-  { table: "workoutPlans", index: "by_userId" },
-];
+// Safety check: every user-scoped table that has a `userId` index. If an
+// orphan has any row here we abort that email and surface it in the report,
+// since orphans should be completely empty.
+const SAFETY_INDEXES: Record<string, string> = {
+  aiUsage: "by_userId",
+  checkIns: "by_userId",
+  completedWorkouts: "by_userId_activityId",
+  currentStrengthScores: "by_userId",
+  emailChangeRequests: "by_userId",
+  exercisePerformance: "by_userId_movementId",
+  externalActivities: "by_userId_externalId",
+  goals: "by_userId",
+  injuries: "by_userId",
+  muscleReadiness: "by_userId",
+  personalRecords: "by_userId_movementId",
+  strengthScoreSnapshots: "by_userId_date",
+  tonalCache: "by_userId_dataType",
+  trainingBlocks: "by_userId",
+  userProfiles: "by_userId",
+  weekPlans: "by_userId",
+  workoutFeedback: "by_userId",
+  workoutPlans: "by_userId",
+};
+
+type PlanResult =
+  | { kind: "skip"; reason: string }
+  | {
+      kind: "plan";
+      authAccountId: Id<"authAccounts">;
+      currentAuthUserId: Id<"users">;
+      oldestUserId: Id<"users">;
+      orphanIds: Array<Id<"users">>;
+      dataHits: Array<{ userId: Id<"users">; table: string }>;
+    };
+
+export const planEmail = internalQuery({
+  args: { email: v.string() },
+  handler: async (ctx, { email }): Promise<PlanResult> => {
+    const users = await ctx.db
+      .query("users")
+      .withIndex("email", (q) => q.eq("email", email))
+      .collect();
+
+    if (users.length <= 1) {
+      return { kind: "skip", reason: "no duplicates" };
+    }
+
+    const sorted = [...users].sort((a, b) => a._creationTime - b._creationTime);
+    const oldest = sorted[0];
+    const orphans = sorted.slice(1);
+
+    const authAccount = await ctx.db
+      .query("authAccounts")
+      .withIndex("providerAndAccountId", (q) =>
+        q.eq("provider", "password").eq("providerAccountId", email),
+      )
+      .unique();
+
+    if (!authAccount) {
+      return { kind: "skip", reason: "no password authAccount" };
+    }
+
+    const dataHits: Array<{ userId: Id<"users">; table: string }> = [];
+    for (const orphan of orphans) {
+      for (const [table, idx] of Object.entries(SAFETY_INDEXES)) {
+        const row = await ctx.db
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .query(table as any)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .withIndex(idx as any, (q: any) => q.eq("userId", orphan._id))
+          .first();
+        if (row) {
+          dataHits.push({ userId: orphan._id, table });
+          break;
+        }
+      }
+    }
+
+    return {
+      kind: "plan",
+      authAccountId: authAccount._id,
+      currentAuthUserId: authAccount.userId,
+      oldestUserId: oldest._id,
+      orphanIds: orphans.map((o) => o._id),
+      dataHits,
+    };
+  },
+});
+
+export const repointAuthAccount = internalMutation({
+  args: {
+    authAccountId: v.id("authAccounts"),
+    newUserId: v.id("users"),
+  },
+  handler: async (ctx, { authAccountId, newUserId }) => {
+    await ctx.db.patch(authAccountId, { userId: newUserId });
+  },
+});
 
 type EmailResult = {
   email: string;
@@ -62,114 +145,109 @@ type EmailResult = {
   reason?: string;
   oldestUserId?: Id<"users">;
   previousAuthAccountUserId?: Id<"users">;
-  orphanUserIds?: Array<Id<"users">>;
+  orphanIds?: Array<Id<"users">>;
   orphansWithData?: Array<{ userId: Id<"users">; table: string }>;
-  deletedSessions?: number;
-  deletedRefreshTokens?: number;
 };
 
-export const run = internalMutation({
+export const run = internalAction({
   args: { dryRun: v.boolean() },
-  handler: async (ctx, { dryRun }) => {
+  handler: async (ctx, { dryRun }): Promise<{ dryRun: boolean; results: EmailResult[] }> => {
     const results: EmailResult[] = [];
 
     for (const email of AFFECTED_EMAILS) {
-      results.push(await repairOneEmail(ctx, email, dryRun));
+      const plan: PlanResult = await ctx.runQuery(
+        internal.migrations.repairOrphanedAuthAccounts.planEmail,
+        { email },
+      );
+
+      if (plan.kind === "skip") {
+        results.push({ email, status: "skipped", reason: plan.reason });
+        continue;
+      }
+
+      if (plan.dataHits.length > 0) {
+        results.push({
+          email,
+          status: "aborted",
+          reason: "orphan row has app data — refusing to delete",
+          orphansWithData: plan.dataHits,
+        });
+        continue;
+      }
+
+      const base: EmailResult = {
+        email,
+        status: dryRun ? "planned" : "applied",
+        oldestUserId: plan.oldestUserId,
+        previousAuthAccountUserId: plan.currentAuthUserId,
+        orphanIds: plan.orphanIds,
+      };
+
+      if (dryRun) {
+        results.push(base);
+        continue;
+      }
+
+      if (plan.currentAuthUserId !== plan.oldestUserId) {
+        await ctx.runMutation(internal.migrations.repairOrphanedAuthAccounts.repointAuthAccount, {
+          authAccountId: plan.authAccountId,
+          newUserId: plan.oldestUserId,
+        });
+      }
+
+      for (const orphanId of plan.orphanIds) {
+        await deleteOneOrphan(ctx, orphanId);
+      }
+
+      results.push(base);
     }
 
     return { dryRun, results };
   },
 });
 
-async function repairOneEmail(
-  ctx: MutationCtx,
-  email: string,
-  dryRun: boolean,
-): Promise<EmailResult> {
-  const usersForEmail = await ctx.db
-    .query("users")
-    .withIndex("email", (q) => q.eq("email", email))
-    .collect();
+/**
+ * Full user-data wipe for one orphan userId. Mirrors the sequence in
+ * `convex/account.ts:deleteAccount` so every user-scoped table (including
+ * agent component data) is drained. The password `authAccounts` row is
+ * already repointed at the oldest user by the time this runs, so
+ * `deleteAuthData` only drains `authSessions` + `authRefreshTokens`.
+ */
+async function deleteOneOrphan(ctx: ActionCtx, orphanId: Id<"users">): Promise<void> {
+  await ctx.runAction(components.agent.users.deleteAllForUserId, {
+    userId: orphanId,
+  });
 
-  if (usersForEmail.length <= 1) {
-    return { email, status: "skipped", reason: "no duplicates" };
-  }
-
-  const sorted = [...usersForEmail].sort((a, b) => a._creationTime - b._creationTime);
-  const oldest = sorted[0];
-  const orphans = sorted.slice(1);
-
-  const authAccount = await ctx.db
-    .query("authAccounts")
-    .withIndex("providerAndAccountId", (q) =>
-      q.eq("provider", "password").eq("providerAccountId", email),
-    )
-    .unique();
-
-  if (!authAccount) {
-    return { email, status: "skipped", reason: "no password authAccount" };
-  }
-
-  const orphansWithData: Array<{ userId: Id<"users">; table: string }> = [];
-  for (const orphan of orphans) {
-    for (const { table, index } of USER_REFERENCING_TABLES) {
-      const row = await ctx.db
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .query(table as any)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .withIndex(index as any, (q: any) => q.eq("userId", orphan._id))
-        .first();
-      if (row) {
-        orphansWithData.push({ userId: orphan._id, table });
-        break;
-      }
+  for (const table of BY_USER_ID_BATCH_TABLES) {
+    let hasMore = true;
+    while (hasMore) {
+      hasMore = await ctx.runMutation(internal.accountDeletion.deleteUserTableBatch, {
+        userId: orphanId,
+        table,
+      });
     }
   }
 
-  if (orphansWithData.length > 0) {
-    return {
-      email,
-      status: "aborted",
-      reason: "orphan row has app data — refusing to delete",
-      orphansWithData,
-    };
-  }
-
-  const plan: EmailResult = {
-    email,
-    status: dryRun ? "planned" : "applied",
-    oldestUserId: oldest._id,
-    previousAuthAccountUserId: authAccount.userId,
-    orphanUserIds: orphans.map((o) => o._id),
-    deletedSessions: 0,
-    deletedRefreshTokens: 0,
-  };
-
-  if (dryRun) return plan;
-
-  if (authAccount.userId !== oldest._id) {
-    await ctx.db.patch(authAccount._id, { userId: oldest._id });
-  }
-
-  for (const orphan of orphans) {
-    const sessions = await ctx.db
-      .query("authSessions")
-      .withIndex("userId", (q) => q.eq("userId", orphan._id))
-      .collect();
-    for (const session of sessions) {
-      const tokens = await ctx.db
-        .query("authRefreshTokens")
-        .withIndex("sessionId", (q) => q.eq("sessionId", session._id))
-        .collect();
-      for (const token of tokens) {
-        await ctx.db.delete(token._id);
-        plan.deletedRefreshTokens = (plan.deletedRefreshTokens ?? 0) + 1;
-      }
-      await ctx.db.delete(session._id);
-      plan.deletedSessions = (plan.deletedSessions ?? 0) + 1;
+  for (const mutation of [
+    internal.accountDeletion.deletePersonalRecordsBatch,
+    internal.accountDeletion.deleteExercisePerformanceBatch,
+    internal.accountDeletion.deleteTonalCacheBatch,
+    internal.accountDeletion.deleteExternalActivitiesBatch,
+  ] as const) {
+    let hasMore = true;
+    while (hasMore) {
+      hasMore = await ctx.runMutation(mutation, { userId: orphanId });
     }
-    await ctx.db.delete(orphan._id);
   }
 
-  return plan;
+  let hasMoreAuth = true;
+  while (hasMoreAuth) {
+    hasMoreAuth = await ctx.runMutation(internal.accountDeletion.deleteAuthData, {
+      userId: orphanId,
+    });
+  }
+
+  await ctx.runMutation(internal.accountDeletion.deleteUserRecord, {
+    userId: orphanId,
+  });
 }

--- a/convex/migrations/repairOrphanedAuthAccounts.ts
+++ b/convex/migrations/repairOrphanedAuthAccounts.ts
@@ -1,0 +1,175 @@
+/**
+ * One-shot cleanup for users whose `authAccounts.userId` got repointed at an
+ * empty duplicate row by the old `createOrUpdateUser` callback bug (fixed in
+ * #228). For each affected email:
+ *
+ * 1. Find the oldest `users` row for the email (the real one holding data).
+ * 2. Verify every OTHER `users` row for that email has zero references in
+ *    the 18 app tables that carry a `userId`. Abort that email if any found.
+ * 3. Repoint the `authAccounts` row back to the oldest user.
+ * 4. Delete orphan `authSessions` + `authRefreshTokens` for the duplicate
+ *    user rows.
+ * 5. Delete the duplicate user rows themselves.
+ *
+ * Dry run:  npx convex run migrations/repairOrphanedAuthAccounts:run '{"dryRun": true}' --prod
+ * Execute:  npx convex run migrations/repairOrphanedAuthAccounts:run '{"dryRun": false}' --prod
+ */
+
+import { v } from "convex/values";
+import { internalMutation, type MutationCtx } from "../_generated/server";
+import type { Id, TableNames } from "../_generated/dataModel";
+
+// Emails with duplicate user rows from the pre-fix prod scan.
+const AFFECTED_EMAILS = [
+  "otano.jeffrey@gmail.com",
+  "chris24mansfield@gmail.com",
+  "ken.adler@gmail.com",
+  "ricardovasq@gmail.com",
+  "arianna.ratner@gmail.com",
+  "mike.byron@outlook.com",
+] as const;
+
+// Tables whose `userId` index we check to confirm an orphan row has no data.
+// Index name is `by_userId` for most tables; a few use a compound index
+// whose first field is `userId`, which Convex lets us query with `eq("userId", ...)`.
+const USER_REFERENCING_TABLES: ReadonlyArray<{
+  table: TableNames;
+  index: string;
+}> = [
+  { table: "aiUsage", index: "by_userId" },
+  { table: "checkIns", index: "by_userId" },
+  { table: "completedWorkouts", index: "by_userId_activityId" },
+  { table: "currentStrengthScores", index: "by_userId" },
+  { table: "emailChangeRequests", index: "by_userId" },
+  { table: "exercisePerformance", index: "by_userId_movementId" },
+  { table: "externalActivities", index: "by_userId_externalId" },
+  { table: "goals", index: "by_userId" },
+  { table: "injuries", index: "by_userId" },
+  { table: "muscleReadiness", index: "by_userId" },
+  { table: "personalRecords", index: "by_userId_movementId" },
+  { table: "strengthScoreSnapshots", index: "by_userId_date" },
+  { table: "tonalCache", index: "by_userId_dataType" },
+  { table: "trainingBlocks", index: "by_userId" },
+  { table: "userProfiles", index: "by_userId" },
+  { table: "weekPlans", index: "by_userId" },
+  { table: "workoutFeedback", index: "by_userId" },
+  { table: "workoutPlans", index: "by_userId" },
+];
+
+type EmailResult = {
+  email: string;
+  status: "skipped" | "aborted" | "planned" | "applied";
+  reason?: string;
+  oldestUserId?: Id<"users">;
+  previousAuthAccountUserId?: Id<"users">;
+  orphanUserIds?: Array<Id<"users">>;
+  orphansWithData?: Array<{ userId: Id<"users">; table: string }>;
+  deletedSessions?: number;
+  deletedRefreshTokens?: number;
+};
+
+export const run = internalMutation({
+  args: { dryRun: v.boolean() },
+  handler: async (ctx, { dryRun }) => {
+    const results: EmailResult[] = [];
+
+    for (const email of AFFECTED_EMAILS) {
+      results.push(await repairOneEmail(ctx, email, dryRun));
+    }
+
+    return { dryRun, results };
+  },
+});
+
+async function repairOneEmail(
+  ctx: MutationCtx,
+  email: string,
+  dryRun: boolean,
+): Promise<EmailResult> {
+  const usersForEmail = await ctx.db
+    .query("users")
+    .withIndex("email", (q) => q.eq("email", email))
+    .collect();
+
+  if (usersForEmail.length <= 1) {
+    return { email, status: "skipped", reason: "no duplicates" };
+  }
+
+  const sorted = [...usersForEmail].sort((a, b) => a._creationTime - b._creationTime);
+  const oldest = sorted[0];
+  const orphans = sorted.slice(1);
+
+  const authAccount = await ctx.db
+    .query("authAccounts")
+    .withIndex("providerAndAccountId", (q) =>
+      q.eq("provider", "password").eq("providerAccountId", email),
+    )
+    .unique();
+
+  if (!authAccount) {
+    return { email, status: "skipped", reason: "no password authAccount" };
+  }
+
+  const orphansWithData: Array<{ userId: Id<"users">; table: string }> = [];
+  for (const orphan of orphans) {
+    for (const { table, index } of USER_REFERENCING_TABLES) {
+      const row = await ctx.db
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .query(table as any)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .withIndex(index as any, (q: any) => q.eq("userId", orphan._id))
+        .first();
+      if (row) {
+        orphansWithData.push({ userId: orphan._id, table });
+        break;
+      }
+    }
+  }
+
+  if (orphansWithData.length > 0) {
+    return {
+      email,
+      status: "aborted",
+      reason: "orphan row has app data — refusing to delete",
+      orphansWithData,
+    };
+  }
+
+  const plan: EmailResult = {
+    email,
+    status: dryRun ? "planned" : "applied",
+    oldestUserId: oldest._id,
+    previousAuthAccountUserId: authAccount.userId,
+    orphanUserIds: orphans.map((o) => o._id),
+    deletedSessions: 0,
+    deletedRefreshTokens: 0,
+  };
+
+  if (dryRun) return plan;
+
+  if (authAccount.userId !== oldest._id) {
+    await ctx.db.patch(authAccount._id, { userId: oldest._id });
+  }
+
+  for (const orphan of orphans) {
+    const sessions = await ctx.db
+      .query("authSessions")
+      .withIndex("userId", (q) => q.eq("userId", orphan._id))
+      .collect();
+    for (const session of sessions) {
+      const tokens = await ctx.db
+        .query("authRefreshTokens")
+        .withIndex("sessionId", (q) => q.eq("sessionId", session._id))
+        .collect();
+      for (const token of tokens) {
+        await ctx.db.delete(token._id);
+        plan.deletedRefreshTokens = (plan.deletedRefreshTokens ?? 0) + 1;
+      }
+      await ctx.db.delete(session._id);
+      plan.deletedSessions = (plan.deletedSessions ?? 0) + 1;
+    }
+    await ctx.db.delete(orphan._id);
+  }
+
+  return plan;
+}


### PR DESCRIPTION
## Summary
Follow-up to #228. Ships a one-shot `internalMutation` that repairs the 6 users whose `authAccounts.userId` got repointed at empty duplicate `users` rows by the pre-#228 `createOrUpdateUser` bug.

## What it does
For each affected email:
1. Find the oldest `users` row (the real one holding their data).
2. Verify every **other** `users` row for that email has zero references in the 18 app tables that carry a `userId`. Abort that email if any found — defensive check, since orphans were created by an auth-only path that never completed a signed-in session.
3. Repoint the `authAccounts` row at the oldest user.
4. Delete orphan `authSessions` + `authRefreshTokens`.
5. Delete the duplicate `users` rows.

`dryRun: true` returns a plan-only report without touching the DB.

## Affected emails (hard-coded from the cross-checked prod scan)
- otano.jeffrey@gmail.com (8 rows → repoint + delete 7)
- chris24mansfield@gmail.com (3 rows → repoint + delete 2)
- ken.adler@gmail.com (3 rows → repoint + delete 2)
- ricardovasq@gmail.com (3 rows → repoint + delete 2)
- arianna.ratner@gmail.com (2 rows → repoint + delete 1)
- mike.byron@outlook.com (2 rows → repoint + delete 1)

Total: 15 orphan `users` rows to delete, 6 `authAccounts` rows to repoint.

## Test plan
- [ ] CI green
- [ ] `npx convex run migrations/repairOrphanedAuthAccounts:run '{"dryRun": true}' --prod` — review plan
- [ ] `npx convex run migrations/repairOrphanedAuthAccounts:run '{"dryRun": false}' --prod` — apply
- [ ] Re-run the prod scan (fresh `authAccounts` + `users` dump + the cross-check script) → expect 0 affected
- [ ] Affected users can sign in and see their original data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated repair mechanism to safely resolve orphaned user authentication records. Includes comprehensive validation checks across system tables and dry-run testing capability to prevent data loss during repairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->