### PR TITLE
chore: drop unused export from SPLIT_OPTIONS

### DIFF
--- a/src/app/onboarding/SplitPreferenceField.tsx
+++ b/src/app/onboarding/SplitPreferenceField.tsx
@@ -2,7 +2,7 @@
 
 import { Label } from "@/components/ui/label";
 
-export const SPLIT_OPTIONS = [
+const SPLIT_OPTIONS = [
   { value: "ppl", label: "Push / Pull / Legs" },
   { value: "upper_lower", label: "Upper / Lower" },
   { value: "full_body", label: "Full Body" },


### PR DESCRIPTION
## Summary

Knip 6.7.0 flagged `SPLIT_OPTIONS` in `src/app/onboarding/SplitPreferenceField.tsx` as an unused export — the constant is only consumed inside its own module. Knip 6.5.0 (currently on main) missed this.

Dropping the unnecessary `export` so the pending dev-dependency group bump (PR #286, knip 6.5.0 → 6.7.0) can lint cleanly.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Internal usages still resolve (still referenced on lines 12 and 25 of the same file)