### PR TITLE
feat(ai): attribute transient provider outages to the upstream, not Roni

### DIFF
--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -6,6 +6,7 @@ import {
   isTransientError,
   withByokErrorSanitization,
 } from "./resilience";
+import { buildProviderTransientMessage, classifyTransientError } from "./transientErrors";
 
 function apiCallError(overrides: {
   statusCode?: number;
@@ -225,6 +226,97 @@ describe("buildByokErrorMessage", () => {
 
     expect(msg).toContain("OpenAI");
     expect(msg).toContain("(https://platform.openai.com/settings/organization/billing)");
+  });
+});
+
+describe("classifyTransientError", () => {
+  it("returns null for non-transient errors", () => {
+    expect(classifyTransientError(new Error("database blew up"))).toBeNull();
+  });
+
+  it("returns 'provider_overload' for 'high demand'", () => {
+    expect(
+      classifyTransientError(new Error("This model is currently experiencing high demand.")),
+    ).toBe("provider_overload");
+  });
+
+  it("returns 'provider_overload' for 'overloaded'", () => {
+    expect(classifyTransientError(new Error("The model is overloaded, try again."))).toBe(
+      "provider_overload",
+    );
+  });
+
+  it("returns 'provider_overload' for 'try again later'", () => {
+    expect(classifyTransientError(new Error("Service busy — please try again later."))).toBe(
+      "provider_overload",
+    );
+  });
+
+  it("returns 'rate_limit' for explicit rate limit text", () => {
+    expect(classifyTransientError(new Error("Rate limit exceeded"))).toBe("rate_limit");
+  });
+
+  it("returns 'rate_limit' for a 429 APICallError", () => {
+    expect(
+      classifyTransientError(apiCallError({ statusCode: 429, isRetryable: true, message: "" })),
+    ).toBe("rate_limit");
+  });
+
+  it("returns 'timeout' for AbortError name", () => {
+    const error = new Error("aborted");
+    error.name = "AbortError";
+    expect(classifyTransientError(error)).toBe("timeout");
+  });
+
+  it("returns 'network' for fetch TypeError", () => {
+    expect(classifyTransientError(new TypeError("fetch failed"))).toBe("network");
+  });
+
+  it("returns 'server_error' for a bare 500", () => {
+    expect(classifyTransientError(Object.assign(new Error("Internal"), { status: 500 }))).toBe(
+      "server_error",
+    );
+  });
+
+  it("falls back to 'provider_overload' for a retryable APICallError with no matching signal", () => {
+    expect(
+      classifyTransientError(
+        apiCallError({ statusCode: 418, isRetryable: true, message: "teapot" }),
+      ),
+    ).toBe("provider_overload");
+  });
+});
+
+describe("buildProviderTransientMessage", () => {
+  it("names the provider and blames upstream for overload", () => {
+    const msg = buildProviderTransientMessage("provider_overload", "gemini");
+    expect(msg).toContain("Google Gemini");
+    expect(msg).toContain("not Roni");
+    expect(msg).toContain("(/settings)");
+  });
+
+  it("keeps rate-limit messaging short and directive", () => {
+    const msg = buildProviderTransientMessage("rate_limit", "claude");
+    expect(msg).toContain("Anthropic Claude");
+    expect(msg).toContain("rate-limited");
+  });
+
+  it("phrases timeouts as being on the provider's side", () => {
+    const msg = buildProviderTransientMessage("timeout", "openai");
+    expect(msg).toContain("OpenAI");
+    expect(msg).toContain("timed out");
+  });
+
+  it("labels network hiccups against the provider name", () => {
+    const msg = buildProviderTransientMessage("network", "openrouter");
+    expect(msg).toContain("OpenRouter");
+    expect(msg.toLowerCase()).toContain("network");
+  });
+
+  it("attributes server errors to the provider", () => {
+    const msg = buildProviderTransientMessage("server_error", "gemini");
+    expect(msg).toContain("Google Gemini");
+    expect(msg).toContain("not Roni");
   });
 });
 

--- a/convex/ai/resilience.test.ts
+++ b/convex/ai/resilience.test.ts
@@ -61,6 +61,16 @@ describe("isTransientError", () => {
     expect(isTransientError(error)).toBe(true);
   });
 
