### PR TITLE
feat(evals): gate nightly experiment on evaluator scores

### DIFF
--- a/scripts/evals/phoenix/lib/experimentScoreGate.test.ts
+++ b/scripts/evals/phoenix/lib/experimentScoreGate.test.ts
@@ -1,0 +1,82 @@
+import type { ExperimentEvaluationRun } from "@arizeai/phoenix-client/types/experiments";
+import { describe, expect, it } from "vitest";
+import { findScoreGateRegressions, formatScoreGateSummary } from "./experimentScoreGate";
+
+function evaluationRun(overrides: Partial<ExperimentEvaluationRun>): ExperimentEvaluationRun {
+  return {
+    id: "eval-1",
+    experimentRunId: "run-1",
+    startTime: new Date(0),
+    endTime: new Date(1),
+    name: "rubric-checks",
+    annotatorKind: "CODE",
+    error: null,
+    result: { score: 1, label: "pass", explanation: "ok" },
+    traceId: null,
+    ...overrides,
+  };
+}
+
+describe("findScoreGateRegressions", () => {
+  it("returns no regressions when evaluation runs are missing", () => {
+    expect(findScoreGateRegressions(undefined)).toEqual([]);
+  });
+
+  it("returns gated evaluator runs with score zero", () => {
+    const regressions = findScoreGateRegressions([
+      evaluationRun({
+        id: "eval-2",
+        experimentRunId: "run-2",
+        name: "banned-phrases",
+        result: { score: 0, label: "banned-phrase", explanation: "found: disclaimer" },
+      }),
+    ]);
+
+    expect(regressions).toEqual([
+      {
+        evaluatorName: "banned-phrases",
+        evaluationRunId: "eval-2",
+        experimentRunId: "run-2",
+        explanation: "found: disclaimer",
+      },
+    ]);
+  });
+
+  it("ignores passing and non-gated evaluator runs", () => {
+    const regressions = findScoreGateRegressions([
+      evaluationRun({ result: { score: 1, label: "pass" } }),
+      evaluationRun({ id: "eval-3", name: "diagnostic-only", result: { score: 0 } }),
+    ]);
+
+    expect(regressions).toEqual([]);
+  });
+});
+
+describe("formatScoreGateSummary", () => {
+  it("summarizes evaluator counts and failed runs", () => {
+    const summary = formatScoreGateSummary([
+      {
+        evaluatorName: "rubric-checks",
+        evaluationRunId: "eval-1",
+        experimentRunId: "run-1",
+        explanation: "missing term",
+      },
+      {
+        evaluatorName: "rubric-checks",
+        evaluationRunId: "eval-2",
+        experimentRunId: "run-2",
+        explanation: "response too long",
+      },
+      {
+        evaluatorName: "coach-correctness",
+        evaluationRunId: "eval-3",
+        experimentRunId: "run-3",
+        explanation: "low quality",
+      },
+    ]);
+
+    expect(summary).toContain("rubric-checks=2");
+    expect(summary).toContain("coach-correctness=1");
+    expect(summary).toContain("rubric-checks run=run-1 eval=eval-1: missing term");
+  });
+});

--- a/scripts/evals/phoenix/lib/experimentScoreGate.ts
+++ b/scripts/evals/phoenix/lib/experimentScoreGate.ts
@@ -1,12 +1,12 @@
 import type { ExperimentEvaluationRun } from "@arizeai/phoenix-client/types/experiments";
 
