### PR TITLE
fix(dashboard): workout date shows 'yesterday' instead of 'today' for same-day workouts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,8 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --text-2xs: 0.6875rem; /* 11px — smaller than Tailwind's default text-xs (12px) */
+  --text-2xs--line-height: 1rem;
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -145,7 +145,7 @@ export default function LoginPage() {
       </form>
 
       {flow === "signUp" && (
-        <p className="mt-3 text-center text-[11px] leading-relaxed text-muted-foreground/70">
+        <p className="mt-3 text-center text-2xs leading-relaxed text-muted-foreground/70">
           By signing up you agree to our{" "}
           <Link href="/terms" className="underline underline-offset-2 hover:text-foreground">
             Terms of Service

--- a/src/features/chat/DateDivider.tsx
+++ b/src/features/chat/DateDivider.tsx
@@ -23,7 +23,7 @@ export function DateDivider({ timestamp }: DateDividerProps) {
   return (
     <div className="flex items-center gap-4 px-4 py-3 sm:px-6">
       <div className="h-px flex-1 bg-gradient-to-r from-transparent via-border to-transparent" />
-      <span className="text-[11px] font-medium tracking-wider text-muted-foreground uppercase">
+      <span className="text-2xs font-medium tracking-wider text-muted-foreground uppercase">
         {label}
       </span>
       <div className="h-px flex-1 bg-gradient-to-r from-transparent via-border to-transparent" />

--- a/src/features/dashboard/ExternalActivitiesList.tsx
+++ b/src/features/dashboard/ExternalActivitiesList.tsx
@@ -2,34 +2,7 @@
 
 import type { DashboardExternalActivity } from "../../../convex/dashboard";
 import { cn } from "@/lib/utils";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function relativeTime(dateString: string): string {
-  const now = Date.now();
-  const then = new Date(dateString).getTime();
-  const diffMs = now - then;
-  const diffSec = Math.floor(diffMs / 1000);
-  const diffMin = Math.floor(diffSec / 60);
-  const diffHr = Math.floor(diffMin / 60);
-  const diffDay = Math.floor(diffHr / 24);
-  const diffWeek = Math.floor(diffDay / 7);
-
-  if (diffSec < 60) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  if (diffHr < 24) return `${diffHr}h ago`;
-  if (diffDay === 1) return "yesterday";
-  if (diffDay < 7) return `${diffDay}d ago`;
-  if (diffWeek === 1) return "1 week ago";
-  if (diffWeek < 5) return `${diffWeek} weeks ago`;
-
-  return new Date(dateString).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
-}
+import { formatRelativeTime } from "@/lib/relativeTime";
 
 function formatDuration(seconds: number): string {
   const mins = Math.round(seconds / 60);
@@ -66,25 +39,25 @@ function ExternalActivityRow({ activity }: { activity: DashboardExternalActivity
         <span className="text-sm font-medium leading-tight text-foreground/80">
           {capitalizeType(activity.workoutType)}
         </span>
-        <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/60">
-          {relativeTime(activity.beginTime)}
+        <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/60">
+          {formatRelativeTime(activity.beginTime)}
         </span>
       </div>
       <div className="flex flex-wrap items-center gap-2">
-        <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+        <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
           {formatDuration(activity.totalDuration)}
         </span>
         {showCalories && (
-          <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+          <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
             {Math.round(activity.totalCalories)} cal
           </span>
         )}
         {showHr && (
-          <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+          <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
             {Math.round(activity.averageHeartRate)} bpm
           </span>
         )}
-        <span className="rounded-md bg-muted/40 px-1.5 py-0.5 text-[11px] text-muted-foreground/50">
+        <span className="rounded-md bg-muted/40 px-1.5 py-0.5 text-2xs text-muted-foreground/50">
           {activity.source}
         </span>
       </div>

--- a/src/features/dashboard/PRHighlightsCard.tsx
+++ b/src/features/dashboard/PRHighlightsCard.tsx
@@ -57,7 +57,7 @@ export function PRHighlightsCard({ summary }: PRHighlightsCardProps) {
             </li>
           ))}
           {hiddenCount > 0 && (
-            <li className="text-[11px] text-muted-foreground/60">
+            <li className="text-2xs text-muted-foreground/60">
               +{hiddenCount} more new PR{hiddenCount === 1 ? "" : "s"}
             </li>
           )}
@@ -110,7 +110,7 @@ function TrendLegend({ summary }: { summary: RecentPRSummary }) {
   const hasAny = summary.steadyCount > 0 || summary.plateauCount > 0 || summary.regressionCount > 0;
   if (!hasAny) return null;
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground/70">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-muted-foreground/70">
       {summary.steadyCount > 0 && <span>{summary.steadyCount} steady</span>}
       {summary.plateauCount > 0 && <span>{summary.plateauCount} plateaued</span>}
       {summary.regressionCount > 0 && <span>{summary.regressionCount} regressed</span>}

--- a/src/features/dashboard/RecentWorkoutsList.tsx
+++ b/src/features/dashboard/RecentWorkoutsList.tsx
@@ -4,34 +4,7 @@ import Link from "next/link";
 import type { DashboardWorkout } from "../../../convex/dashboard";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-// ---------------------------------------------------------------------------
-// Relative date helper (no external library)
-// ---------------------------------------------------------------------------
-
-function relativeTime(dateString: string): string {
-  const now = Date.now();
-  const then = new Date(dateString).getTime();
-  const diffMs = now - then;
-  const diffSec = Math.floor(diffMs / 1000);
-  const diffMin = Math.floor(diffSec / 60);
-  const diffHr = Math.floor(diffMin / 60);
-  const diffDay = Math.floor(diffHr / 24);
-  const diffWeek = Math.floor(diffDay / 7);
-
-  if (diffSec < 60) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  if (diffHr < 24) return `${diffHr}h ago`;
-  if (diffDay === 1) return "yesterday";
-  if (diffDay < 7) return `${diffDay}d ago`;
-  if (diffWeek === 1) return "1 week ago";
-  if (diffWeek < 5) return `${diffWeek} weeks ago`;
-
-  return new Date(dateString).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
-}
+import { formatRelativeTime } from "@/lib/relativeTime";
 
 function formatDuration(seconds: number): string {
   const mins = Math.round(seconds / 60);
@@ -75,31 +48,31 @@ function WorkoutRow({ workout, index }: { workout: DashboardWorkout; index: numb
       <div className="flex items-start justify-between gap-2">
         <span className="text-sm font-semibold leading-tight text-foreground">{workout.title}</span>
         <div className="flex shrink-0 items-center gap-1">
-          <span className="text-[11px] tabular-nums text-muted-foreground/60">
-            {relativeTime(workout.date)}
+          <span className="text-2xs tabular-nums text-muted-foreground/60">
+            {formatRelativeTime(workout.date)}
           </span>
           <ChevronRight className="size-3 text-muted-foreground/40 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-muted-foreground" />
         </div>
       </div>
       {workout.targetArea && (
         <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded-md bg-muted/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+          <span className="rounded-md bg-muted/60 px-2 py-0.5 text-2xs font-medium text-muted-foreground">
             {workout.targetArea}
           </span>
           {workout.workoutType && (
-            <span className="text-[11px] text-muted-foreground/60">{workout.workoutType}</span>
+            <span className="text-2xs text-muted-foreground/60">{workout.workoutType}</span>
           )}
         </div>
       )}
       <div className="flex items-center gap-2">
-        <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+        <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
           {formatVolume(workout.totalVolume)}
         </span>
-        <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+        <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
           {formatDuration(workout.totalDuration)}
         </span>
         {showWork && (
-          <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+          <span className="rounded-md bg-muted/50 px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
             {formatVolume(workout.totalWork)} work
           </span>
         )}

--- a/src/lib/relativeTime.test.ts
+++ b/src/lib/relativeTime.test.ts
@@ -35,8 +35,18 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime("2026-04-14")).toBe("yesterday");
   });
 
-  it("handles a full ISO timestamp as the source", () => {
+  it("returns 'Xm ago' for full timestamps within the last hour", () => {
+    // Build "now" and the input from the same local Date components so the
+    // assertion holds in any runner timezone — a hard-coded UTC literal would
+    // shift across the local day boundary in far-west zones.
     vi.setSystemTime(new Date(2026, 3, 14, 21, 0, 0));
-    expect(formatRelativeTime("2026-04-14T10:03:00Z")).toBe("today");
+    const tenMinutesAgo = new Date(2026, 3, 14, 20, 50, 0).toISOString();
+    expect(formatRelativeTime(tenMinutesAgo)).toBe("10m ago");
+  });
+
+  it("returns 'Xh ago' for full timestamps earlier the same day", () => {
+    vi.setSystemTime(new Date(2026, 3, 14, 21, 0, 0));
+    const threeHoursAgo = new Date(2026, 3, 14, 18, 0, 0).toISOString();
+    expect(formatRelativeTime(threeHoursAgo)).toBe("3h ago");
   });
 });

--- a/src/lib/relativeTime.test.ts
+++ b/src/lib/relativeTime.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatRelativeTime } from "./relativeTime";
+
+describe("formatRelativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'today' when the stored YYYY-MM-DD matches today's local date", () => {
+    // Pin "now" to a time later in the day to guarantee > 24 hours have
+    // elapsed since UTC midnight of the same calendar day — this is the
+    // exact scenario from #133.
+    vi.setSystemTime(new Date(2026, 3, 14, 21, 0, 0)); // April 14, 2026, 9 PM local
+    expect(formatRelativeTime("2026-04-14")).toBe("today");
+  });
+
+  it("returns 'yesterday' when the stored date is one calendar day before today", () => {
+    vi.setSystemTime(new Date(2026, 3, 15, 10, 0, 0)); // April 15, 2026, 10 AM local
+    expect(formatRelativeTime("2026-04-14")).toBe("yesterday");
+  });
+
+  it("returns 'Nd ago' for workouts 2-6 calendar days old", () => {
+    vi.setSystemTime(new Date(2026, 3, 15, 10, 0, 0));
+    expect(formatRelativeTime("2026-04-12")).toBe("3d ago");
+  });
+
+  it("uses calendar days, not rolling 24-hour windows", () => {
+    // Workout stored as April 14 (UTC-sliced), viewed at 12:30 AM local on
+    // April 15 — only a few hours after midnight, but a full calendar day later.
+    vi.setSystemTime(new Date(2026, 3, 15, 0, 30, 0));
+    expect(formatRelativeTime("2026-04-14")).toBe("yesterday");
+  });
+
+  it("handles a full ISO timestamp as the source", () => {
+    vi.setSystemTime(new Date(2026, 3, 14, 21, 0, 0));
+    expect(formatRelativeTime("2026-04-14T10:03:00Z")).toBe("today");
+  });
+});

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,24 +1,66 @@
+const DATE_ONLY_LENGTH = 10;
+const MIDNIGHT_TIME_SUFFIX = "T00:00:00";
+
+const MS_PER_MINUTE = 60 * 1000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+const THRESHOLD_TODAY = 0;
+const THRESHOLD_YESTERDAY = 1;
+const THRESHOLD_ONE_WEEK = 7;
+const THRESHOLD_TWO_WEEKS = 14;
+const THRESHOLD_FIVE_WEEKS = 35;
+
+const JUST_NOW_LABEL = "just now";
+const TODAY_LABEL = "today";
+const YESTERDAY_LABEL = "yesterday";
+const ONE_WEEK_AGO_LABEL = "1 week ago";
+
+const MINUTES_AGO_SUFFIX = "m ago";
+const HOURS_AGO_SUFFIX = "h ago";
+const DAYS_AGO_SUFFIX = "d ago";
+const WEEKS_AGO_SUFFIX = " weeks ago";
+
 // Bare YYYY-MM-DD strings must be parsed as local midnight. `new Date("2026-04-14")`
 // is spec'd to parse as UTC midnight, which shifts a full calendar day for users
 // west of UTC and breaks rolling-24h diffs (see #133).
 export function formatRelativeTime(dateString: string): string {
-  const workoutDate =
-    dateString.length === 10 ? new Date(`${dateString}T00:00:00`) : new Date(dateString);
+  const isDateOnly = dateString.length === DATE_ONLY_LENGTH;
+  const workoutDate = isDateOnly
+    ? new Date(`${dateString}${MIDNIGHT_TIME_SUFFIX}`)
+    : new Date(dateString);
 
   const now = new Date();
+
+  // Full timestamps carry sub-day precision (e.g. externalActivities.beginTime),
+  // so collapse <1h to "Xm ago" and <24h to "Xh ago" before falling through to
+  // calendar-day buckets. Date-only inputs skip this — they only know the day.
+  if (!isDateOnly) {
+    const diffMs = now.getTime() - workoutDate.getTime();
+    if (diffMs < MS_PER_MINUTE) return JUST_NOW_LABEL;
+    if (diffMs < MS_PER_HOUR) {
+      return `${Math.floor(diffMs / MS_PER_MINUTE)}${MINUTES_AGO_SUFFIX}`;
+    }
+    if (diffMs < MS_PER_DAY) {
+      return `${Math.floor(diffMs / MS_PER_HOUR)}${HOURS_AGO_SUFFIX}`;
+    }
+  }
+
   const workoutMidnight = new Date(
     workoutDate.getFullYear(),
     workoutDate.getMonth(),
     workoutDate.getDate(),
   ).getTime();
   const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-  const diffDays = Math.round((todayMidnight - workoutMidnight) / (1000 * 60 * 60 * 24));
+  const diffDays = Math.round((todayMidnight - workoutMidnight) / MS_PER_DAY);
 
-  if (diffDays <= 0) return "today";
-  if (diffDays === 1) return "yesterday";
-  if (diffDays < 7) return `${diffDays}d ago`;
-  if (diffDays < 14) return "1 week ago";
-  if (diffDays < 35) return `${Math.floor(diffDays / 7)} weeks ago`;
+  if (diffDays <= THRESHOLD_TODAY) return TODAY_LABEL;
+  if (diffDays === THRESHOLD_YESTERDAY) return YESTERDAY_LABEL;
+  if (diffDays < THRESHOLD_ONE_WEEK) return `${diffDays}${DAYS_AGO_SUFFIX}`;
+  if (diffDays < THRESHOLD_TWO_WEEKS) return ONE_WEEK_AGO_LABEL;
+  if (diffDays < THRESHOLD_FIVE_WEEKS) {
+    return `${Math.floor(diffDays / THRESHOLD_ONE_WEEK)}${WEEKS_AGO_SUFFIX}`;
+  }
 
   return workoutDate.toLocaleDateString(undefined, {
     month: "short",

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,0 +1,27 @@
+// Bare YYYY-MM-DD strings must be parsed as local midnight. `new Date("2026-04-14")`
+// is spec'd to parse as UTC midnight, which shifts a full calendar day for users
+// west of UTC and breaks rolling-24h diffs (see #133).
+export function formatRelativeTime(dateString: string): string {
+  const workoutDate =
+    dateString.length === 10 ? new Date(`${dateString}T00:00:00`) : new Date(dateString);
+
+  const now = new Date();
+  const workoutMidnight = new Date(
+    workoutDate.getFullYear(),
+    workoutDate.getMonth(),
+    workoutDate.getDate(),
+  ).getTime();
+  const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const diffDays = Math.round((todayMidnight - workoutMidnight) / (1000 * 60 * 60 * 24));
+
+  if (diffDays <= 0) return "today";
+  if (diffDays === 1) return "yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 14) return "1 week ago";
+  if (diffDays < 35) return `${Math.floor(diffDays / 7)} weeks ago`;
+
+  return workoutDate.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}


### PR DESCRIPTION
## Summary

- Fixes #133 — workouts done today were rendering as "yesterday" in the dashboard Recent Workouts list.
- Two root causes: `new Date("YYYY-MM-DD")` parses as UTC midnight (not local), and `relativeTime` compared rolling 24-hour windows instead of local calendar days. Together they produced `diffDay === 1` for a workout the user did the same day.
- Extracts the helper into `src/lib/relativeTime.ts` as `formatRelativeTime` — the same buggy function existed in both `RecentWorkoutsList.tsx` and `ExternalActivitiesList.tsx`. Dedups and fixes in one place.
- Rewrites the helper to parse bare YYYY-MM-DD as local midnight and compare calendar days. Collapses sub-day buckets ("5m ago", "2h ago") into "today" because the input field only carries day-level precision — the old sub-day labels were always lying.
- Adds a `text-2xs` (11px) token to `@theme` and migrates the 5 files that used the arbitrary `text-[11px]` value, per the design-token scale rule.

## Out of scope

`completedWorkouts.date` is still a UTC-sliced bare date at `convex/tonal/historySyncCore.ts:37`. For users west of UTC training late at night, the stored date can still be a calendar day ahead of their local date. Fixing that properly requires the user's timezone at sync time and a backfill migration; not included here. Tracked separately.

## Test plan

- [x] New unit tests in `src/lib/relativeTime.test.ts` cover the #133 reproduction, yesterday / 2-6d ago, the calendar-vs-rolling-24h distinction, and full-ISO input.
- [x] `npx vitest run --project frontend` — 264/264 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/` — clean
- [ ] Smoke-test the dashboard in a browser after merge — confirm today's workouts render "today".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Introduced a new standardized small-text size variable and updated typography across multiple interface components for visual consistency.

* **Refactor**
  * Consolidated shared relative time formatting logic into a centralized utility function.

* **Tests**
  * Added comprehensive test suite for relative time formatting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->