### PR TITLE
test(auth): regression test + reset-password error logging

### DIFF
--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -1,0 +1,57 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { createOrUpdateUser } from "./auth";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.*s");
+
+describe("createOrUpdateUser", () => {
+  test("returns existingUserId without inserting on update path", async () => {
+    const t = convexTest(schema, modules);
+
+    const existingUserId = await t.run((ctx) =>
+      ctx.db.insert("users", { email: "repeat@example.com", name: "Repeat User" }),
+    );
+
+    const result = await t.run((ctx) =>
+      createOrUpdateUser(ctx, {
+        existingUserId,
+        profile: { email: "repeat@example.com" },
+      }),
+    );
+
+    expect(result).toBe(existingUserId);
+
+    const users = await t.run((ctx) => ctx.db.query("users").collect());
+    expect(users).toHaveLength(1);
+    expect(users[0]._id).toBe(existingUserId);
+  });
+
+  test("does not repoint when called twice with same existingUserId", async () => {
+    const t = convexTest(schema, modules);
+
+    const existingUserId = await t.run((ctx) =>
+      ctx.db.insert("users", { email: "repeat@example.com" }),
+    );
+
+    // Simulate the reset-send + reset-verify sequence that used to create
+    // two orphan rows under the pre-#228 bug.
+    await t.run((ctx) =>
+      createOrUpdateUser(ctx, {
+        existingUserId,
+        profile: { email: "repeat@example.com" },
+      }),
+    );
+    await t.run((ctx) =>
+      createOrUpdateUser(ctx, {
+        existingUserId,
+        profile: { email: "repeat@example.com" },
+      }),
+    );
+
+    const users = await t.run((ctx) => ctx.db.query("users").collect());
+    expect(users).toHaveLength(1);
+    expect(users[0]._id).toBe(existingUserId);
+  });
+});

--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -1,8 +1,14 @@
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
-import { createOrUpdateUser } from "./auth";
+import { describe, expect, test, vi } from "vitest";
 import schema from "./schema";
+
+const limitMock = vi.fn(async (..._args: unknown[]) => ({ ok: true, retryAfter: undefined }));
+vi.mock("./rateLimits", () => ({
+  rateLimiter: { limit: limitMock },
+}));
+
+const { createOrUpdateUser } = await import("./auth");
 
 const modules = import.meta.glob("./**/*.*s");
 
@@ -26,6 +32,29 @@ describe("createOrUpdateUser", () => {
     const users = await t.run((ctx) => ctx.db.query("users").collect());
     expect(users).toHaveLength(1);
     expect(users[0]._id).toBe(existingUserId);
+  });
+
+  test("rate-limits and inserts a new user on create path", async () => {
+    limitMock.mockClear();
+    const t = convexTest(schema, modules);
+
+    const result = await t.run((ctx) =>
+      createOrUpdateUser(ctx, {
+        existingUserId: null,
+        profile: { email: "new@example.com", name: "New User" },
+      }),
+    );
+
+    expect(limitMock).toHaveBeenCalledTimes(1);
+    const [, name, options] = limitMock.mock.calls[0];
+    expect(name).toBe("newSignup");
+    expect(options).toEqual({ throws: true });
+
+    const users = await t.run((ctx) => ctx.db.query("users").collect());
+    expect(users).toHaveLength(1);
+    expect(users[0]._id).toBe(result);
+    expect(users[0].email).toBe("new@example.com");
+    expect(users[0].name).toBe("New User");
   });
 
   test("does not repoint when called twice with same existingUserId", async () => {

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -29,7 +29,7 @@ export async function createOrUpdateUser(
 
   return await ctx.db.insert("users", {
     ...(args.profile.email ? { email: args.profile.email } : {}),
-    ...(args.profile.name ? { name: args.profile.name as string } : {}),
+    ...(args.profile.name ? { name: args.profile.name } : {}),
   });
 }
 
@@ -40,6 +40,6 @@ export const { auth, signIn, signOut, store } = convexAuth({
     }),
   ],
   callbacks: {
-    createOrUpdateUser: (ctx, args) => createOrUpdateUser(ctx, args),
+    createOrUpdateUser,
   },
 });

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -2,6 +2,36 @@ import { convexAuth } from "@convex-dev/auth/server";
 import { Password } from "@convex-dev/auth/providers/Password";
 import { ResendOTP } from "./ResendOTP";
 import { rateLimiter } from "./rateLimits";
