### PR TITLE
perf: reduce Convex background sync churn

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -131,6 +131,7 @@ import type * as tonal_workoutCatalogSync from "../tonal/workoutCatalogSync.js";
 import type * as tonal_workoutDetailProjection from "../tonal/workoutDetailProjection.js";
 import type * as tonal_workoutHistoryProxy from "../tonal/workoutHistoryProxy.js";
 import type * as tonal_workoutMeta from "../tonal/workoutMeta.js";
+import type * as userActivity from "../userActivity.js";
 import type * as userData from "../userData.js";
 import type * as userProfiles from "../userProfiles.js";
 import type * as users from "../users.js";
@@ -275,6 +276,7 @@ declare const fullApi: ApiFromModules<{
   "tonal/workoutDetailProjection": typeof tonal_workoutDetailProjection;
   "tonal/workoutHistoryProxy": typeof tonal_workoutHistoryProxy;
   "tonal/workoutMeta": typeof tonal_workoutMeta;
+  userActivity: typeof userActivity;
   userData: typeof userData;
   userProfiles: typeof userProfiles;
   users: typeof users;

--- a/convex/coachState.test.ts
+++ b/convex/coachState.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { internal } from "./_generated/api";
 import schema from "./schema";
 
@@ -9,6 +9,10 @@ const modules = import.meta.glob("./**/*.*s");
 async function createUser(t: ReturnType<typeof convexTest>) {
   return t.run(async (ctx) => ctx.db.insert("users", {}));
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("coachState", () => {
   test("upserts one materialized snapshot per user", async () => {
@@ -42,6 +46,53 @@ describe("coachState", () => {
     expect(row?.snapshot).toBe("usable");
     expect(row?.lastError).toBe("boom");
     expect(row?.failedAt).toBeTypeOf("number");
+  });
+
+  test("skips duplicate snapshot writes when no refresh is pending", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+
+    await t.mutation(internal.coachState.upsertSnapshot, { userId, snapshot: "same" });
+    const first = await t.query(internal.coachState.getForUser, { userId });
+
+    vi.setSystemTime(2000);
+    await t.mutation(internal.coachState.upsertSnapshot, { userId, snapshot: "same" });
+    const second = await t.query(internal.coachState.getForUser, { userId });
+
+    expect(second?._id).toBe(first?._id);
+    expect(second?.refreshedAt).toBe(1000);
+  });
+
+  test("clears pending refresh for unchanged snapshots without replacing snapshot fields", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2000);
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+
+    await t.run(async (ctx) =>
+      ctx.db.insert("coachState", {
+        userId,
+        snapshot: "same",
+        snapshotVersion: 1,
+        userTimezone: null,
+        refreshedAt: 1000,
+        refreshRequestedAt: 1500,
+        refreshRequestedTimezone: null,
+      }),
+    );
+
+    await t.mutation(internal.coachState.upsertSnapshot, {
+      userId,
+      snapshot: "same",
+      requestedAt: 1500,
+    });
+    const row = await t.query(internal.coachState.getForUser, { userId });
+
+    expect(row?.snapshot).toBe("same");
+    expect(row?.refreshedAt).toBe(2000);
+    expect(row?.refreshRequestedAt).toBeUndefined();
   });
 
   test("older refresh completions keep newer refresh requests pending", async () => {

--- a/convex/coachState.ts
+++ b/convex/coachState.ts
@@ -136,6 +136,34 @@ export const upsertSnapshot = internalMutation({
         }
       : { ...values, failedAt: undefined, lastError: undefined };
     if (existing) {
+      const timezone = userTimezone ?? null;
+      const snapshotUnchanged =
+        existing.snapshot === snapshot &&
+        existing.snapshotVersion === SNAPSHOT_VERSION &&
+        (existing.userTimezone ?? null) === timezone;
+
+      if (
+        snapshotUnchanged &&
+        existing.refreshRequestedAt === undefined &&
+        existing.refreshRequestedTimezone === undefined &&
+        existing.failedAt === undefined &&
+        existing.lastError === undefined &&
+        existing.refreshedAt > 0
+      ) {
+        return;
+      }
+
+      if (snapshotUnchanged && clearPending) {
+        await ctx.db.patch(existing._id, {
+          refreshedAt: now,
+          refreshRequestedAt: undefined,
+          refreshRequestedTimezone: undefined,
+          failedAt: undefined,
+          lastError: undefined,
+        });
+        return;
+      }
+
       await ctx.db.patch(existing._id, patch);
       if (newerRequestAt !== undefined) {
         await ctx.scheduler.runAfter(REFRESH_DELAY_MS, internal.coachState.refreshForUser, {

--- a/convex/migrations/backfillAvgWeight.ts
+++ b/convex/migrations/backfillAvgWeight.ts
@@ -123,9 +123,7 @@ export const backfillUser = internalAction({
 export const backfillAll = internalAction({
   args: {},
   handler: async (ctx) => {
-    const users = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
-      sinceTimestamp: 0,
-    });
+    const users = await ctx.runQuery(internal.userActivity.getAllConnectedUsers, {});
 
     for (const profile of users) {
       try {

--- a/convex/migrations/backfillPersonalRecords.ts
+++ b/convex/migrations/backfillPersonalRecords.ts
@@ -89,9 +89,7 @@ export const backfillUser = internalAction({
 export const backfillAll = internalAction({
   args: {},
   handler: async (ctx) => {
-    const users = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
-      sinceTimestamp: 0,
-    });
+    const users = await ctx.runQuery(internal.userActivity.getAllConnectedUsers, {});
     for (const profile of users) {
       await ctx.scheduler.runAfter(0, internal.migrations.backfillPersonalRecords.backfillUser, {
         userId: profile.userId,

--- a/convex/rateLimits.ts
+++ b/convex/rateLimits.ts
@@ -47,6 +47,12 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
     period: MINUTE,
     capacity: 3,
   },
+  recordAppActivity: {
+    kind: "token bucket",
+    rate: 5,
+    period: MINUTE,
+    capacity: 10,
+  },
   reportInjury: {
     kind: "token bucket",
     rate: 5,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -48,6 +48,8 @@ export default defineSchema({
       }),
     ),
     lastActiveAt: v.number(),
+    /** Last real app activity, separate from background token/sync jobs. */
+    appLastActiveAt: v.optional(v.number()),
     /** When the user first connected their Tonal account (signup for activation analytics). */
     tonalConnectedAt: v.optional(v.number()),
     /** ISO date of the most recent synced activity (high-water mark for incremental sync). */
@@ -122,6 +124,7 @@ export default defineSchema({
     .index("by_tonalUserId", ["tonalUserId"])
     .index("by_tonalTokenExpiresAt", ["tonalTokenExpiresAt"])
     .index("by_lastActiveAt", ["lastActiveAt"])
+    .index("by_appLastActiveAt", ["appLastActiveAt"])
     .index("by_tonalConnectedAt", ["tonalConnectedAt"]),
 
   /** In-app check-ins (proactive messages). No SMS. */

--- a/convex/tonal/cacheRefresh.ts
+++ b/convex/tonal/cacheRefresh.ts
@@ -5,7 +5,7 @@ export const refreshActiveUsers = internalAction({
   handler: async (ctx) => {
     const threeDaysAgo = Date.now() - 72 * 60 * 60 * 1000;
 
-    const activeUsers = await ctx.runQuery(internal.userProfiles.getActiveUsers, {
+    const activeUsers = await ctx.runQuery(internal.userActivity.getActiveUsers, {
       sinceTimestamp: threeDaysAgo,
     });
 

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -141,11 +141,9 @@ export const syncUserHistoryWorkflow = workflow.define({
       { userId },
     );
 
-    await Promise.all([
-      step.runAction(internal.tonal.historySync.doSyncStrength, { userId }),
-      step.runAction(internal.tonal.enrichmentSync.doPersistNewTableData, { userId }),
-      step.runAction(internal.tonal.historySync.doMaybeRefreshProfile, { userId }),
-    ]);
+    await step.runAction(internal.tonal.historySync.doSyncStrength, { userId });
+    await step.runAction(internal.tonal.enrichmentSync.doPersistNewTableData, { userId });
+    await step.runAction(internal.tonal.historySync.doMaybeRefreshProfile, { userId });
 
     if (newestDate) {
       await step.runMutation(internal.userProfiles.updateLastSyncedActivityDate, {
@@ -220,11 +218,9 @@ export const backfillUserHistoryWorkflow = workflow.define({
       });
     }
 
-    await Promise.all([
-      step.runAction(internal.tonal.historySync.doSyncStrength, { userId }),
-      step.runAction(internal.tonal.enrichmentSync.doPersistNewTableData, { userId }),
-      step.runAction(internal.tonal.historySync.doMaybeRefreshProfile, { userId }),
-    ]);
+    await step.runAction(internal.tonal.historySync.doSyncStrength, { userId });
+    await step.runAction(internal.tonal.enrichmentSync.doPersistNewTableData, { userId });
+    await step.runAction(internal.tonal.historySync.doMaybeRefreshProfile, { userId });
 
     await step.runMutation(internal.userProfiles.updateSyncStatus, {
       userId,

--- a/convex/tonal/historySyncMutations.test.ts
+++ b/convex/tonal/historySyncMutations.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { internal } from "../_generated/api";
 import schema from "../schema";
 
@@ -35,21 +35,28 @@ const baseReadiness = {
   calves: 0.7,
 };
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 // ---------------------------------------------------------------------------
 // persistCurrentStrengthScores
 // ---------------------------------------------------------------------------
 
 describe("persistCurrentStrengthScores", () => {
-  test("inserts scores and they exist in DB", async () => {
+  test("inserts scores and skips unchanged rewrites", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
     const t = convexTest(schema, modules);
     const userId = await createUser(t);
+    const scores = [
+      { bodyRegion: "upper", score: 120 },
+      { bodyRegion: "lower", score: 95 },
+    ];
 
     await t.mutation(internal.tonal.historySyncMutations.persistCurrentStrengthScores, {
       userId,
-      scores: [
-        { bodyRegion: "upper", score: 120 },
-        { bodyRegion: "lower", score: 95 },
-      ],
+      scores,
     });
 
     const rows = await t.run(async (ctx) =>
@@ -61,6 +68,21 @@ describe("persistCurrentStrengthScores", () => {
     expect(rows).toHaveLength(2);
     const regions = rows.map((r) => r.bodyRegion).sort();
     expect(regions).toEqual(["lower", "upper"]);
+
+    vi.setSystemTime(2000);
+    await t.mutation(internal.tonal.historySyncMutations.persistCurrentStrengthScores, {
+      userId,
+      scores,
+    });
+
+    const after = await t.run(async (ctx) =>
+      ctx.db
+        .query("currentStrengthScores")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .collect(),
+    );
+    expect(after.map((row) => row._id).sort()).toEqual(rows.map((row) => row._id).sort());
+    expect(after.map((row) => row.fetchedAt).sort()).toEqual([1000, 1000]);
   });
 
   test("second call replaces existing scores", async () => {
@@ -89,6 +111,38 @@ describe("persistCurrentStrengthScores", () => {
     expect(rows).toHaveLength(2);
     const upper = rows.find((r) => r.bodyRegion === "upper");
     expect(upper?.score).toBe(110);
+  });
+
+  test("does not skip persistence when incoming score regions are duplicated", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+
+    await t.mutation(internal.tonal.historySyncMutations.persistCurrentStrengthScores, {
+      userId,
+      scores: [
+        { bodyRegion: "upper", score: 100 },
+        { bodyRegion: "lower", score: 100 },
+      ],
+    });
+
+    vi.setSystemTime(2000);
+    await t.mutation(internal.tonal.historySyncMutations.persistCurrentStrengthScores, {
+      userId,
+      scores: [
+        { bodyRegion: "upper", score: 100 },
+        { bodyRegion: "upper", score: 100 },
+      ],
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("currentStrengthScores")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .collect(),
+    );
+    expect(rows.map((row) => row.fetchedAt).sort()).toEqual([2000, 2000]);
   });
 
   test("empty scores array deletes all existing", async () => {
@@ -120,7 +174,9 @@ describe("persistCurrentStrengthScores", () => {
 // ---------------------------------------------------------------------------
 
 describe("persistMuscleReadiness", () => {
-  test("inserts a readiness snapshot", async () => {
+  test("inserts a readiness snapshot and skips unchanged rewrites", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
     const t = convexTest(schema, modules);
     const userId = await createUser(t);
 
@@ -137,6 +193,21 @@ describe("persistMuscleReadiness", () => {
     );
     expect(row).not.toBeNull();
     expect(row?.chest).toBe(0.8);
+
+    vi.setSystemTime(2000);
+    await t.mutation(internal.tonal.historySyncMutations.persistMuscleReadiness, {
+      userId,
+      readiness: baseReadiness,
+    });
+
+    const after = await t.run(async (ctx) =>
+      ctx.db
+        .query("muscleReadiness")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .first(),
+    );
+    expect(after?._id).toBe(row?._id);
+    expect(after?.fetchedAt).toBe(1000);
   });
 
   test("second call replaces so only one row exists with new values", async () => {
@@ -183,7 +254,9 @@ const baseActivity = {
 };
 
 describe("persistExternalActivities", () => {
-  test("inserts new activities", async () => {
+  test("inserts new activities and skips unchanged rewrites", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
     const t = convexTest(schema, modules);
     const userId = await createUser(t);
 
@@ -200,6 +273,22 @@ describe("persistExternalActivities", () => {
     );
     expect(rows).toHaveLength(1);
     expect(rows[0].workoutType).toBe("run");
+
+    vi.setSystemTime(2000);
+    await t.mutation(internal.tonal.historySyncMutations.persistExternalActivities, {
+      userId,
+      activities: [baseActivity],
+    });
+
+    const after = await t.run(async (ctx) =>
+      ctx.db
+        .query("externalActivities")
+        .withIndex("by_userId_externalId", (q) => q.eq("userId", userId).eq("externalId", "ext-1"))
+        .collect(),
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0]._id).toBe(rows[0]._id);
+    expect(after[0].syncedAt).toBe(1000);
   });
 
   test("upserts existing activity by externalId without duplicating", async () => {

--- a/convex/tonal/historySyncMutations.ts
+++ b/convex/tonal/historySyncMutations.ts
@@ -304,7 +304,7 @@ export const persistCurrentStrengthScores = internalMutation({
     for (const s of scores) {
       await ctx.db.insert("currentStrengthScores", { userId, ...s, fetchedAt: now });
     }
-    if (existing.length > 0 || scores.length > 0) await requestCoachStateRefresh(ctx, userId);
+    await requestCoachStateRefresh(ctx, userId);
   },
 });
 

--- a/convex/tonal/historySyncMutations.ts
+++ b/convex/tonal/historySyncMutations.ts
@@ -202,6 +202,8 @@ export const strengthScoreValidator = v.object({
   score: v.number(),
 });
 
+type StrengthScorePayload = typeof strengthScoreValidator.type;
+
 export const muscleReadinessValidator = v.object({
   chest: v.number(),
   shoulders: v.number(),
@@ -216,6 +218,8 @@ export const muscleReadinessValidator = v.object({
   calves: v.number(),
 });
 
+type MuscleReadinessPayload = typeof muscleReadinessValidator.type;
+
 export const externalActivityValidator = v.object({
   externalId: v.string(),
   workoutType: v.string(),
@@ -228,6 +232,60 @@ export const externalActivityValidator = v.object({
   distance: v.number(),
 });
 
+type ExternalActivityPayload = typeof externalActivityValidator.type;
+
+function strengthScoresMatch(
+  existing: readonly Doc<"currentStrengthScores">[],
+  scores: readonly StrengthScorePayload[],
+): boolean {
+  if (existing.length !== scores.length) return false;
+  const existingScores = new Map(existing.map((row) => [row.bodyRegion, row.score]));
+  if (existingScores.size !== existing.length) return false;
+
+  const nextRegions = new Set<string>();
+  for (const score of scores) {
+    if (nextRegions.has(score.bodyRegion)) return false;
+    nextRegions.add(score.bodyRegion);
+    if (existingScores.get(score.bodyRegion) !== score.score) return false;
+  }
+  return true;
+}
+
+function muscleReadinessMatches(
+  existing: Doc<"muscleReadiness">,
+  readiness: MuscleReadinessPayload,
+): boolean {
+  return (
+    existing.chest === readiness.chest &&
+    existing.shoulders === readiness.shoulders &&
+    existing.back === readiness.back &&
+    existing.triceps === readiness.triceps &&
+    existing.biceps === readiness.biceps &&
+    existing.abs === readiness.abs &&
+    existing.obliques === readiness.obliques &&
+    existing.quads === readiness.quads &&
+    existing.glutes === readiness.glutes &&
+    existing.hamstrings === readiness.hamstrings &&
+    existing.calves === readiness.calves
+  );
+}
+
+function externalActivityMatches(
+  existing: Doc<"externalActivities">,
+  activity: ExternalActivityPayload,
+): boolean {
+  return (
+    existing.workoutType === activity.workoutType &&
+    existing.beginTime === activity.beginTime &&
+    existing.totalDuration === activity.totalDuration &&
+    existing.activeCalories === activity.activeCalories &&
+    existing.totalCalories === activity.totalCalories &&
+    existing.averageHeartRate === activity.averageHeartRate &&
+    existing.source === activity.source &&
+    existing.distance === activity.distance
+  );
+}
+
 /** Replace all current strength scores for a user (delete old, insert fresh). */
 export const persistCurrentStrengthScores = internalMutation({
   args: { userId: v.id("users"), scores: v.array(strengthScoreValidator) },
@@ -237,6 +295,8 @@ export const persistCurrentStrengthScores = internalMutation({
       .query("currentStrengthScores")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .collect();
+    if (strengthScoresMatch(existing, scores)) return;
+
     for (const row of existing) {
       await ctx.db.delete(row._id);
     }
@@ -258,9 +318,11 @@ export const persistMuscleReadiness = internalMutation({
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .first();
     if (existing) {
-      await ctx.db.delete(existing._id);
+      if (muscleReadinessMatches(existing, readiness)) return;
+      await ctx.db.patch(existing._id, { ...readiness, fetchedAt: Date.now() });
+    } else {
+      await ctx.db.insert("muscleReadiness", { userId, ...readiness, fetchedAt: Date.now() });
     }
-    await ctx.db.insert("muscleReadiness", { userId, ...readiness, fetchedAt: Date.now() });
     await requestCoachStateRefresh(ctx, userId);
   },
 });
@@ -287,6 +349,7 @@ export const persistExternalActivities = internalMutation({
   handler: async (ctx, { userId, activities }) => {
     if (await isDeletionInProgress(ctx, userId)) return;
     const now = Date.now();
+    let changed = false;
     for (const a of activities) {
       const existing = await ctx.db
         .query("externalActivities")
@@ -295,11 +358,14 @@ export const persistExternalActivities = internalMutation({
         )
         .first();
       if (existing) {
+        if (externalActivityMatches(existing, a)) continue;
         await ctx.db.replace(existing._id, { userId, ...a, syncedAt: now });
+        changed = true;
       } else {
         await ctx.db.insert("externalActivities", { userId, ...a, syncedAt: now });
+        changed = true;
       }
     }
-    if (activities.length > 0) await requestCoachStateRefresh(ctx, userId);
+    if (changed) await requestCoachStateRefresh(ctx, userId);
   },
 });

--- a/convex/tonal/profileBackfill.ts
+++ b/convex/tonal/profileBackfill.ts
@@ -14,10 +14,8 @@ export const backfillAllProfiles = internalAction({
   args: {},
   handler: async (ctx): Promise<{ success: number; failed: number; total: number }> => {
     const profiles: Doc<"userProfiles">[] = await ctx.runQuery(
-      internal.userProfiles.getActiveUsers,
-      {
-        sinceTimestamp: 0,
-      },
+      internal.userActivity.getAllConnectedUsers,
+      {},
     );
 
     let success = 0;

--- a/convex/tonal/proxy.ts
+++ b/convex/tonal/proxy.ts
@@ -112,9 +112,11 @@ export async function cachedFetch<T>(
       }
     }
 
-    await ctx
-      .runMutation(internal.systemHealth.recordSuccess, { service: "tonal" })
-      .catch((err: unknown) => console.warn("[circuitBreaker] recordSuccess failed", err));
+    if (circuitOpen) {
+      await ctx
+        .runMutation(internal.systemHealth.recordSuccess, { service: "tonal" })
+        .catch((err: unknown) => console.warn("[circuitBreaker] recordSuccess failed", err));
+    }
 
     return data;
   } catch (error) {

--- a/convex/tonal/proxyCacheBehavior.test.ts
+++ b/convex/tonal/proxyCacheBehavior.test.ts
@@ -13,7 +13,7 @@ function makeCacheKey(userId: unknown, dataType: string) {
   return `${String(userId ?? "global")}:${dataType}`;
 }
 
-function makeMockCtx() {
+function makeMockCtx(circuitOpen = false) {
   const cache = new Map<string, CacheRow>();
 
   const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
@@ -21,7 +21,7 @@ function makeMockCtx() {
       return cache.get(makeCacheKey(args.userId, String(args.dataType))) ?? null;
     }
     if ("service" in args) {
-      return false;
+      return circuitOpen;
     }
     return null;
   });
@@ -97,6 +97,32 @@ describe("cachedFetch", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       "cachedFetch(oversized): payload too large to cache, skipping write",
     );
+  });
+
+  it("records circuit recovery only when the circuit was open", async () => {
+    const closed = makeMockCtx(false);
+    await cachedFetch(closed.ctx, {
+      dataType: "closed-circuit",
+      ttl: 60_000,
+      fetcher: async () => ({ ok: true }),
+    });
+
+    const open = makeMockCtx(true);
+    await cachedFetch(open.ctx, {
+      dataType: "open-circuit",
+      ttl: 60_000,
+      fetcher: async () => ({ ok: true }),
+    });
+
+    const closedRecoveryWrites = closed.runMutation.mock.calls.filter(
+      ([, args]) => args && typeof args === "object" && "service" in args,
+    );
+    const openRecoveryWrites = open.runMutation.mock.calls.filter(
+      ([, args]) => args && typeof args === "object" && "service" in args,
+    );
+
+    expect(closedRecoveryWrites).toHaveLength(0);
+    expect(openRecoveryWrites).toHaveLength(1);
   });
 });
 

--- a/convex/userActivity.ts
+++ b/convex/userActivity.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { internalQuery, mutation } from "./_generated/server";
 import { getEffectiveUserId } from "./lib/auth";
+import { rateLimiter } from "./rateLimits";
 
 const APP_ACTIVITY_THROTTLE_MS = 30 * 60 * 1000;
 
@@ -29,6 +30,7 @@ export const recordAppActivity = mutation({
   handler: async (ctx) => {
     const userId = await getEffectiveUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
+    await rateLimiter.limit(ctx, "recordAppActivity", { key: userId });
 
     const profile = await ctx.db
       .query("userProfiles")

--- a/convex/userActivity.ts
+++ b/convex/userActivity.ts
@@ -1,0 +1,49 @@
+import { v } from "convex/values";
+import { internalQuery, mutation } from "./_generated/server";
+import { getEffectiveUserId } from "./lib/auth";
+
+const APP_ACTIVITY_THROTTLE_MS = 30 * 60 * 1000;
+
+export const getActiveUsers = internalQuery({
+  args: { sinceTimestamp: v.number() },
+  handler: async (ctx, { sinceTimestamp }) => {
+    return await ctx.db
+      .query("userProfiles")
+      .withIndex("by_appLastActiveAt", (q) => q.gt("appLastActiveAt", sinceTimestamp))
+      .collect();
+  },
+});
+
+export const getAllConnectedUsers = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db
+      .query("userProfiles")
+      .withIndex("by_lastActiveAt", (q) => q.gt("lastActiveAt", 0))
+      .collect();
+  },
+});
+
+export const recordAppActivity = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getEffectiveUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const profile = await ctx.db
+      .query("userProfiles")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+    if (!profile) return;
+
+    const now = Date.now();
+    if (profile.appLastActiveAt && now - profile.appLastActiveAt < APP_ACTIVITY_THROTTLE_MS) {
+      return;
+    }
+
+    await ctx.db.patch(profile._id, {
+      appLastActiveAt: now,
+      lastActiveAt: now,
+    });
+  },
+});

--- a/convex/userProfiles.test.ts
+++ b/convex/userProfiles.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
@@ -7,6 +8,12 @@ import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.*s");
 const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+
+function createTest() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t);
+  return t;
+}
 
 async function createUser(t: ReturnType<typeof convexTest>): Promise<Id<"users">> {
   return t.run(async (ctx) => ctx.db.insert("users", {}));
@@ -38,7 +45,7 @@ afterEach(() => {
 
 describe("user activity tracking", () => {
   test("uses app activity instead of background token freshness", async () => {
-    const t = convexTest(schema, modules);
+    const t = createTest();
     const activeUserId = await createUser(t);
     const tokenOnlyUserId = await createUser(t);
     const legacyUserId = await createUser(t);
@@ -55,7 +62,7 @@ describe("user activity tracking", () => {
   });
 
   test("token refresh does not update app activity", async () => {
-    const t = convexTest(schema, modules);
+    const t = createTest();
     const userId = await createUser(t);
     const profileId = await createProfile(t, userId, {
       lastActiveAt: 1000,
@@ -76,7 +83,7 @@ describe("user activity tracking", () => {
   });
 
   test("recordAppActivity requires authentication", async () => {
-    const t = convexTest(schema, modules);
+    const t = createTest();
 
     await expect(t.mutation(api.userActivity.recordAppActivity, {})).rejects.toThrow(
       "Not authenticated",
@@ -86,7 +93,7 @@ describe("user activity tracking", () => {
   test("recordAppActivity throttles writes and updates both activity timestamps", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
-    const t = convexTest(schema, modules);
+    const t = createTest();
     const userId = await createUser(t);
     const profileId = await createProfile(t, userId, {
       lastActiveAt: 10_000,
@@ -110,7 +117,7 @@ describe("user activity tracking", () => {
   });
 
   test("recordAppActivity is a no-op before a Tonal profile exists", async () => {
-    const t = convexTest(schema, modules);
+    const t = createTest();
     const userId = await createUser(t);
     const authed = t.withIdentity({ subject: `${userId}|session` });
 

--- a/convex/userProfiles.test.ts
+++ b/convex/userProfiles.test.ts
@@ -1,0 +1,127 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.*s");
+const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+
+async function createUser(t: ReturnType<typeof convexTest>): Promise<Id<"users">> {
+  return t.run(async (ctx) => ctx.db.insert("users", {}));
+}
+
+async function createProfile(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+  overrides: Partial<{
+    lastActiveAt: number;
+    appLastActiveAt: number;
+    tonalTokenExpiresAt: number;
+  }> = {},
+) {
+  return t.run(async (ctx) =>
+    ctx.db.insert("userProfiles", {
+      userId,
+      tonalUserId: `tonal-${userId}`,
+      tonalToken: "token",
+      lastActiveAt: 1000,
+      ...overrides,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("user activity tracking", () => {
+  test("uses app activity instead of background token freshness", async () => {
+    const t = convexTest(schema, modules);
+    const activeUserId = await createUser(t);
+    const tokenOnlyUserId = await createUser(t);
+    const legacyUserId = await createUser(t);
+
+    await createProfile(t, activeUserId, { lastActiveAt: 9000, appLastActiveAt: 9000 });
+    await createProfile(t, tokenOnlyUserId, { lastActiveAt: 9000, appLastActiveAt: 1000 });
+    await createProfile(t, legacyUserId, { lastActiveAt: 9000 });
+
+    const activeUsers = await t.query(internal.userActivity.getActiveUsers, {
+      sinceTimestamp: 5000,
+    });
+
+    expect(activeUsers.map((profile) => profile.userId)).toEqual([activeUserId]);
+  });
+
+  test("token refresh does not update app activity", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+    const profileId = await createProfile(t, userId, {
+      lastActiveAt: 1000,
+      appLastActiveAt: 2000,
+      tonalTokenExpiresAt: 3000,
+    });
+
+    await t.mutation(internal.userProfiles.updateTonalToken, {
+      userId,
+      tonalToken: "fresh-token",
+      tonalTokenExpiresAt: 4000,
+    });
+
+    const profile = await t.run(async (ctx) => ctx.db.get(profileId));
+
+    expect(profile?.lastActiveAt).toBe(1000);
+    expect(profile?.appLastActiveAt).toBe(2000);
+  });
+
+  test("recordAppActivity requires authentication", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(t.mutation(api.userActivity.recordAppActivity, {})).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
+
+  test("recordAppActivity throttles writes and updates both activity timestamps", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+    const profileId = await createProfile(t, userId, {
+      lastActiveAt: 10_000,
+      appLastActiveAt: 10_000,
+    });
+    const authed = t.withIdentity({ subject: `${userId}|session` });
+
+    vi.setSystemTime(10_000 + THIRTY_MINUTES_MS - 1);
+    await authed.mutation(api.userActivity.recordAppActivity, {});
+
+    const throttled = await t.run(async (ctx) => ctx.db.get(profileId));
+    expect(throttled?.lastActiveAt).toBe(10_000);
+    expect(throttled?.appLastActiveAt).toBe(10_000);
+
+    vi.setSystemTime(10_000 + THIRTY_MINUTES_MS);
+    await authed.mutation(api.userActivity.recordAppActivity, {});
+
+    const updated = await t.run(async (ctx) => ctx.db.get(profileId));
+    expect(updated?.lastActiveAt).toBe(10_000 + THIRTY_MINUTES_MS);
+    expect(updated?.appLastActiveAt).toBe(10_000 + THIRTY_MINUTES_MS);
+  });
+
+  test("recordAppActivity is a no-op before a Tonal profile exists", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createUser(t);
+    const authed = t.withIdentity({ subject: `${userId}|session` });
+
+    await authed.mutation(api.userActivity.recordAppActivity, {});
+
+    const profiles = await t.run(async (ctx) =>
+      ctx.db
+        .query("userProfiles")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .collect(),
+    );
+    expect(profiles).toHaveLength(0);
+  });
+});

--- a/convex/userProfiles.ts
+++ b/convex/userProfiles.ts
@@ -63,6 +63,7 @@ export const create = internalMutation({
         tonalTokenExpiresAt: args.tonalTokenExpiresAt,
         profileData: args.profileData,
         lastActiveAt: Date.now(),
+        appLastActiveAt: Date.now(),
       });
       if (args.profileData) await requestCoachStateRefresh(ctx, args.userId);
       return existing._id;
@@ -72,6 +73,7 @@ export const create = internalMutation({
     const id = await ctx.db.insert("userProfiles", {
       ...args,
       lastActiveAt: now,
+      appLastActiveAt: now,
       tonalConnectedAt: now,
     });
     if (args.profileData) await requestCoachStateRefresh(ctx, args.userId);
@@ -121,7 +123,6 @@ export const updateTonalToken = internalMutation({
 
     const patch: Record<string, unknown> = {
       tonalToken,
-      lastActiveAt: Date.now(),
     };
     if (tonalRefreshToken !== undefined) patch.tonalRefreshToken = tonalRefreshToken;
     if (tonalTokenExpiresAt !== undefined) patch.tonalTokenExpiresAt = tonalTokenExpiresAt;
@@ -138,16 +139,6 @@ export const markTokenExpired = internalMutation({
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .unique();
     if (profile) await ctx.db.patch(profile._id, { tonalTokenExpiresAt: 0 });
-  },
-});
-
-export const getActiveUsers = internalQuery({
-  args: { sinceTimestamp: v.number() },
-  handler: async (ctx, { sinceTimestamp }) => {
-    return await ctx.db
-      .query("userProfiles")
-      .withIndex("by_lastActiveAt", (q) => q.gt("lastActiveAt", sinceTimestamp))
-      .collect();
   },
 });
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -107,7 +107,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       window.clearInterval(intervalId);
       document.removeEventListener("visibilitychange", record);
     };
-  }, [isAuthenticated, pathname, recordAppActivity]);
+  }, [isAuthenticated, recordAppActivity]);
 
   useEffect(() => {
     if (me && (!me.hasTonalProfile || !me.onboardingCompleted || !me.hasCheckInPreferences)) {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useConvexAuth, useQuery } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import {
   CalendarDays,
@@ -38,6 +38,7 @@ const navLinks: Array<{
   { href: "/progress", label: "Progress", icon: TrendingUp },
   { href: "/settings", label: "Settings", icon: Settings },
 ];
+const APP_ACTIVITY_PING_MS = 30 * 60 * 1000;
 // Note: /prs is intentionally not in the nav — it's surfaced as a hero tile on
 // the dashboard (PRHighlightsCard) and reached via that tile's CTA.
 
@@ -72,6 +73,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
   const me = useQuery(api.users.getMe, isAuthenticated ? {} : "skip");
+  const recordAppActivity = useMutation(api.userActivity.recordAppActivity);
 
   // Dismissed resets when token status changes (successful reconnect or new expiry).
   // The key ensures a fresh dismissed=false whenever tokenExpired flips.
@@ -89,6 +91,23 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       router.replace("/login");
     }
   }, [authLoading, isAuthenticated, router]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const record = () => {
+      if (document.visibilityState !== "visible") return;
+      void recordAppActivity();
+    };
+
+    record();
+    const intervalId = window.setInterval(record, APP_ACTIVITY_PING_MS);
+    document.addEventListener("visibilitychange", record);
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", record);
+    };
+  }, [isAuthenticated, pathname, recordAppActivity]);
 
   useEffect(() => {
     if (me && (!me.hasTonalProfile || !me.onboardingCompleted || !me.hasCheckInPreferences)) {


### PR DESCRIPTION
## Summary
- Separate real app activity from background token refreshes so 30-minute Tonal sync targets recently active app users instead of every refreshed token.
- Reduce Convex contention by avoiding steady-state circuit-breaker success writes, serializing history-sync workflow steps, and skipping unchanged sync/coachState writes.
- Preserve all-user backfill helpers with a separate connected-user query and add focused regression tests for the new cost controls.

## Verification
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npx knip`
- `npx vitest run --coverage`
- `npm audit --audit-level=high` (passes high threshold; reports existing moderate PostCSS advisories through Next/Sentry/Vercel dependencies)
- `bash scripts/check-file-size.sh ...` (no hard failures; soft warnings remain for existing large Convex modules)

## Not Run
- `npm run test:e2e` (requires browser/dev-server smoke setup and Tonal test context)
- `npm run ai:eval:smoke` (requires external Gemini/Phoenix credentials and would incur model calls)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added app activity tracking to better monitor user engagement and activity patterns.

* **Performance & Reliability**
  * Optimized data synchronization to skip redundant writes when incoming payloads match existing records.
  * Improved API circuit-breaker resilience for enhanced service stability.
  * Enhanced sync operation sequencing for increased consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->