-export const SCORE_GATED_EVALUATOR_NAMES = [
+const SCORE_GATED_EVALUATOR_NAMES = [
   "rubric-checks",
   "banned-phrases",
   "coach-correctness",
 ] as const;
 
-export type EvaluatorRegression = {
+type EvaluatorRegression = {
   evaluatorName: string;
   evaluationRunId: string;
   experimentRunId: string;

--- a/scripts/evals/phoenix/lib/experimentScoreGate.ts
+++ b/scripts/evals/phoenix/lib/experimentScoreGate.ts
@@ -1,0 +1,59 @@
+import type { ExperimentEvaluationRun } from "@arizeai/phoenix-client/types/experiments";
+
+export const SCORE_GATED_EVALUATOR_NAMES = [
+  "rubric-checks",
+  "banned-phrases",
+  "coach-correctness",
+] as const;
+
+export type EvaluatorRegression = {
+  evaluatorName: string;
+  evaluationRunId: string;
+  experimentRunId: string;
+  explanation: string;
+};
+
+export function findScoreGateRegressions(
+  evaluationRuns: readonly ExperimentEvaluationRun[] | undefined,
+  gatedEvaluatorNames: readonly string[] = SCORE_GATED_EVALUATOR_NAMES,
+): EvaluatorRegression[] {
+  const gatedEvaluatorNameSet = new Set(gatedEvaluatorNames);
+
+  return (evaluationRuns ?? []).flatMap((run) => {
+    if (!gatedEvaluatorNameSet.has(run.name)) return [];
+    if (run.result?.score !== 0) return [];
+
+    return [
+      {
+        evaluatorName: run.name,
+        evaluationRunId: run.id,
+        experimentRunId: run.experimentRunId,
+        explanation: run.result.explanation ?? run.result.label ?? run.error ?? "score=0",
+      },
+    ];
+  });
+}
+
+export function formatScoreGateSummary(regressions: readonly EvaluatorRegression[]): string {
+  if (regressions.length === 0) return "Evaluator score gate: passed";
+
+  const countsByEvaluator = new Map<string, number>();
+  for (const regression of regressions) {
+    countsByEvaluator.set(
+      regression.evaluatorName,
+      (countsByEvaluator.get(regression.evaluatorName) ?? 0) + 1,
+    );
+  }
+
+  const countSummary = Array.from(countsByEvaluator.entries())
+    .map(([name, count]) => `${name}=${count}`)
+    .join(", ");
+  const details = regressions
+    .map(
+      (regression) =>
+        `${regression.evaluatorName} run=${regression.experimentRunId} eval=${regression.evaluationRunId}: ${regression.explanation}`,
+    )
+    .join("\n");
+
+  return `Evaluator score gate failed: ${countSummary}\n${details}`;
+}

--- a/scripts/evals/phoenix/runAgentExperiment.ts
+++ b/scripts/evals/phoenix/runAgentExperiment.ts
@@ -12,17 +12,17 @@
  */
 import { google } from "@ai-sdk/google";
 import { createClient } from "@arizeai/phoenix-client";
-import { runExperiment } from "@arizeai/phoenix-client/experiments";
+import { getExperiment, runExperiment } from "@arizeai/phoenix-client/experiments";
 import type { Evaluator } from "@arizeai/phoenix-client/types/experiments";
 import { createCorrectnessEvaluator } from "@arizeai/phoenix-evals";
 import { EVAL_SCENARIOS, type EvalScenario, type Rubric } from "../../../convex/ai/evalScenarios";
 import { runScenarioAgainstPrompt } from "../../../convex/ai/evalHarness";
+import { findScoreGateRegressions, formatScoreGateSummary } from "./lib/experimentScoreGate";
 import { BANNED_PHRASES, DEFAULT_MAX_RESPONSE_CHARS } from "./lib/thresholds";
 
 const DATASET_NAME = process.env.PHOENIX_DATASET_NAME ?? "roni-coach-smoke";
 const EXPERIMENT_NAME = process.env.PHOENIX_EXPERIMENT_NAME ?? `roni-nightly-${Date.now()}`;
 
-/** Reject NaN/<=0 so Phoenix never sees an invalid concurrency value. */
 function positiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (!raw) return fallback;
@@ -78,8 +78,6 @@ const rubricEvaluator: Evaluator = {
     if (!scenario) {
       return { score: 0, label: "missing-scenario", explanation: "no source scenario match" };
     }
-    // Code rubric intentionally sees tool names — scenarios assert on them
-    // (e.g., "must call get_workout_history").
     const notes = rubricChecks(extractTextWithTools(output), scenario.rubric);
     return {
       score: notes.length === 0 ? 1 : 0,
@@ -100,13 +98,11 @@ function getOutputParts(output: unknown): { text: string; toolNames: string } {
   return { text: JSON.stringify(output ?? ""), toolNames: "" };
 }
 
-/** Prose + tool names, for code-based rubric and banned-phrase checks. */
 function extractTextWithTools(output: unknown): string {
   const { text, toolNames } = getOutputParts(output);
   return [text, toolNames].filter(Boolean).join("\n");
 }
 
-/** Prose only, for the LLM judge — tool names would pollute prose evaluation. */
 function extractJudgeText(output: unknown): string {
   return getOutputParts(output).text;
 }
@@ -115,7 +111,6 @@ const bannedPhraseEvaluator: Evaluator = {
   name: "banned-phrases",
   kind: "CODE",
   evaluate: ({ output }) => {
-    // Ban phrases anywhere the user could see — including tool-call surfacing.
     const text = extractTextWithTools(output);
     const lower = text.toLowerCase();
     const hits = BANNED_PHRASES.filter((p) => lower.includes(p));
@@ -138,7 +133,6 @@ async function main(): Promise<void> {
     },
   });
 
-  // LLM-judge for transcript quality — catches persona drift the code rubric misses.
   const correctnessJudge = createCorrectnessEvaluator({
     model: google(process.env.PHOENIX_JUDGE_MODEL ?? "gemini-2.5-flash"),
   });
@@ -148,7 +142,6 @@ async function main(): Promise<void> {
     evaluate: async ({ input, output }) => {
       const scenario = scenarioByName((input as { scenarioName?: unknown }).scenarioName);
       const question = scenario?.userMessage ?? "";
-      // Judge sees prose only — tool names would distort prose quality scoring.
       return correctnessJudge.evaluate({ input: question, output: extractJudgeText(output) });
     },
   };
@@ -176,10 +169,17 @@ async function main(): Promise<void> {
     concurrency: positiveIntEnv("PHOENIX_EXPERIMENT_CONCURRENCY", 2),
   });
 
-  const failed = ran.failedRunCount;
-  const total = ran.exampleCount;
+  const fullExperiment = await getExperiment({ client, experimentId: ran.id });
+  const regressions = findScoreGateRegressions(fullExperiment.evaluationRuns);
+  const failed = fullExperiment.failedRunCount;
+  const total = fullExperiment.exampleCount;
   console.log(`Experiment ${ran.id}: ${total - failed}/${total} successful runs`);
-  if (failed > 0) process.exit(1);
+  if (regressions.length === 0) {
+    console.log(formatScoreGateSummary(regressions));
+  } else {
+    console.error(formatScoreGateSummary(regressions));
+  }
+  if (failed > 0 || regressions.length > 0) process.exit(1);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

- Fetches the completed Phoenix experiment after the nightly run so evaluator results are included in CI gating.
- Fails the nightly eval when any gated evaluator records `score === 0`, not just when task execution fails.
- Adds focused tests for score-gate detection and failure summaries.

Closes #252

## Changes

- Added `experimentScoreGate` helper for gated evaluator regression detection and console summaries.
- Updated `runAgentExperiment.ts` to call `getExperiment` after `runExperiment` and fail on evaluator regressions.
- Covered missing evaluation runs, zero-score regressions, non-gated evaluators, and summary formatting.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [x] New logic has tests (happy path + at least one error/edge case)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [x] Tested in browser (if UI changes) — N/A, no UI changes
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- `npx tsc --noEmit`
- `npx vitest run scripts/evals/phoenix/lib/experimentScoreGate.test.ts --project scripts`
- `npm run lint`
- `npm test`
- `npm run format:check`