+  it("returns true for 504 gateway timeout with non-pattern message", () => {
+    const error = Object.assign(new Error("Bad"), { status: 504 });
+    expect(isTransientError(error)).toBe(true);
+  });
+
+  it("returns true for 529 Anthropic overloaded via bare status", () => {
+    const error = Object.assign(new Error("overload"), { status: 529 });
+    expect(isTransientError(error)).toBe(true);
+  });
+
   it("returns true for timeout errors", () => {
     const error = new Error("Request timed out");
     error.name = "TimeoutError";
@@ -274,6 +284,12 @@ describe("classifyTransientError", () => {
 
   it("returns 'server_error' for a bare 500", () => {
     expect(classifyTransientError(Object.assign(new Error("Internal"), { status: 500 }))).toBe(
+      "server_error",
+    );
+  });
+
+  it("returns 'server_error' for a bare 504 gateway timeout", () => {
+    expect(classifyTransientError(Object.assign(new Error("Bad"), { status: 504 }))).toBe(
       "server_error",
     );
   });

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -176,7 +176,10 @@ export async function streamWithRetry(
       accumulator.markFallback("transient_exhaustion");
       const final = await runAttempt(fallbackAgent);
       if (final.done) return accumulator;
-      // Fallback also hit a transient error — terminal now, surface the generic message.
+      // Fallback also hit a transient error. Classify it, record the terminal
+      // class on the accumulator + span, then hand off to reportError — which
+      // surfaces a provider-attributed message for transient outages and falls
+      // back to the generic "trouble right now" message otherwise.
       const cls = errorClassName(final.error);
       accumulator.setTerminalErrorClass(cls);
       span.recordError(cls);

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -17,7 +17,11 @@ import { type ProviderId } from "./providers";
 import { type AccumulatorInit, RunAccumulator } from "./runTelemetry";
 import { buildByokErrorMessage, classifyByokError } from "./byokErrors";
 import { runInRunSpan } from "./otel";
-import { isTransientError } from "./transientErrors";
+import {
+  buildProviderTransientMessage,
+  classifyTransientError,
+  isTransientError,
+} from "./transientErrors";
 
 // Re-export for backwards compatibility with existing callers/tests.
 export { buildByokErrorMessage, classifyByokError, withByokErrorSanitization } from "./byokErrors";
@@ -333,11 +337,22 @@ async function tryReportByok(ctx: ActionCtx, report: ErrorReport): Promise<boole
 async function reportError(ctx: ActionCtx, report: ErrorReport): Promise<void> {
   const reason = report.error instanceof Error ? report.error.message : String(report.error);
   await finalizePendingMessages(ctx, report.threadId, reason);
+
+  const transientKind = classifyTransientError(report.error);
+  const content = transientKind
+    ? buildProviderTransientMessage(transientKind, report.provider)
+    : AI_ERROR_MESSAGE;
+
   await saveMessage(ctx, components.agent, {
     threadId: report.threadId,
     userId: report.userId,
-    message: { role: "assistant", content: AI_ERROR_MESSAGE },
+    message: { role: "assistant", content },
   });
+
+  // Upstream provider outages already surface to the user with an attributed
+  // message; paging Discord on every Gemini/Claude capacity blip is noise.
+  if (transientKind) return;
+
   await ctx.runAction(internal.discord.notifyError, {
     source: "streamWithRetry",
     message: reason,

--- a/convex/ai/transientErrors.ts
+++ b/convex/ai/transientErrors.ts
@@ -5,8 +5,6 @@ import { getProviderConfig, type ProviderId } from "./providers";
 // Transient error classification
 // ---------------------------------------------------------------------------
 
-const TRANSIENT_STATUS_CODES = new Set([429, 500, 502, 503]);
-
 const TRANSIENT_MESSAGE_PATTERNS = [
   "high demand",
   "unavailable",
@@ -33,7 +31,9 @@ export function isTransientError(error: unknown): boolean {
     if (TRANSIENT_MESSAGE_PATTERNS.some((p) => lower.includes(p))) return true;
 
     const status = (error as Error & { status?: number }).status;
-    if (typeof status === "number" && TRANSIENT_STATUS_CODES.has(status)) return true;
+    if (typeof status === "number") {
+      if (status === 429 || (status >= 500 && status <= 599)) return true;
+    }
   }
 
   return false;

--- a/convex/ai/transientErrors.ts
+++ b/convex/ai/transientErrors.ts
@@ -1,4 +1,5 @@
 import { APICallError } from "@ai-sdk/provider";
+import { getProviderConfig, type ProviderId } from "./providers";
 
 // ---------------------------------------------------------------------------
 // Transient error classification
@@ -14,6 +15,8 @@ const TRANSIENT_MESSAGE_PATTERNS = [
   "rate limit",
   "resource_exhausted",
 ];
+
+const OVERLOAD_MESSAGE_PATTERNS = ["high demand", "unavailable", "overloaded", "try again later"];
 
 export function isTransientError(error: unknown): boolean {
   // Prefer the SDK's own retry decision — it knows provider-specific cases
@@ -34,4 +37,68 @@ export function isTransientError(error: unknown): boolean {
   }
 
   return false;
+}
+
+// ---------------------------------------------------------------------------
+// Transient error kind — drives user-facing messaging
+// ---------------------------------------------------------------------------
+
+export type TransientErrorKind =
+  | "provider_overload"
+  | "rate_limit"
+  | "timeout"
+  | "network"
+  | "server_error";
+
+function extractStatus(error: unknown): number | undefined {
+  if (APICallError.isInstance(error)) return error.statusCode;
+  if (error instanceof Error) return (error as Error & { status?: number }).status;
+  return undefined;
+}
+
+export function classifyTransientError(error: unknown): TransientErrorKind | null {
+  if (!isTransientError(error)) return null;
+
+  if (error instanceof TypeError && error.message.includes("fetch")) return "network";
+
+  if (error instanceof Error) {
+    if (error.name === "TimeoutError" || error.name === "AbortError") return "timeout";
+    const lower = error.message.toLowerCase();
+    if (lower.includes("timeout") || lower.includes("aborted")) return "timeout";
+    if (OVERLOAD_MESSAGE_PATTERNS.some((p) => lower.includes(p))) return "provider_overload";
+    if (lower.includes("rate limit") || lower.includes("resource_exhausted")) return "rate_limit";
+  }
+
+  const status = extractStatus(error);
+  if (status === 429) return "rate_limit";
+  if (typeof status === "number" && status >= 500) return "server_error";
+
+  // Transient but unmatched (e.g., APICallError with isRetryable=true and no
+  // recognizable message/status). Overload is the safest user-facing framing.
+  return "provider_overload";
+}
+
+// ---------------------------------------------------------------------------
+// User-facing messages that attribute the outage to the upstream provider
+// ---------------------------------------------------------------------------
+
+const SETTINGS_LINK = "[Settings](/settings)";
+
+export function buildProviderTransientMessage(
+  kind: TransientErrorKind,
+  provider: ProviderId,
+): string {
+  const label = getProviderConfig(provider).label;
+  switch (kind) {
+    case "provider_overload":
+      return `**${label} is experiencing high demand right now** — this is on their end, not Roni. Try again in a moment, or switch providers in ${SETTINGS_LINK} if it keeps happening.`;
+    case "rate_limit":
+      return `**${label} rate-limited this request.** Give it a minute and try again.`;
+    case "timeout":
+      return `**That request timed out on ${label}'s side.** Try again — a shorter message sometimes helps.`;
+    case "network":
+      return `**Network hiccup talking to ${label}.** Try again in a moment.`;
+    case "server_error":
+      return `**${label} returned a server error.** That's on their end, not Roni. Try again shortly.`;
+  }
 }

--- a/convex/chatHelpers.test.ts
+++ b/convex/chatHelpers.test.ts
@@ -51,6 +51,28 @@ describe("getScheduledFailureContent", () => {
       getScheduledFailureContent(new Error("You exceeded your current quota: insufficient_quota.")),
     ).toBe("I'm having trouble right now. Please try again in a moment.");
   });
+
+  it("attributes 'high demand' errors to the upstream provider when provider is known", () => {
+    const msg = getScheduledFailureContent(
+      new Error("This model is currently experiencing high demand. Please try again later."),
+      "gemini",
+    );
+    expect(msg).toContain("Google Gemini");
+    expect(msg).toContain("not Roni");
+    expect(msg).toContain("(/settings)");
+  });
+
+  it("attributes transient server errors to the provider", () => {
+    const error = Object.assign(new Error("Internal"), { status: 503 });
+    const msg = getScheduledFailureContent(error, "claude");
+    expect(msg).toContain("Anthropic Claude");
+  });
+
+  it("stays generic for transient errors when provider is unknown", () => {
+    expect(
+      getScheduledFailureContent(new Error("This model is currently experiencing high demand.")),
+    ).toBe("I'm having trouble right now. Please try again in a moment.");
+  });
 });
 
 describe("shouldNotifyScheduledFailure", () => {
@@ -70,5 +92,14 @@ describe("shouldNotifyScheduledFailure", () => {
 
   it("notifies on unexpected failures", () => {
     expect(shouldNotifyScheduledFailure(new Error("database blew up"))).toBe(true);
+  });
+
+  it("does not notify on transient provider outages", () => {
+    expect(
+      shouldNotifyScheduledFailure(new Error("This model is currently experiencing high demand.")),
+    ).toBe(false);
+    expect(
+      shouldNotifyScheduledFailure(Object.assign(new Error("Unavailable"), { status: 503 })),
+    ).toBe(false);
   });
 });

--- a/convex/chatHelpers.ts
+++ b/convex/chatHelpers.ts
@@ -8,6 +8,11 @@ import { type ProviderKeyResult, resolveProviderKey } from "./byok";
 // pull Phoenix-otel's Node-only deps into this V8-runtime module's graph.
 import { buildByokErrorMessage, type ByokErrorCode, classifyByokError } from "./ai/byokErrors";
 import type { ProviderId } from "./ai/providers";
+import {
+  buildProviderTransientMessage,
+  classifyTransientError,
+  isTransientError,
+} from "./ai/transientErrors";
 
 export const MAX_IMAGES_PER_MESSAGE = 4;
 
@@ -118,6 +123,9 @@ export function getScheduledFailureContent(error: unknown, provider?: ProviderId
   if (provider) {
     const classified = classifyByokError(error);
     if (classified) return buildByokErrorMessage(classified, provider);
+
+    const transientKind = classifyTransientError(error);
+    if (transientKind) return buildProviderTransientMessage(transientKind, provider);
   }
 
   return CHAT_ERROR_MESSAGE;
@@ -126,7 +134,12 @@ export function getScheduledFailureContent(error: unknown, provider?: ProviderId
 export function shouldNotifyScheduledFailure(error: unknown): boolean {
   const code = error instanceof Error ? error.message : String(error);
   if (EXPECTED_SCHEDULED_FAILURE_CODES.has(code)) return false;
-  return classifyByokError(error) === null;
+  if (classifyByokError(error) !== null) return false;
+  // Transient provider outages are handled inside streamWithRetry; if one
+  // reaches persistScheduledFailure, the user already sees an attributed
+  // message — no human needs to be paged.
+  if (isTransientError(error)) return false;
+  return true;
 }
 
 export async function persistScheduledFailure(args: {


### PR DESCRIPTION
## Summary

- Users now see provider-attributed messages (e.g. "**Google Gemini is experiencing high demand right now** — this is on their end, not Roni") when the coach hits a transient upstream failure, instead of a generic "I'm having trouble" that reads as a Roni bug.
- Discord stops getting paged for these — the user already sees an actionable message and streamWithRetry's retry/fallback handles recovery.

## Changes

- **`convex/ai/transientErrors.ts`** — new `TransientErrorKind` + `classifyTransientError(error)` (kinds: `provider_overload`, `rate_limit`, `timeout`, `network`, `server_error`) and `buildProviderTransientMessage(kind, provider)` that names the provider via `getProviderConfig`.
- **`convex/ai/resilience.ts`** — `reportError` now saves the attributed message when the terminal error is transient, and returns early to suppress the Discord notification in that case.
- **`convex/chatHelpers.ts`** — `getScheduledFailureContent` returns the attributed message when provider is known and the error classifies as transient; `shouldNotifyScheduledFailure` returns `false` for transient errors so the outer catch in `processMessage` stops paging too.
- **Tests** — 15 new cases covering the classifier across status codes / message patterns, message shape per provider (gemini/claude/openai/openrouter), and both user-facing entry points plus Discord-suppress assertions.

## Checklist

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (1146 tests, 15 new)
- [x] New logic has tests (classifier + builder + both wiring points, happy + error paths)
- [x] No file exceeds the 300-line soft cap (largest touched: \`transientErrors.ts\` at 105 lines)
- [x] No file exceeds the 400-line hard cap
- [x] Functions stay near the 60-line convention
- [x] No new \`any\` types; no new \`as\` casts
- [x] No UI changes
- [x] Commit follows conventional format
- [x] No unused exports or dead code

## Test Plan

- Unit: \`npx vitest run convex/ai/resilience.test.ts convex/chatHelpers.test.ts\` — 68 passed.
- Full suite: \`npm test\` — 1146 pass, 13 pre-existing skips.
- Manual trace: the Discord alerts from 2026-04-21 08:24 / 08:43 MDT ("This model is currently experiencing high demand...") would now surface in-thread as a Gemini-attributed message and would not page Discord, since \`isTransientError\` already matches and \`shouldNotifyScheduledFailure\`/\`reportError\` both short-circuit on that signal.
- No schema changes; fully backwards compatible with BYOK error handling (BYOK classification runs first in both paths, transient only kicks in when BYOK returns null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transient error classification system that categorizes provider issues (overload, rate limits, timeouts, network, server errors).
  * Provider-specific error messages that clearly attribute issues to upstream providers with contextual wording.

* **Bug Fixes**
  * Reduced false notifications for transient provider outages.
  * Improved error handling to distinguish between transient and permanent failures.

* **Tests**
  * Extended test coverage for error classification and messaging logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->