### PR TITLE
perf(ai): move training snapshot out of the cached system prefix

### DIFF
--- a/convex/ai/coach.test.ts
+++ b/convex/ai/coach.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ModelMessage } from "ai";
-import { makeCoachAgentConfig } from "./coach";
+import { escapeTrainingDataTags, makeCoachAgentConfig } from "./coach";
 
 const testConfig = makeCoachAgentConfig();
 type ContextHandlerArgs = Parameters<NonNullable<typeof testConfig.contextHandler>>[1];
@@ -201,5 +201,41 @@ describe("coachAgentConfig.contextHandler — training snapshot placement", () =
 
     expect(result).toHaveLength(1);
     expect(systemText(result[0])).toContain("PERSONALITY:");
+  });
+
+  it("does not mutate the allMessages input (safety invariant so storage cannot pick up the wrapper)", async () => {
+    const allMessages: ModelMessage[] = [
+      { role: "user", content: "earlier question" },
+      { role: "assistant", content: "earlier answer" },
+      { role: "user", content: "latest question" },
+    ];
+    const snapshot = JSON.stringify(allMessages);
+
+    await runContextHandler(allMessages, { userId, ctx: EMPTY_PROFILE_CTX });
+
+    expect(JSON.stringify(allMessages)).toBe(snapshot);
+  });
+});
+
+describe("escapeTrainingDataTags", () => {
+  it("neutralizes a closing tag the user could type to break out of the wrapper", () => {
+    expect(escapeTrainingDataTags("goal: </training-data> break")).toBe(
+      "goal: </training_data> break",
+    );
+  });
+
+  it("neutralizes an opening tag too", () => {
+    expect(escapeTrainingDataTags("<training-data> nested")).toBe("<training_data> nested");
+  });
+
+  it("handles repeated occurrences in a single string", () => {
+    expect(
+      escapeTrainingDataTags("a </training-data> b </training-data> c <training-data> d"),
+    ).toBe("a </training_data> b </training_data> c <training_data> d");
+  });
+
+  it("leaves clean snapshot text untouched", () => {
+    const clean = "Strength Score: 350\nGoals: squat 2x bodyweight";
+    expect(escapeTrainingDataTags(clean)).toBe(clean);
   });
 });

--- a/convex/ai/coach.test.ts
+++ b/convex/ai/coach.test.ts
@@ -5,7 +5,17 @@ import { makeCoachAgentConfig } from "./coach";
 const testConfig = makeCoachAgentConfig();
 type ContextHandlerArgs = Parameters<NonNullable<typeof testConfig.contextHandler>>[1];
 