+import type { MutationCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+
+type CreateOrUpdateUserArgs = {
+  existingUserId: Id<"users"> | null;
+  profile: Record<string, unknown> & { email?: string; name?: string };
+};
+
+/**
+ * Called by `@convex-dev/auth` whenever the library needs to resolve a user
+ * for an auth event (sign-up, email-OTP verification, password reset). On the
+ * update path (`existingUserId !== null`) we MUST return that existing ID —
+ * otherwise the auth library re-points the authAccount at a freshly-inserted
+ * row and the user loses access to their data. See #228 for the incident.
+ */
+export async function createOrUpdateUser(
+  ctx: MutationCtx,
+  args: CreateOrUpdateUserArgs,
+): Promise<Id<"users">> {
+  if (args.existingUserId !== null) {
+    return args.existingUserId;
+  }
+
+  await rateLimiter.limit(ctx, "newSignup", { throws: true });
+
+  return await ctx.db.insert("users", {
+    ...(args.profile.email ? { email: args.profile.email } : {}),
+    ...(args.profile.name ? { name: args.profile.name as string } : {}),
+  });
+}
 
 export const { auth, signIn, signOut, store } = convexAuth({
   providers: [
@@ -10,22 +40,6 @@ export const { auth, signIn, signOut, store } = convexAuth({
     }),
   ],
   callbacks: {
-    async createOrUpdateUser(ctx, args) {
-      // Update path: auth library is linking an existing user (email
-      // verification, password reset). Return the existing ID so the
-      // authAccount stays pointed at the original user row.
-      if (args.existingUserId !== null) {
-        return args.existingUserId;
-      }
-
-      // Create path: rate-limit before inserting so the auth library
-      // rolls back the half-created auth account if the bucket is empty.
-      await rateLimiter.limit(ctx, "newSignup", { throws: true });
-
-      return await ctx.db.insert("users", {
-        ...(args.profile.email ? { email: args.profile.email } : {}),
-        ...(args.profile.name ? { name: args.profile.name as string } : {}),
-      });
-    },
+    createOrUpdateUser: (ctx, args) => createOrUpdateUser(ctx, args),
   },
 });

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -49,7 +49,8 @@ export default function ResetPasswordPage() {
       await signIn("password", { email, flow: "reset" });
       track("password_reset_requested");
       setStep("enter-code");
-    } catch {
+    } catch (err) {
+      console.error("[reset-password] send failed:", err);
       setError("Could not send reset code. Please check your email and try again.");
     } finally {
       setSubmitting(false);
@@ -81,7 +82,8 @@ export default function ResetPasswordPage() {
       });
       track("password_reset_completed");
       setStep("success");
-    } catch {
+    } catch (err) {
+      console.error("[reset-password] verify failed:", err);
       setError("Invalid or expired code. Please check the code and try again.");
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
## Summary
Two small follow-ups to the #228 password-reset incident.

### 1. `createOrUpdateUser` regression test
Extract the callback from `convex/auth.ts` into a named exported function and add a `convex-test` regression test that asserts the update path returns `existingUserId` without inserting a new `users` row. Second test simulates the reset-send + reset-verify sequence that duplicated rows pre-#228 and asserts one row still stands.

Locks in the contract so the bug can't silently regress.

### 2. reset-password error logging
Bind the caught error in both handlers and `console.error` it. Before, both catches were anonymous so any auth failure surfaced as a generic "Could not send reset code" / "Invalid or expired code" with no way to diagnose from the browser.

The #228 investigation took longer than it should have because these messages hid first a `SITE_URL` env error, then a `Uncaught Error: Invalid code` from the callback-bug cascade. Next mystery will show the real message in DevTools.

## Test plan
- [x] `npx vitest run convex/auth.test.ts` — 2 tests pass
- [x] `npx tsc --noEmit` — no new errors in the changed files
- [ ] Manual: attempt an invalid reset code in the browser, confirm `[reset-password] verify failed: ...` is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for user creation and update functionality to ensure data consistency.

* **Refactor**
  * Restructured authentication logic for improved maintainability.

* **Chores**
  * Enhanced error logging in password reset flows for better debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->