### PR TITLE
feat(nav): drop /prs from nav, elevate Dashboard PR tile as destination

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -21,6 +21,7 @@ import { PRHighlightsCard } from "@/features/dashboard/PRHighlightsCard";
 import { AsyncCard } from "@/components/AsyncCard";
 import { useActionData } from "@/hooks/useActionData";
 import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DashboardCardSkeleton } from "@/features/dashboard/DashboardCardSkeleton";
 
@@ -32,17 +33,20 @@ function QueryCard<T>({
   data,
   title,
   tall,
+  wide,
   children,
 }: {
   data: T | undefined;
   title: string;
   tall?: boolean;
+  /** Span both columns on the 2-col dashboard grid. */
+  wide?: boolean;
   children: (data: T) => React.ReactNode;
 }) {
-  if (data === undefined) return <DashboardCardSkeleton tall={tall} />;
+  if (data === undefined) return <DashboardCardSkeleton tall={tall} wide={wide} />;
 
   return (
-    <Card className="animate-in fade-in duration-300">
+    <Card className={cn("animate-in fade-in duration-300", wide && "sm:col-span-2")}>
       <CardHeader>
         <CardTitle>
           <span className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
@@ -183,7 +187,7 @@ export default function DashboardPage() {
         <QueryCard<DashboardWorkout[]> data={workouts} title="Recent Workouts" tall>
           {(d) => <RecentWorkoutsList workouts={d} />}
         </QueryCard>
-        <QueryCard<RecentPRSummary> data={prSummary} title="Personal Records">
+        <QueryCard<RecentPRSummary> data={prSummary} title="Personal Records" wide>
           {(d) => <PRHighlightsCard summary={d} />}
         </QueryCard>
         <QueryCard<DashboardExternalActivity[]> data={externalActivities} title="Other Activities">

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -14,7 +14,6 @@ import {
   Settings,
   Sun,
   TrendingUp,
-  Trophy,
   User,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -37,9 +36,10 @@ const navLinks: Array<{
   { href: "/schedule", label: "Schedule", icon: CalendarDays },
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard, exact: true },
   { href: "/progress", label: "Progress", icon: TrendingUp },
-  { href: "/prs", label: "PRs", icon: Trophy },
   { href: "/settings", label: "Settings", icon: Settings },
 ];
+// Note: /prs is intentionally not in the nav — it's surfaced as a hero tile on
+// the dashboard (PRHighlightsCard) and reached via that tile's CTA.
 
 function mobileIsActive(pathname: string, href: string, exact?: boolean) {
   if (href === "/dashboard") return pathname.startsWith("/dashboard");

--- a/src/features/dashboard/DashboardCardSkeleton.tsx
+++ b/src/features/dashboard/DashboardCardSkeleton.tsx
@@ -1,14 +1,26 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 function ShimmerBar({ className }: { className?: string }) {
-  return <div className={`animate-pulse rounded-md bg-primary/6 ${className ?? ""}`} />;
+  return <div className={cn("animate-pulse rounded-md bg-primary/6", className)} />;
 }
 
-export function DashboardCardSkeleton({ tall }: { tall?: boolean }) {
+export function DashboardCardSkeleton({
+  tall,
+  wide,
+}: {
+  tall?: boolean;
+  /** Span both columns on the 2-col dashboard grid. */
+  wide?: boolean;
+}) {
   return (
-    <Card className={tall ? "min-h-[300px]" : "min-h-[200px]"} role="status" aria-label="Loading">
+    <Card
+      className={cn(tall ? "min-h-[300px]" : "min-h-[200px]", wide && "sm:col-span-2")}
+      role="status"
+      aria-label="Loading"
+    >
       <CardHeader>
         <ShimmerBar className="h-4 w-32" />
       </CardHeader>

--- a/src/features/dashboard/PRHighlightsCard.tsx
+++ b/src/features/dashboard/PRHighlightsCard.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, TrendingUp } from "lucide-react";
+import { ArrowRight, Trophy } from "lucide-react";
 import type { RecentPRSummary } from "../../../convex/prs";
 
-const RECENT_PR_DISPLAY_LIMIT = 3;
+/** Recent PRs listed underneath the hero, not counting the hero itself. */
+const REST_DISPLAY_LIMIT = 3;
 
 interface PRHighlightsCardProps {
   summary: RecentPRSummary;
@@ -19,52 +20,112 @@ export function PRHighlightsCard({ summary }: PRHighlightsCardProps) {
     );
   }
 
-  const hasPRs = summary.recentPRs.length > 0;
-  const displayPRs = summary.recentPRs.slice(0, RECENT_PR_DISPLAY_LIMIT);
+  if (summary.recentPRs.length === 0) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-muted-foreground">
+          No new PRs yet — {summary.totalMovementsTracked} movements tracked.
+        </p>
+        <TrendLegend summary={summary} />
+        <ViewAllCta totalMovements={summary.totalMovementsTracked} />
+      </div>
+    );
+  }
+
+  // Lead with the biggest weight in the recent-PR window — the most
+  // motivational moment — and list the rest underneath.
+  const sorted = [...summary.recentPRs].sort((a, b) => b.newWeightLbs - a.newWeightLbs);
+  const [hero, ...rest] = sorted;
+  const shownRest = rest.slice(0, REST_DISPLAY_LIMIT);
+  const hiddenCount = rest.length - shownRest.length;
 
   return (
-    <div className="flex flex-col gap-3">
-      {hasPRs ? (
-        <div className="flex flex-col gap-2">
-          {displayPRs.map((pr) => (
-            <div
-              key={pr.movementId}
-              className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2"
-            >
-              <div className="flex items-center gap-2">
-                <TrendingUp className="size-3.5 text-chart-2" />
-                <span className="text-sm font-medium text-foreground">{pr.movementName}</span>
-              </div>
-              <div className="flex items-center gap-2 text-xs tabular-nums text-muted-foreground">
-                <span>{pr.newWeightLbs} lbs</span>
-                <span className="text-chart-2">+{pr.improvementPct}%</span>
-              </div>
-            </div>
+    <div className="flex flex-col gap-4">
+      <HeroPR pr={hero} />
+
+      {shownRest.length > 0 && (
+        <ul className="flex flex-col gap-1.5">
+          {shownRest.map((pr) => (
+            <li key={pr.movementId} className="flex items-center justify-between gap-3 text-sm">
+              <span className="min-w-0 flex-1 truncate text-foreground">{pr.movementName}</span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                {pr.newWeightLbs} lbs
+              </span>
+              <span className="w-10 shrink-0 text-right text-xs font-medium tabular-nums text-chart-2">
+                +{pr.improvementPct}%
+              </span>
+            </li>
           ))}
-          {summary.recentPRs.length > RECENT_PR_DISPLAY_LIMIT && (
-            <p className="text-[11px] text-muted-foreground/60">
-              +{summary.recentPRs.length - RECENT_PR_DISPLAY_LIMIT} more
-            </p>
+          {hiddenCount > 0 && (
+            <li className="text-[11px] text-muted-foreground/60">
+              +{hiddenCount} more new PR{hiddenCount === 1 ? "" : "s"}
+            </li>
           )}
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground">
-          No new PRs — {summary.totalMovementsTracked} movements tracked.
-        </p>
+        </ul>
       )}
 
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground/60">
-        {summary.steadyCount > 0 && <span>{summary.steadyCount} steady</span>}
-        {summary.plateauCount > 0 && <span>{summary.plateauCount} plateaued</span>}
-        {summary.regressionCount > 0 && <span>{summary.regressionCount} regressed</span>}
-      </div>
-
-      <Link
-        href="/prs"
-        className="mt-1 flex items-center gap-1 text-xs font-medium text-primary hover:underline"
-      >
-        View all records <ArrowRight className="size-3" />
-      </Link>
+      <TrendLegend summary={summary} />
+      <ViewAllCta totalMovements={summary.totalMovementsTracked} />
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subcomponents (local — only used here)
+// ---------------------------------------------------------------------------
+
+function HeroPR({ pr }: { pr: RecentPRSummary["recentPRs"][number] }) {
+  return (
+    <div className="relative overflow-hidden rounded-lg border border-chart-5/25 bg-gradient-to-br from-chart-5/15 via-chart-5/5 to-transparent px-4 py-3.5">
+      {/* Subtle radial glow behind the trophy */}
+      <div
+        className="pointer-events-none absolute -right-8 -top-8 size-24 rounded-full bg-chart-5/25 blur-2xl"
+        aria-hidden
+      />
+      <div className="relative flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <Trophy className="size-3.5 text-chart-5" aria-hidden />
+            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-chart-5">
+              Top recent PR
+            </span>
+          </div>
+          <p className="mt-1.5 truncate text-sm font-medium text-foreground">{pr.movementName}</p>
+        </div>
+        <div className="flex shrink-0 flex-col items-end leading-tight">
+          <span className="text-2xl font-bold tabular-nums text-foreground">
+            {pr.newWeightLbs}
+            <span className="ml-1 text-xs font-normal text-muted-foreground">lbs</span>
+          </span>
+          <span className="text-xs font-semibold tabular-nums text-chart-2">
+            +{pr.improvementPct}%
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TrendLegend({ summary }: { summary: RecentPRSummary }) {
+  const hasAny = summary.steadyCount > 0 || summary.plateauCount > 0 || summary.regressionCount > 0;
+  if (!hasAny) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground/70">
+      {summary.steadyCount > 0 && <span>{summary.steadyCount} steady</span>}
+      {summary.plateauCount > 0 && <span>{summary.plateauCount} plateaued</span>}
+      {summary.regressionCount > 0 && <span>{summary.regressionCount} regressed</span>}
+    </div>
+  );
+}
+
+function ViewAllCta({ totalMovements }: { totalMovements: number }) {
+  return (
+    <Link
+      href="/prs"
+      className="group inline-flex w-fit items-center gap-1.5 rounded-md border border-border bg-muted/40 px-3 py-1.5 text-xs font-medium text-foreground transition-colors duration-150 hover:border-chart-5/35 hover:bg-chart-5/5 hover:text-chart-5"
+    >
+      View all {totalMovements} record{totalMovements === 1 ? "" : "s"}
+      <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary

Nav had 6 items — one too many for a mobile bottom tab bar. Rather than hide the engagement-y PR feature, promotes it to a full-width hero tile on the dashboard so it earns the demotion from the nav.

- **AppShell** — remove `/prs` from `navLinks`. Both the desktop sidebar and mobile bottom tabs now show 5 items: Chat, Schedule, Dashboard, Progress, Settings.
- **PRHighlightsCard** — lead with a chart-5-tinted hero block (trophy icon, big weight readout, improvement %) for the biggest weight in the recent-PR window. Remaining PRs become a compact list underneath, followed by the trend legend and a clearer "View all N records" CTA that hover-tints gold.
- **Dashboard grid** — pass a new `wide` prop to `QueryCard` so the PR tile spans both columns at ≥sm. Skeleton gets the same prop so loading state doesn't reflow.
- **Theme coherence** — uses `chart-5` (hue 85, the theme's warm gold in both light and dark) instead of arbitrary `amber-*`, so the accent tracks any future theme change.

`/prs` route is untouched — just reached via the card's CTA.

## Test Plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` — 1108 passing
- [ ] Visual: desktop sidebar shows 5 items; mobile bottom bar shows 5 tabs; PR tile spans 2 cols on ≥sm, stacks on mobile
- [ ] Visual: hero PR card renders with gold gradient in light + dark themes
- [ ] Empty states: "no data" and "no new PRs" both still surface the CTA to `/prs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personal Records card now spans two columns on the dashboard at tablet breakpoint
  * PR highlights display features a prominent hero PR showing your heaviest recent lift with a Trophy icon
  * PRs navigation link removed; access via the dashboard card instead

* **Improvements**
  * Recent PRs reorganized to display a featured hero PR separately from additional recent lifts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->