### PR TITLE
feat(ai): internalQuery to measure cache hit rate by provider

### DIFF
--- a/convex/aiUsage.test.ts
+++ b/convex/aiUsage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { BUDGET_WARNING_THRESHOLD, DAILY_TOKEN_BUDGET } from "./aiUsage";
+import {
+  aggregateCacheHitsByProvider,
+  BUDGET_WARNING_THRESHOLD,
+  DAILY_TOKEN_BUDGET,
+} from "./aiUsage";
 
 describe("AI usage constants", () => {
   it("DAILY_TOKEN_BUDGET is 500k", () => {
@@ -12,5 +16,57 @@ describe("AI usage constants", () => {
 
   it("warning threshold is less than budget", () => {
     expect(DAILY_TOKEN_BUDGET * BUDGET_WARNING_THRESHOLD).toBeLessThan(DAILY_TOKEN_BUDGET);
+  });
+});
+
+describe("aggregateCacheHitsByProvider", () => {
+  it("groups rows by provider and computes cache read ratio", () => {
+    const result = aggregateCacheHitsByProvider([
+      { provider: "gemini", inputTokens: 10_000, cacheReadTokens: 8_000, cacheWriteTokens: 0 },
+      { provider: "gemini", inputTokens: 5_000, cacheReadTokens: 1_000, cacheWriteTokens: 0 },
+      { provider: "claude", inputTokens: 8_000, cacheReadTokens: 6_000, cacheWriteTokens: 500 },
+    ]);
+
+    const gemini = result.find((r) => r.provider === "gemini");
+    expect(gemini).toMatchObject({ rows: 2, inputTokens: 15_000, cacheReadTokens: 9_000 });
+    expect(gemini!.cacheReadRatio).toBeCloseTo(9_000 / 15_000);
+
+    const claude = result.find((r) => r.provider === "claude");
+    expect(claude).toMatchObject({
+      rows: 1,
+      inputTokens: 8_000,
+      cacheReadTokens: 6_000,
+      cacheWriteTokens: 500,
+    });
+  });
+
+  it("skips rows with zero input tokens (routing entries)", () => {
+    const result = aggregateCacheHitsByProvider([
+      { provider: "local", inputTokens: 0 },
+      { provider: "gemini", inputTokens: 1_000, cacheReadTokens: 500 },
+    ]);
+
+    expect(result.map((r) => r.provider)).toEqual(["gemini"]);
+  });
+
+  it("returns providers sorted by input token volume descending", () => {
+    const result = aggregateCacheHitsByProvider([
+      { provider: "openai", inputTokens: 1_000 },
+      { provider: "gemini", inputTokens: 100_000 },
+      { provider: "claude", inputTokens: 20_000 },
+    ]);
+
+    expect(result.map((r) => r.provider)).toEqual(["gemini", "claude", "openai"]);
+  });
+
+  it("defaults missing cache fields to zero without NaN ratios", () => {
+    const result = aggregateCacheHitsByProvider([{ provider: "openai", inputTokens: 2_000 }]);
+
+    expect(result[0]).toMatchObject({
+      provider: "openai",
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      cacheReadRatio: 0,
+    });
   });
 });

--- a/convex/aiUsage.ts
+++ b/convex/aiUsage.ts
@@ -76,6 +76,71 @@ export const record = internalMutation({
   },
 });
 
+const DEFAULT_CACHE_RATE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface CacheHitRateRow {
+  provider: string;
+  rows: number;
+  inputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  cacheReadRatio: number;
+}
+
+export interface AiUsageTokenRow {
+  provider: string;
+  inputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+export function aggregateCacheHitsByProvider(rows: AiUsageTokenRow[]): CacheHitRateRow[] {
+  const byProvider = new Map<
+    string,
+    { rows: number; inputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }
+  >();
+  for (const row of rows) {
+    // Routing rows (`provider: "local"`) have no model call, skip them.
+    if (row.inputTokens === 0) continue;
+    const agg = byProvider.get(row.provider) ?? {
+      rows: 0,
+      inputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+    agg.rows += 1;
+    agg.inputTokens += row.inputTokens;
+    agg.cacheReadTokens += row.cacheReadTokens ?? 0;
+    agg.cacheWriteTokens += row.cacheWriteTokens ?? 0;
+    byProvider.set(row.provider, agg);
+  }
+
+  return Array.from(byProvider.entries())
+    .map(([provider, agg]) => ({
+      provider,
+      ...agg,
+      cacheReadRatio: agg.inputTokens === 0 ? 0 : agg.cacheReadTokens / agg.inputTokens,
+    }))
+    .sort((a, b) => b.inputTokens - a.inputTokens);
+}
+
+/**
+ * Aggregate cache-read ratio grouped by provider over a recent window.
+ * Run ad-hoc (e.g. `npx convex run aiUsage:getCacheHitRateByProvider --prod`)
+ * to decide whether explicit provider caching is worth pursuing.
+ */
+export const getCacheHitRateByProvider = internalQuery({
+  args: { windowMs: v.optional(v.number()) },
+  handler: async (ctx, { windowMs = DEFAULT_CACHE_RATE_WINDOW_MS }) => {
+    const since = Date.now() - windowMs;
+    const rows = await ctx.db
+      .query("aiUsage")
+      .withIndex("by_createdAt", (q) => q.gte("createdAt", since))
+      .collect();
+    return aggregateCacheHitsByProvider(rows);
+  },
+});
+
 export const recordRouting = internalMutation({
   args: {
     userId: v.string(),


### PR DESCRIPTION
## Summary

- Groundwork for deciding whether #194 (Gemini explicit context caching) is worth building. Turns out `@ai-sdk/google` already maps `cachedContentTokenCount` to `inputTokenDetails.cacheReadTokens`, which our `usageHandler` already persists into `aiUsage` — the data is there; we just haven't sliced it.
- Adds `aiUsage:getCacheHitRateByProvider`, a lightweight aggregate query. Run it once in prod to see whether Gemini implicit caching is already covering most of the prefix; if yes, #194 is marginal value, if no, it's justified.

## Changes

- `convex/aiUsage.ts` — adds `aggregateCacheHitsByProvider` (pure helper) and `getCacheHitRateByProvider` (internalQuery wrapping it over a time window, default 7 days). Filters routing rows (`inputTokens === 0`) so they don't distort the aggregate.
- `convex/aiUsage.test.ts` — 4 unit tests on the pure aggregation: multi-provider grouping + ratio math, zero-token skip, sort-by-volume order, and missing-cache-fields NaN guard.

## How to use

```
npx convex run aiUsage:getCacheHitRateByProvider --prod
```

Returns an array like:
```
[
  { provider: "gemini", rows: 1840, inputTokens: 12_500_000, cacheReadTokens: 4_300_000, cacheWriteTokens: 0, cacheReadRatio: 0.344 },
  { provider: "claude", rows: 120,  inputTokens:    850_000, cacheReadTokens:   620_000, cacheWriteTokens: 5_400, cacheReadRatio: 0.729 },
  ...
]
```

Interpretation rubric:
- Gemini ratio > ~0.5 on repeat-user traffic: implicit caching is doing most of the job; #194 has thin marginal value, defer.
- Gemini ratio < ~0.2: implicit caching is not hitting for our shape; #194 case firms up, build it.
- In between: judgment call based on token volume.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes — 1172 passed / 13 skipped (4 new tests)
- [x] New logic has tests (pure helper extracted for testability)
- [x] No file exceeds the 300-line soft cap
- [x] No new `any` types; no `as` casts
- [ ] Tested in browser (N/A — backend query only)
- [x] Commit follows conventional format
- [x] No unused exports or dead code (`npm run knip` clean)

## Test Plan

- Unit tests cover the pure aggregation logic (grouping, ratio, sort, zero-token skip, missing-cache-field defaults).
- Post-merge: run `npx convex run aiUsage:getCacheHitRateByProvider --prod`, eyeball the numbers, decide whether to pursue #194.