### PR TITLE
fix(ai): place training snapshot in system prefix (Gemini rejects mid-conversation system messages)

### DIFF
--- a/convex/ai/coach.test.ts
+++ b/convex/ai/coach.test.ts
@@ -135,7 +135,7 @@ describe("coachAgentConfig.contextHandler — Anthropic prompt caching", () => {
 describe("coachAgentConfig.contextHandler — training snapshot placement", () => {
   const userId = "user_snapshot_test";
 
-  it("inserts the snapshot as a system message immediately before the final turn", async () => {
+  it("inserts the snapshot as a system message directly after the static prefix (Gemini rejects mid-conversation system messages)", async () => {
     const messages: ModelMessage[] = [
       { role: "user", content: "earlier question" },
       { role: "assistant", content: "earlier answer" },
@@ -146,10 +146,24 @@ describe("coachAgentConfig.contextHandler — training snapshot placement", () =
 
     expect(result).toHaveLength(5);
     expect(systemText(result[0])).toContain("PERSONALITY:");
-    expect(result[1]).toEqual({ role: "user", content: "earlier question" });
-    expect(result[2]).toEqual({ role: "assistant", content: "earlier answer" });
-    expect(systemText(result[3])).toMatch(/^<training-data>\n[\s\S]+\n<\/training-data>$/);
+    expect(systemText(result[1])).toMatch(/^<training-data>\n[\s\S]+\n<\/training-data>$/);
+    expect(result[2]).toEqual({ role: "user", content: "earlier question" });
+    expect(result[3]).toEqual({ role: "assistant", content: "earlier answer" });
     expect(result[4]).toEqual({ role: "user", content: "latest question" });
+  });
+
+  it("places every system message at the start of the conversation (no mid-conversation system messages)", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "earlier question" },
+      { role: "assistant", content: "earlier answer" },
+      { role: "user", content: "latest question" },
+    ];
+
+    const result = await runContextHandler(messages, { userId, ctx: EMPTY_PROFILE_CTX });
+
+    const firstNonSystem = result.findIndex((m) => m.role !== "system");
+    const remaining = result.slice(firstNonSystem);
+    expect(remaining.every((m) => m.role !== "system")).toBe(true);
   });
 
   it("keeps exactly one cacheControl marker on the static prefix regardless of snapshot presence", async () => {
@@ -189,7 +203,7 @@ describe("coachAgentConfig.contextHandler — training snapshot placement", () =
 
     const result = await runContextHandler(messages, { userId, ctx: EMPTY_PROFILE_CTX });
 
-    const olderUser = result[1];
+    const olderUser = result[2];
     expect(olderUser).toEqual({ role: "user", content: "earlier question" });
     expect(typeof olderUser.content === "string" && olderUser.content).not.toContain(
       "<training-data>",

--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -202,16 +202,15 @@ export function makeCoachAgentConfig(userTimezone?: string) {
         return [staticSystem, ...messages];
       }
 
-      // Trailing position (not system[1]) keeps the cached prefix byte-stable
-      // so Anthropic's cache breakpoint on STATIC_INSTRUCTIONS holds across calls.
+      // Gemini rejects system messages anywhere except the start of the
+      // conversation (UnsupportedFunctionalityError), so the snapshot must sit
+      // in the system prefix even though it busts Anthropic's prefix cache.
       const snapshot = await buildTrainingSnapshot(ctx, args.userId, userTimezone);
       const snapshotSystem: ModelMessage = {
         role: "system",
         content: `<training-data>\n${escapeTrainingDataTags(snapshot)}\n</training-data>`,
       };
-      const head = messages.slice(0, -1);
-      const tail = messages[messages.length - 1];
-      return [staticSystem, ...head, snapshotSystem, tail];
+      return [staticSystem, snapshotSystem, ...messages];
     }) satisfies ContextHandler,
   };
 }


### PR DESCRIPTION
## Summary

Every coach turn after the first has been failing with:

```
'system messages are only supported at the beginning of the conversation' functionality not supported
```

surfaced through `chatProcessing.processMessage`.

### Root cause

#256 (`perf(ai): move training snapshot out of the cached system prefix`) changed `makeCoachAgentConfig`'s `contextHandler` in `convex/ai/coach.ts` to splice the training snapshot as a system message **right before the final turn** rather than at the start:

```ts
const head = messages.slice(0, -1);
const tail = messages[messages.length - 1];
return [staticSystem, ...head, snapshotSystem, tail];
```

The commit message claimed Gemini "collapses every system message into `systemInstruction` regardless of position, so placement is a no-op." That assumption is wrong. `@ai-sdk/google` throws `UnsupportedFunctionalityError` the moment it sees a `system` role after any non-system message — see `node_modules/@ai-sdk/google/src/convert-to-google-generative-ai-messages.ts:185`:

```ts
if (!systemMessagesAllowed) {
  throw new UnsupportedFunctionalityError({
    functionality:
      'system messages are only supported at the beginning of the conversation',
  });
}
```

So every multi-turn conversation broke on Gemini (the primary provider).

### Fix

Place the snapshot immediately after `STATIC_INSTRUCTIONS`, before any conversation turns:

```ts
return [staticSystem, snapshotSystem, ...messages];
```

This reverts the prefix-cache win from #256 for Anthropic. The trade-off is correctness-over-cost: the cache optimization can be re-attempted later in a Gemini-safe way (e.g. inlining the snapshot into the latest user message, or provider-specific placement).

Tests updated:
- `inserts the snapshot as a system message directly after the static prefix` — asserts new ordering
- New regression test: `places every system message at the start of the conversation (no mid-conversation system messages)` — guards against this class of bug
- `leaves older user messages untouched` — index updated for the new layout

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest --project backend run` — 826 passed, 13 skipped
- [x] `npx vitest run convex/ai/coach.test.ts` — 16 passed
- [ ] Smoke test a multi-turn conversation in the app (unable to run dev server in this environment)

https://claude.ai/code/session_01RgGJmFAiR4gj6YExp8wSjh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgGJmFAiR4gj6YExp8wSjh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined AI coaching message sequencing to improve conversation context management and training data placement.

* **Tests**
  * Added and updated tests to verify proper message ordering and enforce that system messages only appear at conversation start, not mid-conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->