### PR TITLE
chore: ignore CHANGELOG.md in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,7 @@ coverage
 .vercel
 convex/_generated
 *.tsbuildinfo
+
+# Managed by release-please; its template uses double blank lines that
+# Prettier would otherwise reformat on every release PR.
+CHANGELOG.md


### PR DESCRIPTION
## Summary

- Release-please writes `CHANGELOG.md` using its own template (double blank lines between `###` sections), which Prettier collapses to single blanks.
- As a result, `Lint & Format` has been failing on every release-please PR — most recently #241 at the `npx prettier --check .` step.
- `CHANGELOG.md` is owned by release-please, so the right fix is to exempt it from Prettier rather than keep re-formatting release-please's output.

## Test plan

- [x] `npx prettier --check .` passes locally with the new ignore entry
- [ ] Once merged, confirm the next release-please PR's `Lint & Format` job goes green
- [ ] Rebase PR #241 on this change (or close/reopen) to clear its failing check

🤖 Generated with [Claude Code](https://claude.com/claude-code)