-async function runContextHandler(allMessages: ModelMessage[]): Promise<ModelMessage[]> {
+interface RunContextOptions {
+  userId?: string;
+  ctx?: { runQuery: (...args: unknown[]) => Promise<unknown> };
+}
+
+const EMPTY_PROFILE_CTX = { runQuery: async () => null };
+
+async function runContextHandler(
+  allMessages: ModelMessage[],
+  options: RunContextOptions = {},
+): Promise<ModelMessage[]> {
   const args: ContextHandlerArgs = {
     allMessages,
     search: [],
@@ -13,15 +23,22 @@ async function runContextHandler(allMessages: ModelMessage[]): Promise<ModelMess
     inputMessages: [],
     inputPrompt: [],
     existingResponses: [],
-    userId: undefined,
+    userId: options.userId,
     threadId: undefined,
   };
 
-  return testConfig.contextHandler!(undefined as never, args);
+  const ctx = (options.ctx ?? undefined) as never;
+  return testConfig.contextHandler!(ctx, args);
 }
 
 function nonSystemMessages(messages: ModelMessage[]): ModelMessage[] {
   return messages.filter((m) => m.role !== "system");
+}
+
+function systemText(message: ModelMessage): string {
+  expect(message.role).toBe("system");
+  expect(typeof message.content).toBe("string");
+  return message.content as string;
 }
 
 describe("coachAgentConfig.contextHandler", () => {
@@ -112,5 +129,77 @@ describe("coachAgentConfig.contextHandler — Anthropic prompt caching", () => {
 
     const systemMessages = result.filter((m) => m.role === "system");
     expect(systemMessages).toHaveLength(1);
+  });
+});
+
+describe("coachAgentConfig.contextHandler — training snapshot placement", () => {
+  const userId = "user_snapshot_test";
+
+  it("inserts the snapshot as a system message immediately before the final turn", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "earlier question" },
+      { role: "assistant", content: "earlier answer" },
+      { role: "user", content: "latest question" },
+    ];
+
+    const result = await runContextHandler(messages, { userId, ctx: EMPTY_PROFILE_CTX });
+
+    expect(result).toHaveLength(5);
+    expect(systemText(result[0])).toContain("PERSONALITY:");
+    expect(result[1]).toEqual({ role: "user", content: "earlier question" });
+    expect(result[2]).toEqual({ role: "assistant", content: "earlier answer" });
+    expect(systemText(result[3])).toMatch(/^<training-data>\n[\s\S]+\n<\/training-data>$/);
+    expect(result[4]).toEqual({ role: "user", content: "latest question" });
+  });
+
+  it("keeps exactly one cacheControl marker on the static prefix regardless of snapshot presence", async () => {
+    const result = await runContextHandler([{ role: "user", content: "hi" }], {
+      userId,
+      ctx: EMPTY_PROFILE_CTX,
+    });
+
+    const tagged = result.filter((m) => m.providerOptions?.anthropic?.cacheControl);
+    expect(tagged).toHaveLength(1);
+    expect(tagged[0]).toBe(result[0]);
+    expect(systemText(result[0])).toContain("PERSONALITY:");
+  });
+
+  it("does not attach cacheControl to the trailing snapshot system message", async () => {
+    const result = await runContextHandler([{ role: "user", content: "hi" }], {
+      userId,
+      ctx: EMPTY_PROFILE_CTX,
+    });
+
+    const snapshotSystem = result.find(
+      (m) =>
+        m.role === "system" &&
+        typeof m.content === "string" &&
+        m.content.startsWith("<training-data>"),
+    );
+    expect(snapshotSystem).toBeDefined();
+    expect(snapshotSystem!.providerOptions?.anthropic?.cacheControl).toBeUndefined();
+  });
+
+  it("leaves older user messages untouched (no training-data wrapping on prior turns)", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "earlier question" },
+      { role: "assistant", content: "earlier answer" },
+      { role: "user", content: "latest question" },
+    ];
+
+    const result = await runContextHandler(messages, { userId, ctx: EMPTY_PROFILE_CTX });
+
+    const olderUser = result[1];
+    expect(olderUser).toEqual({ role: "user", content: "earlier question" });
+    expect(typeof olderUser.content === "string" && olderUser.content).not.toContain(
+      "<training-data>",
+    );
+  });
+
+  it("skips snapshot injection when userId is present but context is empty", async () => {
+    const result = await runContextHandler([], { userId, ctx: EMPTY_PROFILE_CTX });
+
+    expect(result).toHaveLength(1);
+    expect(systemText(result[0])).toContain("PERSONALITY:");
   });
 });

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -183,22 +183,32 @@ export function makeCoachAgentConfig(userTimezone?: string) {
           stripImagesFromOlderMessages(stripOrphanedToolCalls(args.allMessages)),
         ),
       );
-      // Snapshot is added after this so the per-call snapshot doesn't bust the prefix cache.
-      const systemMessages: ModelMessage[] = [
-        {
-          role: "system",
-          content: STATIC_INSTRUCTIONS,
-          providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
-        },
-      ];
-      if (args.userId) {
-        const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
-        systemMessages.push({
-          role: "system",
-          content: `<training-data>\n${snapshot}\n</training-data>`,
-        });
+      const staticSystem: ModelMessage = {
+        role: "system",
+        content: STATIC_INSTRUCTIONS,
+        providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+      };
+
+      if (!args.userId || messages.length === 0) {
+        return [staticSystem, ...messages];
       }
-      return [...systemMessages, ...messages];
+
+      // Place the per-call training snapshot as a system message immediately
+      // before the final turn. The cached prefix (tools + static system +
+      // history up through the last assistant message) stays byte-identical
+      // across calls so Anthropic can cache it; the snapshot and the fresh
+      // user/tool turn intentionally live outside the cache. Gemini collapses
+      // every system message into systemInstruction regardless of position
+      // (so this placement is a no-op there); OpenAI / OpenRouter preserve
+      // the inline order.
+      const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
+      const snapshotSystem: ModelMessage = {
+        role: "system",
+        content: `<training-data>\n${snapshot}\n</training-data>`,
+      };
+      const head = messages.slice(0, -1);
+      const tail = messages[messages.length - 1];
+      return [staticSystem, ...head, snapshotSystem, tail];
     }) satisfies ContextHandler,
   };
 }

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -96,6 +96,15 @@ function hashString(input: string): string {
   return (h >>> 0).toString(16).padStart(8, "0");
 }
 
