### PR TITLE
chore(migrations): add deleteEmptyOrphans targeted cleanup

### DIFF
--- a/convex/migrations/repairOrphanedAuthAccounts.ts
+++ b/convex/migrations/repairOrphanedAuthAccounts.ts
@@ -129,6 +129,27 @@ export const planEmail = internalQuery({
   },
 });
 
+/**
+ * Safety scan for a single userId. Returns the first table that has a row
+ * for this user, or `null` if the user has no data across all 18
+ * user-scoped app tables.
+ */
+export const findFirstDataHit = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }): Promise<string | null> => {
+    for (const [table, idx] of Object.entries(SAFETY_INDEXES)) {
+      const row = await ctx.db
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .query(table as any)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .withIndex(idx as any, (q: any) => q.eq("userId", userId))
+        .first();
+      if (row) return table;
+    }
+    return null;
+  },
+});
+
 export const repointAuthAccount = internalMutation({
   args: {
     authAccountId: v.id("authAccounts"),
@@ -200,6 +221,68 @@ export const run = internalAction({
       }
 
       results.push(base);
+    }
+
+    return { dryRun, results };
+  },
+});
+
+type EmptyOrphanResult = {
+  userId: Id<"users">;
+  status: "skipped" | "aborted" | "planned" | "applied";
+  reason?: string;
+  dataHitTable?: string;
+};
+
+/**
+ * Targeted cleanup for a specific list of userIds known to be empty orphan
+ * rows. Unlike `run`, this does NOT touch `authAccounts` — useful for the
+ * chris24mansfield / ricardovasq case where the auth account is correctly
+ * pointing at a different (data-bearing) orphan and we just want to remove
+ * the stale empty duplicates.
+ *
+ * Each userId is independently safety-checked: if any of the 18 user-scoped
+ * tables has a row for it, that userId is aborted and reported. Otherwise
+ * the full account-deletion sequence runs (agent component → by-userId
+ * tables → specialized tables → auth data → user record).
+ *
+ * Dry run:  npx convex run migrations/repairOrphanedAuthAccounts:deleteEmptyOrphans \
+ *             '{"dryRun": true, "userIds": ["k5...", ...]}' --prod
+ */
+export const deleteEmptyOrphans = internalAction({
+  args: {
+    dryRun: v.boolean(),
+    userIds: v.array(v.id("users")),
+  },
+  handler: async (
+    ctx,
+    { dryRun, userIds },
+  ): Promise<{ dryRun: boolean; results: EmptyOrphanResult[] }> => {
+    const results: EmptyOrphanResult[] = [];
+
+    for (const userId of userIds) {
+      const hit: string | null = await ctx.runQuery(
+        internal.migrations.repairOrphanedAuthAccounts.findFirstDataHit,
+        { userId },
+      );
+
+      if (hit !== null) {
+        results.push({
+          userId,
+          status: "aborted",
+          reason: "userId has app data — refusing to delete",
+          dataHitTable: hit,
+        });
+        continue;
+      }
+
+      if (dryRun) {
+        results.push({ userId, status: "planned" });
+        continue;
+      }
+
+      await deleteOneOrphan(ctx, userId);
+      results.push({ userId, status: "applied" });
     }
 
     return { dryRun, results };


### PR DESCRIPTION
## Summary
Follow-up to #238. Removes the 6 truly-empty duplicate user rows left behind for chris24mansfield@gmail.com (5) and ricardovasq@gmail.com (1). The \`run\` action from #238 aborted the entire email for these two because each one has a *separate* orphan with real recent app data, so the empties couldn't be cleaned up via the per-email flow.

## What it does
New \`deleteEmptyOrphans\` internalAction takes an explicit list of userIds and handles each independently:
1. Per-userId safety scan against the 18 user-scoped tables via the new \`findFirstDataHit\` internalQuery.
2. If the user has ANY row in any table → abort for that userId, report the table that hit.
3. Otherwise run the same full \`deleteOneOrphan\` sequence used by #238 (agent component → by-userId tables → specialized tables → auth data → user record).

Does **not** touch \`authAccounts\`. For the two affected users the auth account is currently pointing at the data-bearing orphan they've been actively using since the bug, and that stays pointed there.

## Target user IDs for this run
- \`k575ptv1xpeyfsjcdzfne2fb9x84rdbt\` — ricardovasq empty orphan
- \`k573cj8m68pvhx8sjxr09spkkn8558h3\` — chris24mansfield empty orphan
- \`k57dk2s6bwtg36bbv0v6eagg3x854ypn\` — chris24mansfield empty orphan
- \`k57a8842ecdk6b800fseby0sz18578b5\` — chris24mansfield empty orphan
- \`k571cjf3rr7va20tzpmetva1ms856qpw\` — chris24mansfield empty orphan
- \`k57ah49sm3q0mcjhpbycgc87qh8570fc\` — chris24mansfield empty orphan

All six were scanned across every user-referencing table and have zero rows.

## Test plan
- [ ] Merge + Vercel deploy (auto)
- [ ] Dry run: \`npx convex run migrations/repairOrphanedAuthAccounts:deleteEmptyOrphans '{"dryRun": true, "userIds": [...]}' --prod\` → expect 6 \`"planned"\`
- [ ] Apply: \`"dryRun": false\` → expect 6 \`"applied"\`
- [ ] Re-run the duplicate-email scan → expect 0 duplicates remaining for both emails' empties (only the original + data-bearing orphan left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)