### PR TITLE
perf(ai): remove exercise catalog from snapshot

### DIFF
--- a/convex/ai/context.test.ts
+++ b/convex/ai/context.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
+import { getFunctionName } from "convex/server";
 import {
-  buildExerciseCatalogSection,
+  buildTrainingSnapshot,
   formatExternalActivityLine,
   getHrIntensityLabel,
   type SnapshotSection,
   trimSnapshot,
 } from "./context";
-import type { ExternalActivity, Movement } from "../tonal/types";
-import type { OwnedAccessories } from "../tonal/accessories";
+import { internal } from "../_generated/api";
+import type { ExternalActivity } from "../tonal/types";
 
 describe("trimSnapshot", () => {
   const makeSection = (priority: number, text: string): SnapshotSection => ({
@@ -144,203 +145,56 @@ describe("formatExternalActivityLine", () => {
   });
 });
 
-// Exercise catalog section
-
-describe("buildExerciseCatalogSection", () => {
-  function makeMovement(overrides: Partial<Movement> = {}): Movement {
-    return {
-      id: "m-1",
-      name: "Bench Press",
-      shortName: "Bench Press",
-      muscleGroups: ["Chest"],
-      skillLevel: 1,
-      publishState: "published",
-      sortOrder: 1,
-      onMachine: true,
-      inFreeLift: false,
-      countReps: true,
-      isTwoSided: false,
-      isBilateral: true,
-      isAlternating: false,
-      descriptionHow: "",
-      descriptionWhy: "",
-      onMachineInfo: {
-        accessory: "Handle",
-        resistanceType: "cable",
-        spotterDisabled: false,
-        eccentricDisabled: false,
-        chainsDisabled: false,
-        burnoutDisabled: false,
+describe("buildTrainingSnapshot", () => {
+  it("does not load or inject the exercise catalog into every chat turn", async () => {
+    const getAllMovementsName = getFunctionName(internal.tonal.movementSync.getAllMovements);
+    const getUserProfileName = getFunctionName(internal.tonal.cache.getUserProfile);
+    const nullableQueryNames = new Set([
+      getFunctionName(internal.tonal.syncQueries.getMuscleReadiness),
+      getFunctionName(internal.coach.periodization.getActiveBlock),
+      getFunctionName(internal.weekPlans.getByUserIdAndWeekStartInternal),
+    ]);
+    const queryCalls: string[] = [];
+    const ctx = {
+      runQuery: async (query: unknown) => {
+        const queryName = getFunctionName(query as never);
+        queryCalls.push(queryName);
+        if (queryName === getAllMovementsName) {
+          throw new Error("movement catalog should not be loaded");
+        }
+        if (queryName === getUserProfileName) {
+          return {
+            profileData: {
+              firstName: "Alice",
+              lastName: "Lifter",
+              heightInches: 66,
+              weightPounds: 150,
+              level: "intermediate",
+              workoutsPerWeek: 4,
+              dateOfBirth: "1990-01-01",
+            },
+            ownedAccessories: {
+              smartHandles: true,
+              smartBar: true,
+              rope: false,
+              roller: true,
+              weightBar: true,
+              pilatesLoops: true,
+              ankleStraps: true,
+            },
+          };
+        }
+        if (nullableQueryNames.has(queryName)) {
+          return null;
+        }
+        return [];
       },
-      ...overrides,
     };
-  }
 
-  const allOwned: OwnedAccessories = {
-    smartHandles: true,
-    smartBar: true,
-    rope: true,
-    roller: true,
-    weightBar: true,
-    pilatesLoops: true,
-    ankleStraps: true,
-  };
+    const snapshot = await buildTrainingSnapshot(ctx as never, "user-1");
 
-  it("groups exercises by accessory display name", () => {
-    const movements = [
-      makeMovement({
-        id: "1",
-        name: "Bench Press",
-        onMachineInfo: {
-          accessory: "Handle",
-          resistanceType: "cable",
-          spotterDisabled: false,
-          eccentricDisabled: false,
-          chainsDisabled: false,
-          burnoutDisabled: false,
-        },
-      }),
-      makeMovement({
-        id: "2",
-        name: "Biceps Curl",
-        onMachineInfo: {
-          accessory: "Handle",
-          resistanceType: "cable",
-          spotterDisabled: false,
-          eccentricDisabled: false,
-          chainsDisabled: false,
-          burnoutDisabled: false,
-        },
-      }),
-      makeMovement({
-        id: "3",
-        name: "Seated Row",
-        onMachineInfo: {
-          accessory: "Rope",
-          resistanceType: "cable",
-          spotterDisabled: false,
-          eccentricDisabled: false,
-          chainsDisabled: false,
-          burnoutDisabled: false,
-        },
-      }),
-    ];
-    const section = buildExerciseCatalogSection(movements, allOwned);
-    expect(section).not.toBeNull();
-    const text = section!.lines.join("\n");
-    expect(text).toContain("Handles: Bench Press, Biceps Curl");
-    expect(text).toContain("Rope: Seated Row");
-  });
-
-  it("filters out exercises requiring unowned accessories", () => {
-    const noRope: OwnedAccessories = { ...allOwned, rope: false };
-    const movements = [
-      makeMovement({
-        id: "1",
-        name: "Bench Press",
-        onMachineInfo: {
-          accessory: "Handle",
-          resistanceType: "cable",
-          spotterDisabled: false,
-          eccentricDisabled: false,
-          chainsDisabled: false,
-          burnoutDisabled: false,
-        },
-      }),
-      makeMovement({
-        id: "2",
-        name: "Face Pull",
-        onMachineInfo: {
-          accessory: "Rope",
-          resistanceType: "cable",
-          spotterDisabled: false,
-          eccentricDisabled: false,
-          chainsDisabled: false,
-          burnoutDisabled: false,
-        },
-      }),
-    ];
-    const section = buildExerciseCatalogSection(movements, noRope);
-    expect(section).not.toBeNull();
-    const text = section!.lines.join("\n");
-    expect(text).toContain("Bench Press");
-    expect(text).not.toContain("Face Pull");
-  });
-
-  it("excludes placeholder movements", () => {
-    const movements = [
-      makeMovement({ id: "1", name: "Bench Press" }),
-      makeMovement({ id: "2", name: "Handle Move" }),
-      makeMovement({ id: "3", name: "Rope Move" }),
-    ];
-    const section = buildExerciseCatalogSection(movements, allOwned);
-    expect(section).not.toBeNull();
-    const text = section!.lines.join("\n");
-    expect(text).toContain("Bench Press");
-    expect(text).not.toContain("Handle Move");
-    expect(text).not.toContain("Rope Move");
-  });
-
-  it("excludes unpublished movements", () => {
-    const movements = [
-      makeMovement({ id: "1", name: "Bench Press", publishState: "published" }),
-      makeMovement({ id: "2", name: "Secret Move", publishState: "draft" }),
-    ];
-    const section = buildExerciseCatalogSection(movements, allOwned);
-    const text = section!.lines.join("\n");
-    expect(text).toContain("Bench Press");
-    expect(text).not.toContain("Secret Move");
-  });
-
-  it("puts exercises without onMachineInfo in Bodyweight group", () => {
-    const movements = [makeMovement({ id: "1", name: "Pushup", onMachineInfo: undefined })];
-    const section = buildExerciseCatalogSection(movements, allOwned);
-    const text = section!.lines.join("\n");
-    expect(text).toContain("Bodyweight: Pushup");
-  });
-
-  it("returns null when no movements pass filters", () => {
-    const section = buildExerciseCatalogSection([], allOwned);
-    expect(section).toBeNull();
-  });
-
-  it("includes all accessories when owned is undefined", () => {
-    const movements = [
-      makeMovement({
-        id: "1",
-        name: "Face Pull",
-        onMachineInfo: {
-          accessory: "Rope",
-          resistanceType: "cable",
-          spotterDisabled: false,
-          eccentricDisabled: false,
-          chainsDisabled: false,
-          burnoutDisabled: false,
-        },
-      }),
-      makeMovement({
-        id: "2",
-        name: "Hip Abduction",
-        onMachineInfo: {
-          accessory: "AnkleStraps",
-          resistanceType: "cable",
-          spotterDisabled: false,
-          eccentricDisabled: false,
-          chainsDisabled: false,
-          burnoutDisabled: false,
-        },
-      }),
-    ];
-    const section = buildExerciseCatalogSection(movements, undefined);
-    expect(section).not.toBeNull();
-    const text = section!.lines.join("\n");
-    expect(text).toContain("Face Pull");
-    expect(text).toContain("Hip Abduction");
-  });
-
-  it("sets priority to 6.5", () => {
-    const movements = [makeMovement()];
-    const section = buildExerciseCatalogSection(movements, allOwned);
-    expect(section!.priority).toBe(6.5);
+    expect(queryCalls).not.toContain(getAllMovementsName);
+    expect(snapshot).not.toContain("Available Tonal Exercises");
+    expect(snapshot).toContain("Equipment:");
   });
 });

--- a/convex/ai/context.ts
+++ b/convex/ai/context.ts
@@ -1,14 +1,12 @@
 import type { ActionCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
-import type { Movement } from "../tonal/types";
 import { detectMissedSessions, formatMissedSessionContext } from "../coach/missedSessionDetection";
 import { getWeekStartDateString } from "../weekPlanHelpers";
 import type { OwnedAccessories } from "../tonal/accessories";
 export { getRecencyLabel } from "./timeDecay";
 import { getRecencyLabel } from "./timeDecay";
 import {
-  buildExerciseCatalogSection,
   computeAge,
   formatExternalActivityLine,
   getHrIntensityLabel,
@@ -18,13 +16,7 @@ import {
 } from "./snapshotHelpers";
 
 // Re-export for backward compatibility (tests, other consumers)
-export {
-  type SnapshotSection,
-  trimSnapshot,
-  getHrIntensityLabel,
-  formatExternalActivityLine,
-  buildExerciseCatalogSection,
-};
+export { type SnapshotSection, trimSnapshot, getHrIntensityLabel, formatExternalActivityLine };
 
 export async function buildTrainingSnapshot(
   ctx: Pick<ActionCtx, "runQuery">,
@@ -41,7 +33,7 @@ export async function buildTrainingSnapshot(
     return "No Tonal profile linked yet. Ask the user to connect their Tonal account.";
   }
 
-  // Parallel fetch: Tonal data + coaching data + movement catalog
+  // Parallel fetch: Tonal data + coaching data
   const [
     scores,
     readiness,
@@ -51,7 +43,6 @@ export async function buildTrainingSnapshot(
     activeGoals,
     activeInjuries,
     externalActivities,
-    movementCatalog,
   ] = await Promise.all([
     ctx
       .runQuery(internal.tonal.syncQueries.getCurrentStrengthScores, { userId: convexUserId })
@@ -79,7 +70,6 @@ export async function buildTrainingSnapshot(
         limit: 20,
       })
       .catch(() => []),
-    ctx.runQuery(internal.tonal.movementSync.getAllMovements).catch(() => [] as Movement[]),
   ]);
 
   const pd = profile.profileData;
@@ -145,10 +135,6 @@ export async function buildTrainingSnapshot(
     equipmentLines.push(`Equipment: All accessories assumed available (no equipment profile set).`);
   }
   sections.push({ priority: 2, lines: equipmentLines });
-
-  // Priority 6.5: Exercise catalog grouped by accessory
-  const catalogSection = buildExerciseCatalogSection(movementCatalog, owned);
-  if (catalogSection) sections.push(catalogSection);
 
   // Priority 3: Active injuries
   const injuries = activeInjuries as Doc<"injuries">[];

--- a/convex/ai/promptSections.ts
+++ b/convex/ai/promptSections.ts
@@ -167,6 +167,7 @@ export function bodybuilding(): string {
 export function equipment(): string {
   return `EQUIPMENT:
 - The training snapshot shows owned/missing accessories. Missing accessories auto-filter from programming.
+- Use search_exercises to discover canonical Tonal exercise names, IDs, accessory requirements, and alternatives. The snapshot intentionally does not include the full exercise catalog.
 - Don't suggest exercises requiring equipment the user lacks. Explain which accessory they'd need if asked.`;
 }
 

--- a/convex/ai/snapshotHelpers.test.ts
+++ b/convex/ai/snapshotHelpers.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildExerciseCatalogSection,
   capitalizeWorkoutType,
   computeAge,
   formatExternalActivityLine,
@@ -9,8 +8,7 @@ import {
   type SnapshotSection,
   trimSnapshot,
 } from "./snapshotHelpers";
-import type { ExternalActivity, Movement } from "../tonal/types";
-import type { OwnedAccessories } from "../tonal/accessories";
+import type { ExternalActivity } from "../tonal/types";
 
 // ---------------------------------------------------------------------------
 // Test data builders
@@ -33,40 +31,6 @@ function makeExternalActivity(overrides: Partial<ExternalActivity> = {}): Extern
     source: "Apple Watch",
     externalId: "ext-id-1",
     deviceId: "device-1",
-    ...overrides,
-  };
-}
-
-function makeMovement(overrides: Partial<Movement> = {}): Movement {
-  return {
-    id: "move-1",
-    name: "Bench Press",
-    shortName: "Bench Press",
-    muscleGroups: ["Chest"],
-    inFreeLift: false,
-    onMachine: true,
-    countReps: true,
-    isTwoSided: false,
-    isBilateral: true,
-    isAlternating: false,
-    descriptionHow: "Press the bar",
-    descriptionWhy: "Build chest",
-    skillLevel: 3,
-    publishState: "published",
-    sortOrder: 1,
-    ...overrides,
-  };
-}
-
-function makeOwnedAccessories(overrides: Partial<OwnedAccessories> = {}): OwnedAccessories {
-  return {
-    smartHandles: true,
-    smartBar: true,
-    rope: true,
-    roller: true,
-    weightBar: true,
-    pilatesLoops: true,
-    ankleStraps: true,
     ...overrides,
   };
 }
@@ -233,95 +197,6 @@ describe("SNAPSHOT_MAX_CHARS", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// buildExerciseCatalogSection
-// ---------------------------------------------------------------------------
-
-describe("buildExerciseCatalogSection", () => {
-  const machineInfo = {
-    resistanceType: "cable",
-    spotterDisabled: false,
-    eccentricDisabled: false,
-    chainsDisabled: false,
-    burnoutDisabled: false,
-  };
-
-  it("returns null for empty movements array", () => {
-    expect(buildExerciseCatalogSection([], undefined)).toBeNull();
-  });
-
-  it("groups published movements by accessory", () => {
-    const movements: Movement[] = [
-      makeMovement({
-        name: "Bench Press",
-        onMachineInfo: { accessory: "Smart Bar", ...machineInfo },
-      }),
-      makeMovement({
-        id: "m2",
-        name: "Bicep Curl",
-        onMachineInfo: { accessory: "Smart Handles", ...machineInfo },
-      }),
-    ];
-    const result = buildExerciseCatalogSection(movements, undefined);
-
-    expect(result).not.toBeNull();
-    expect(result!.lines.some((l) => l.includes("Bar"))).toBe(true);
-    expect(result!.lines.some((l) => l.includes("Bench Press"))).toBe(true);
-  });
-
-  it("filters out unpublished movements", () => {
-    const movements: Movement[] = [
-      makeMovement({ name: "Published Move", publishState: "published" }),
-      makeMovement({ id: "m2", name: "Draft Move", publishState: "draft" }),
-    ];
-    const result = buildExerciseCatalogSection(movements, undefined);
-
-    expect(result!.lines.join("\n")).toContain("Published Move");
-    expect(result!.lines.join("\n")).not.toContain("Draft Move");
-  });
-
-  it("filters out placeholder movements", () => {
-    const movements: Movement[] = [
-      makeMovement({ name: "Handle Move" }),
-      makeMovement({ id: "m2", name: "Real Exercise" }),
-    ];
-    const result = buildExerciseCatalogSection(movements, undefined);
-
-    expect(result!.lines.join("\n")).not.toContain("Handle Move");
-    expect(result!.lines.join("\n")).toContain("Real Exercise");
-  });
-
-  it("filters movements for unowned accessories", () => {
-    const movements: Movement[] = [
-      makeMovement({ name: "Bar Ex", onMachineInfo: { accessory: "Smart Bar", ...machineInfo } }),
-      makeMovement({
-        id: "m2",
-        name: "Handle Ex",
-        onMachineInfo: { accessory: "Smart Handles", ...machineInfo },
-      }),
-    ];
-    const result = buildExerciseCatalogSection(
-      movements,
-      makeOwnedAccessories({ smartBar: false }),
-    );
-
-    expect(result!.lines.join("\n")).not.toContain("Bar Ex");
-    expect(result!.lines.join("\n")).toContain("Handle Ex");
-  });
-
-  it("returns null when all movements are filtered out", () => {
-    expect(
-      buildExerciseCatalogSection([makeMovement({ name: "Handle Move" })], undefined),
-    ).toBeNull();
-  });
-
-  it("has priority 6.5", () => {
-    const result = buildExerciseCatalogSection([makeMovement()], undefined);
-    expect(result!.priority).toBe(6.5);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // computeAge
 // ---------------------------------------------------------------------------
 

--- a/convex/ai/snapshotHelpers.ts
+++ b/convex/ai/snapshotHelpers.ts
@@ -3,8 +3,7 @@
  * Extracted from context.ts for file-size hygiene.
  */
 
-import type { ExternalActivity, Movement } from "../tonal/types";
-import { ACCESSORY_MAP, type OwnedAccessories } from "../tonal/accessories";
+import type { ExternalActivity } from "../tonal/types";
 
 export interface SnapshotSection {
   priority: number; // 1 = highest (dropped last), 12 = lowest (dropped first)
@@ -74,100 +73,6 @@ export function formatExternalActivityLine(a: ExternalActivity): string {
     line += ` | Avg HR ${Math.round(a.averageHeartRate)} (${hrLabel})`;
   }
   return line;
-}
-
-// Exercise catalog helpers
-
-/** Placeholder movements that exist in the API but aren't real exercises. */
-const PLACEHOLDER_NAMES = new Set([
-  "Handle Move",
-  "Rope Move",
-  "Bar Move",
-  "Bodyweight Move",
-  "Roller Move",
-  "Pilates Loops Move",
-  "Ankle Straps Move",
-]);
-
-/** Display names for accessory grouping, keyed by OwnedAccessories field. */
-const ACCESSORY_DISPLAY: Record<keyof OwnedAccessories, string> = {
-  smartHandles: "Handles",
-  smartBar: "Bar",
-  rope: "Rope",
-  roller: "Roller",
-  weightBar: "Weight Bar",
-  pilatesLoops: "Pilates Loops",
-  ankleStraps: "Ankle Straps",
-};
-
-/**
- * Builds a compact exercise catalog section grouped by accessory type.
- * Filters out exercises requiring accessories the user doesn't own.
- * Pure function — no side effects.
- */
-export function buildExerciseCatalogSection(
-  movements: Movement[],
-  owned: OwnedAccessories | undefined,
-): SnapshotSection | null {
-  const excludedAccessories = buildExcludedAccessorySet(owned);
-  const grouped = groupMovementsByAccessory(movements, excludedAccessories);
-
-  if (grouped.size === 0) return null;
-
-  const lines: string[] = ["Available Tonal Exercises (use search_exercises for IDs):"];
-  const sortedKeys = [...grouped.keys()].sort();
-  for (const group of sortedKeys) {
-    const names = grouped.get(group)!;
-    lines.push(`  ${group}: ${names.join(", ")}`);
-  }
-
-  return { priority: 6.5, lines };
-}
-
-/** Returns a Set of OwnedAccessories keys that the user does NOT own. */
-function buildExcludedAccessorySet(owned: OwnedAccessories | undefined): Set<string> {
-  if (!owned) return new Set();
-  const excluded = new Set<string>();
-  for (const [apiName, profileKey] of Object.entries(ACCESSORY_MAP)) {
-    if (!owned[profileKey]) excluded.add(apiName);
-  }
-  return excluded;
-}
-
-/** Groups movement names by accessory display name, filtering excluded accessories. */
-function groupMovementsByAccessory(
-  movements: Movement[],
-  excludedAccessories: Set<string>,
-): Map<string, string[]> {
-  const grouped = new Map<string, string[]>();
-
-  for (const m of movements) {
-    if (m.publishState !== "published") continue;
-    if (PLACEHOLDER_NAMES.has(m.name)) continue;
-
-    const apiAccessory = m.onMachineInfo?.accessory;
-    if (apiAccessory && excludedAccessories.has(apiAccessory)) continue;
-
-    const groupName = resolveGroupName(apiAccessory);
-    const list = grouped.get(groupName) ?? [];
-    list.push(m.name);
-    grouped.set(groupName, list);
-  }
-
-  // Sort names alphabetically within each group
-  for (const [key, names] of grouped) {
-    grouped.set(key, [...new Set(names)].sort());
-  }
-
-  return grouped;
-}
-
-/** Maps an API accessory string to a display group name. */
-function resolveGroupName(apiAccessory: string | undefined): string {
-  if (!apiAccessory) return "Bodyweight";
-  const profileKey = ACCESSORY_MAP[apiAccessory];
-  if (!profileKey) return apiAccessory;
-  return ACCESSORY_DISPLAY[profileKey];
 }
 
 /**

--- a/convex/ai/tools.ts
+++ b/convex/ai/tools.ts
@@ -17,17 +17,23 @@ async function getGlobalMovementCatalog(ctx: ToolCtx): Promise<Movement[]> {
 }
 
 export const searchExercisesTool = createTool({
-  description: "Search Tonal exercise catalog by name, muscle group, and/or training type.",
+  description:
+    "Search Tonal's exercise catalog by name, muscle group, and/or training type. Use this before naming, suggesting, swapping, or programming exercises; results include canonical Tonal names, movement IDs, accessory requirements, and duration-vs-rep behavior.",
   inputSchema: z.object({
     name: z
       .string()
       .optional()
-      .describe("Exercise name or common name (e.g. 'Romanian Deadlift', 'RDL')"),
-    muscleGroup: z.string().optional().describe("e.g. Chest, Back, Quads, Shoulders"),
+      .describe(
+        "Exercise name or common name (e.g. 'Romanian Deadlift', 'RDL'). Use shorter names when an exact search misses.",
+      ),
+    muscleGroup: z
+      .string()
+      .optional()
+      .describe("Use when exploring options for a body part, e.g. Chest, Back, Quads, Shoulders."),
     trainingType: z
       .string()
       .optional()
-      .describe("Filter by training type: Warm-up, Mobility, Recovery, Yoga, Strength, etc."),
+      .describe("Use to narrow by type: Warm-up, Mobility, Recovery, Yoga, Strength, etc."),
   }),
   execute: withToolTracking("search_exercises", async (ctx, input, _options) => {
     const catalog = await getGlobalMovementCatalog(ctx);


### PR DESCRIPTION
## Summary
- remove the full Tonal exercise catalog from the per-turn training snapshot path
- delete the now-unused catalog snapshot helper and tests
- direct the coach to use search_exercises for canonical exercise names, IDs, accessory requirements, and alternatives

## Why
The catalog section required loading all movements for every chat turn and could consume a large chunk of the snapshot budget. Moving exercise discovery fully to search_exercises reduces pre-inference work and prompt size while keeping catalog lookup available on demand.

Closes #213
Refs #87

## Validation
- npx vitest run convex/ai/context.test.ts convex/ai/snapshotHelpers.test.ts convex/ai/coach.test.ts
- npm run typecheck
- npm run lint
- npx vitest --project backend
- npm test
- npm run knip
- npm run build
- git diff --check
- focused code review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured training snapshot to remove static exercise catalog section; system now relies on dynamic exercise search for exercise lookup.

* **Documentation**
  * Improved exercise search tool descriptions with enhanced guidance on usage, filtering options, and expected result format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->