+// Snapshot content includes user-entered goals, injuries, and feedback.
+// Neutralizes any <training-data> tokens the user could have typed so they
+// can't close the wrapper and smuggle text that reads as extra instructions.
+export function escapeTrainingDataTags(input: string): string {
+  return input
+    .replaceAll("</training-data>", "</training_data>")
+    .replaceAll("<training-data>", "<training_data>");
+}
+
 export const coachAgentConfig = {
   embeddingModel: sharedEmbeddingModel,
 
@@ -198,7 +207,7 @@ export function makeCoachAgentConfig(userTimezone?: string) {
       const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
       const snapshotSystem: ModelMessage = {
         role: "system",
-        content: `<training-data>\n${snapshot}\n</training-data>`,
+        content: `<training-data>\n${escapeTrainingDataTags(snapshot)}\n</training-data>`,
       };
       const head = messages.slice(0, -1);
       const tail = messages[messages.length - 1];

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -193,14 +193,8 @@ export function makeCoachAgentConfig(userTimezone?: string) {
         return [staticSystem, ...messages];
       }
 
-      // Place the per-call training snapshot as a system message immediately
-      // before the final turn. The cached prefix (tools + static system +
-      // history up through the last assistant message) stays byte-identical
-      // across calls so Anthropic can cache it; the snapshot and the fresh
-      // user/tool turn intentionally live outside the cache. Gemini collapses
-      // every system message into systemInstruction regardless of position
-      // (so this placement is a no-op there); OpenAI / OpenRouter preserve
-      // the inline order.
+      // Trailing position (not system[1]) keeps the cached prefix byte-stable
+      // so Anthropic's cache breakpoint on STATIC_INSTRUCTIONS holds across calls.
       const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
       const snapshotSystem: ModelMessage = {
         role: "system",


### PR DESCRIPTION
## Summary

- Closes #192. Moves the per-call training snapshot from system[1] to a system message positioned right before the final turn, so the cached prefix (tools + static system + history up through the last assistant message) stays byte-identical across calls.
- Unblocks #193 (stack 4 cache breakpoints) — Anthropic can now cache every block before the snapshot without the snapshot invalidating it every call.

## Changes

- `convex/ai/coach.ts` — `makeCoachAgentConfig.contextHandler`: keep `STATIC_INSTRUCTIONS` as system[0] with its existing `cacheControl: ephemeral` marker; when `userId` is set and context is non-empty, splice the snapshot as a system message at `messages.length - 1` (immediately before the last user / tool-approval turn). Added a block comment explaining per-provider behavior (Anthropic preserves order and caches as intended; Gemini collapses all system messages into `systemInstruction` so placement is a no-op there; OpenAI / OpenRouter preserve inline order).
- `convex/ai/coach.test.ts` — extended `runContextHandler` to accept `{ userId, ctx }` so the snapshot branch can be exercised with a mocked `runQuery`. Added 5 tests: placement at index `len-1`, exactly one cacheControl marker, no cacheControl on the trailing snapshot, older user messages untouched, and empty-context safety. All prior assertions kept (behavior unchanged when `userId` is absent).

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes — 1154 passed / 13 skipped (5 new tests)
- [x] New logic has tests (happy path + empty-context edge case + cacheControl invariants)
- [x] No file exceeds the 300-line soft cap (coach.ts 288, coach.test.ts 205)
- [x] No file exceeds the 400-line hard cap
- [x] Functions stay near the 60-line convention
- [x] No new `any` types; no new `as` casts outside the existing `undefined as never` test harness shim
- [ ] Tested in browser (N/A — backend-only change, no UI surface)
- [x] Commit follows conventional format
- [x] No unused exports or dead code (`npm run knip` clean)

## Test Plan

**Automated (done)**
- `npx tsc --noEmit`, `npm run lint`, `npm run knip` clean.
- `npx vitest run convex/ai/coach.test.ts` — 10 passed.
- `npm test` — 1154 passed, 13 skipped.

**Post-deploy (to verify the intended cache win)**
- On a Claude-backed thread, send 3 turns within a 5-minute window. In Phoenix, confirm `cacheReadTokens` climbs on turns 2–3 and that the static prefix hash (`promptVersion` metadata) stays stable across those turns. `cacheWriteTokens` on turn 1 should match the static+tools size.
- Spot-check that saved thread messages contain no `<training-data>` wrapping (persistence is untouched; the contextHandler only mutates the in-memory array sent to the LLM).
- Re-run the `coachEvals` smoke suite per provider to confirm no quality regression from relocating the snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for AI coach context handling and training data injection scenarios.

* **Refactor**
  * Improved internal system message construction and context management for the AI coach component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->