### PR TITLE
fix: batch resolve 2 PostHog production errors (g1 history ordering + g2 quota retry)

### DIFF
--- a/convex/ai/contextWindow.test.ts
+++ b/convex/ai/contextWindow.test.ts
@@ -4,7 +4,6 @@ import {
   buildContextWindow,
   mergeConsecutiveSameRole,
   stripImagesFromOlderMessages,
-  stripOrphanedToolCalls,
 } from "./contextWindow";
 
 describe("mergeConsecutiveSameRole", () => {
@@ -97,129 +96,6 @@ describe("mergeConsecutiveSameRole", () => {
       { type: "text", text: "first" },
       { type: "text", text: "second" },
     ]);
-  });
-});
-
-describe("stripOrphanedToolCalls", () => {
-  it("passes through messages with no tool calls", () => {
-    const msgs: ModelMessage[] = [
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "hi" },
-    ];
-    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
-  });
-
-  it("keeps paired tool-call and tool-result", () => {
-    const msgs: ModelMessage[] = [
-      { role: "user", content: "check scores" },
-      {
-        role: "assistant",
-        content: [{ type: "tool-call", toolCallId: "tc1", toolName: "get_scores", input: {} }],
-      },
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "tc1",
-            toolName: "get_scores",
-            output: { type: "text", value: "done" },
-          },
-        ],
-      },
-      { role: "assistant", content: "Your scores are great." },
-    ];
-    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
-  });
-
-  it("keeps tool-calls that were resolved by an approval response", () => {
-    const msgs: ModelMessage[] = [
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Approve this push?" },
-          { type: "tool-call", toolCallId: "tc1", toolName: "approve_week_plan", input: {} },
-          { type: "tool-approval-request", approvalId: "ap1", toolCallId: "tc1" },
-        ],
-      },
-      {
-        role: "tool",
-        content: [{ type: "tool-approval-response", approvalId: "ap1", approved: true }],
-      },
-      { role: "user", content: "Looks good" },
-    ];
-
-    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
-  });
-
-  it("keeps tool-calls that have a pending approval request", () => {
-    const msgs: ModelMessage[] = [
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Approve this push?" },
-          { type: "tool-call", toolCallId: "tc1", toolName: "approve_week_plan", input: {} },
-          { type: "tool-approval-request", approvalId: "ap1", toolCallId: "tc1" },
-        ],
-      },
-      { role: "user", content: "What does this change?" },
-    ];
-
-    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
-  });
-
-  it("removes orphaned tool-call with no matching tool-result", () => {
-    const msgs: ModelMessage[] = [
-      { role: "user", content: "check scores" },
-      {
-        role: "assistant",
-        content: [
-          { type: "tool-call", toolCallId: "tc-orphan", toolName: "get_scores", input: {} },
-        ],
-      },
-      { role: "user", content: "try again" },
-    ];
-    const result = stripOrphanedToolCalls(msgs);
-    expect(result).toEqual([
-      { role: "user", content: "check scores" },
-      { role: "user", content: "try again" },
-    ]);
-  });
-
-  it("keeps text parts when only some tool-calls are orphaned", () => {
-    const msgs: ModelMessage[] = [
-      { role: "user", content: "hello" },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Let me check." },
-          { type: "tool-call", toolCallId: "tc-good", toolName: "get_scores", input: {} },
-          { type: "tool-call", toolCallId: "tc-orphan", toolName: "search", input: {} },
-        ],
-      },
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "tc-good",
-            toolName: "get_scores",
-            output: { type: "text", value: "ok" },
-          },
-        ],
-      },
-    ];
-    const result = stripOrphanedToolCalls(msgs);
-    expect(result).toHaveLength(3);
-    const assistantContent = result[1].content as Array<{ type: string; toolCallId?: string }>;
-    expect(assistantContent).toHaveLength(2);
-    expect(assistantContent[0]).toEqual({ type: "text", text: "Let me check." });
-    expect(assistantContent[1].toolCallId).toBe("tc-good");
-  });
-
-  it("handles string content on assistant messages", () => {
-    const msgs: ModelMessage[] = [{ role: "assistant", content: "just text" }];
-    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
   });
 });
 

--- a/convex/ai/contextWindow.ts
+++ b/convex/ai/contextWindow.ts
@@ -71,25 +71,64 @@ export function stripOrphanedToolCalls(messages: ModelMessage[]): ModelMessage[]
     }
   }
 
+  // Build the set of tool-call ids that survive the assistant-message filter
+  // below. Any `tool` role message whose tool-result references a non-kept
+  // call is orphaned (typically from a partially-persisted failed stream)
+  // and must be dropped — Gemini rejects history where a tool turn doesn't
+  // immediately follow its originating user/function-response turn.
+  const keptAssistantToolCallIds = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    if (typeof msg.content === "string" || !Array.isArray(msg.content)) continue;
+    for (const part of msg.content as Array<{ type: string; toolCallId?: string }>) {
+      if (part.type !== "tool-call" || !part.toolCallId) continue;
+      if (
+        resolvedToolCallIds.has(part.toolCallId) ||
+        toolCallIdsWithApprovalRequests.has(part.toolCallId)
+      ) {
+        keptAssistantToolCallIds.add(part.toolCallId);
+      }
+    }
+  }
+
   return messages
     .map((msg) => {
-      if (msg.role !== "assistant") return msg;
-      if (typeof msg.content === "string" || !Array.isArray(msg.content)) return msg;
+      if (msg.role === "assistant") {
+        if (typeof msg.content === "string" || !Array.isArray(msg.content)) return msg;
 
-      const parts = msg.content as Array<{ type: string; toolCallId?: string }>;
-      const hasToolCalls = parts.some((p) => p.type === "tool-call");
-      if (!hasToolCalls) return msg;
+        const parts = msg.content as Array<{ type: string; toolCallId?: string }>;
+        const hasToolCalls = parts.some((p) => p.type === "tool-call");
+        if (!hasToolCalls) return msg;
 
-      const filtered = parts.filter(
-        (p) =>
-          p.type !== "tool-call" ||
-          (p.toolCallId &&
-            (resolvedToolCallIds.has(p.toolCallId) ||
-              toolCallIdsWithApprovalRequests.has(p.toolCallId))),
-      );
+        const filtered = parts.filter(
+          (p) =>
+            p.type !== "tool-call" ||
+            (p.toolCallId &&
+              (resolvedToolCallIds.has(p.toolCallId) ||
+                toolCallIdsWithApprovalRequests.has(p.toolCallId))),
+        );
 
-      if (filtered.length === 0) return null;
-      return { ...msg, content: filtered } as ModelMessage;
+        if (filtered.length === 0) return null;
+        return { ...msg, content: filtered } as ModelMessage;
+      }
+
+      if (msg.role === "tool") {
+        if (typeof msg.content === "string" || !Array.isArray(msg.content)) return msg;
+
+        const parts = msg.content as Array<{ type: string; toolCallId?: string }>;
+        // tool-approval-response parts are keyed by approvalId, not toolCallId,
+        // so preserve them regardless of the kept-call set.
+        const filtered = parts.filter(
+          (p) =>
+            p.type === "tool-approval-response" ||
+            (p.toolCallId !== undefined && keptAssistantToolCallIds.has(p.toolCallId)),
+        );
+
+        if (filtered.length === 0) return null;
+        return { ...msg, content: filtered } as ModelMessage;
+      }
+
+      return msg;
     })
     .filter((msg): msg is ModelMessage => msg !== null);
 }

--- a/convex/ai/quotaClassification.test.ts
+++ b/convex/ai/quotaClassification.test.ts
@@ -101,6 +101,15 @@ describe("isContextLimitError", () => {
     expect(isContextLimitError("input_token_count")).toBe(false);
     expect(isContextLimitError(undefined)).toBe(false);
   });
+
+  it("returns false when input_token_count appears without a quota signal", () => {
+    // Guards against a future regression that drops the quota/exceed/limit
+    // requirement — a malformed-prompt error mentioning the field name
+    // shouldn't be reclassified as a transient quota error.
+    const error = new Error("validation failed for field input_token_count");
+
+    expect(isContextLimitError(error)).toBe(false);
+  });
 });
 
 describe("classifyTransientError (context_limit + quota)", () => {

--- a/convex/ai/quotaClassification.test.ts
+++ b/convex/ai/quotaClassification.test.ts
@@ -1,0 +1,172 @@
+import { APICallError } from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+import {
+  buildProviderTransientMessage,
+  classifyTransientError,
+  isContextLimitError,
+  isQuotaError,
+} from "./transientErrors";
+
+function apiCallError(overrides: {
+  statusCode?: number;
+  isRetryable?: boolean;
+  responseBody?: string;
+  message?: string;
+}): APICallError {
+  return new APICallError({
+    message: overrides.message ?? "API call failed",
+    url: "https://example.test/v1/messages",
+    requestBodyValues: {},
+    statusCode: overrides.statusCode,
+    isRetryable: overrides.isRetryable ?? false,
+    responseBody: overrides.responseBody,
+  });
+}
+
+describe("isQuotaError", () => {
+  it("returns true for 'You exceeded your current quota' message", () => {
+    const error = new Error("You exceeded your current quota, please check your plan.");
+
+    expect(isQuotaError(error)).toBe(true);
+  });
+
+  it("returns true for error with responseBody containing 'input_token_count'", () => {
+    const error = apiCallError({
+      statusCode: 429,
+      responseBody: '{"error":{"message":"input_token_count limit reached"}}',
+    });
+
+    expect(isQuotaError(error)).toBe(true);
+  });
+
+  it("returns true for 'resource_exhausted' combined with 'quota'", () => {
+    const error = new Error("RESOURCE_EXHAUSTED: quota exceeded for this project");
+
+    expect(isQuotaError(error)).toBe(true);
+  });
+
+  it("returns true for 'insufficient_quota' message", () => {
+    const error = new Error("insufficient_quota: you have used all your free tier credits");
+
+    expect(isQuotaError(error)).toBe(true);
+  });
+
+  it("returns false for plain 'rate limit' message without quota indicators", () => {
+    const error = new Error("Rate limit exceeded for this endpoint");
+
+    expect(isQuotaError(error)).toBe(false);
+  });
+
+  it("returns false for non-Error string input", () => {
+    expect(isQuotaError("some error string")).toBe(false);
+  });
+
+  it("returns false for undefined input", () => {
+    expect(isQuotaError(undefined)).toBe(false);
+  });
+
+  it("returns true for APICallError with statusCode 429 and quota text in responseBody", () => {
+    const error = apiCallError({
+      statusCode: 429,
+      responseBody: "you exceeded your current quota for gemini-3-flash",
+    });
+
+    expect(isQuotaError(error)).toBe(true);
+  });
+});
+
+describe("isContextLimitError", () => {
+  it("returns true when error message contains 'input_token_count'", () => {
+    const error = new Error("input_token_count exceeds limit for this model");
+
+    expect(isContextLimitError(error)).toBe(true);
+  });
+
+  it("returns true when responseBody contains 'input_token_count' via APICallError", () => {
+    const error = apiCallError({
+      statusCode: 429,
+      responseBody: '{"error":{"code":"input_token_count","message":"token limit exceeded"}}',
+    });
+
+    expect(isContextLimitError(error)).toBe(true);
+  });
+
+  it("returns false for generic quota error without 'input_token_count'", () => {
+    const error = new Error("RESOURCE_EXHAUSTED: quota exceeded for model");
+
+    expect(isContextLimitError(error)).toBe(false);
+  });
+
+  it("returns false for non-Error input", () => {
+    expect(isContextLimitError("input_token_count")).toBe(false);
+    expect(isContextLimitError(undefined)).toBe(false);
+  });
+});
+
+describe("classifyTransientError (context_limit + quota)", () => {
+  it("returns 'context_limit' when error contains 'input_token_count' in responseBody", () => {
+    const error = apiCallError({
+      statusCode: 429,
+      isRetryable: true,
+      responseBody: '{"error":{"code":"input_token_count","message":"token limit exceeded"}}',
+    });
+
+    expect(classifyTransientError(error)).toBe("context_limit");
+  });
+
+  it("returns 'rate_limit' for a non-input_token_count quota error", () => {
+    const error = apiCallError({
+      statusCode: 429,
+      isRetryable: false,
+      responseBody: "you exceeded your current quota for gemini-3-flash",
+    });
+
+    expect(classifyTransientError(error)).toBe("rate_limit");
+  });
+
+  it("returns 'context_limit' even when isTransientError would return false", () => {
+    // A non-retryable 400 with input_token_count in body should still be
+    // classified as context_limit because that check runs before isTransientError.
+    const error = apiCallError({
+      statusCode: 400,
+      isRetryable: false,
+      responseBody: "input_token_count exceeds the model maximum",
+    });
+
+    expect(classifyTransientError(error)).toBe("context_limit");
+  });
+});
+
+describe("buildProviderTransientMessage with isByok flag", () => {
+  it("builds rate-limit message without BYOK hint when isByok is true", () => {
+    const msg = buildProviderTransientMessage("rate_limit", "gemini", true);
+
+    expect(msg).toContain("Google Gemini");
+    expect(msg).toContain("rate-limited");
+    expect(msg).not.toContain("add your own");
+  });
+
+  it("builds rate-limit message with 'add your own ... API key' hint when isByok is false", () => {
+    const msg = buildProviderTransientMessage("rate_limit", "gemini", false);
+
+    expect(msg).toContain("Google Gemini");
+    expect(msg).toContain("rate-limited");
+    expect(msg).toContain("add your own");
+    expect(msg).toContain("API key");
+  });
+
+  it("builds rate-limit message without BYOK hint when isByok is undefined", () => {
+    const msg = buildProviderTransientMessage("rate_limit", "gemini");
+
+    expect(msg).toContain("Google Gemini");
+    expect(msg).toContain("rate-limited");
+    expect(msg).not.toContain("add your own");
+  });
+
+  it("builds context-limit message containing 'fresh chat thread'", () => {
+    const msg = buildProviderTransientMessage("context_limit", "gemini");
+
+    expect(msg).toContain("Google Gemini");
+    expect(msg).toContain("fresh chat thread");
+  });
+});

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -19,6 +19,7 @@ import { runInRunSpan } from "./otel";
 import {
   buildProviderTransientMessage,
   classifyTransientError,
+  isQuotaError,
   isTransientError,
 } from "./transientErrors";
 
@@ -165,11 +166,14 @@ export async function streamWithRetry(
             span.recordError(cls);
             return { done: true };
           }
-          if (!isTransientError(error)) {
+          // Quota errors are technically retryable per HTTP semantics (429),
+          // but RPM/RPD/input-token quotas won't clear in the 3s retry window
+          // — treat as terminal so we don't burn 2 wasted attempts + ~6s.
+          if (isQuotaError(error) || !isTransientError(error)) {
             const cls = errorClassName(error);
             accumulator.setTerminalErrorClass(cls);
             span.recordError(cls);
-            await reportError(ctx, { ...errorReport, error });
+            await safeReportError(ctx, { ...errorReport, error });
             return { done: true };
           }
           return { done: false, error };
@@ -177,22 +181,27 @@ export async function streamWithRetry(
       };
 
       if ((await runAttempt(primaryAgent)).done) return accumulator;
+      // Finalize any pending assistant messages from the failed attempt before
+      // retrying. Otherwise the next attempt's history loader picks up
+      // orphaned tool-call / tool-result fragments and Gemini rejects with
+      // "function call turn must follow user/function-response turn".
+      // Cleanup must never abort the retry — best-effort only.
+      await safeFinalizePending(ctx, threadId, "transient_retry");
       accumulator.markRetry();
       await delay(RETRY_DELAY_MS);
       if ((await runAttempt(primaryAgent)).done) return accumulator;
+      await safeFinalizePending(ctx, threadId, "transient_retry");
       accumulator.markRetry();
 
       accumulator.markFallback("transient_exhaustion");
       const final = await runAttempt(fallbackAgent);
       if (final.done) return accumulator;
-      // Fallback also hit a transient error. Classify it, record the terminal
-      // class on the accumulator + span, then hand off to reportError — which
-      // surfaces a provider-attributed message for transient outages and falls
-      // back to the generic "trouble right now" message otherwise.
+      // Fallback also hit a transient error — surface a provider-attributed
+      // message via reportError (falls back to generic on classification miss).
       const cls = errorClassName(final.error);
       accumulator.setTerminalErrorClass(cls);
       span.recordError(cls);
-      await reportError(ctx, { ...errorReport, error: final.error });
+      await safeReportError(ctx, { ...errorReport, error: final.error });
       return accumulator;
     },
   );
@@ -315,7 +324,7 @@ async function finalizePendingMessages(
 ): Promise<void> {
   const result = await ctx.runQuery(components.agent.messages.listMessagesByThreadId, {
     threadId,
-    paginationOpts: { cursor: null, numItems: 10 },
+    paginationOpts: { cursor: null, numItems: 50 },
     order: "desc",
   });
   for (const message of result.page) {
@@ -325,6 +334,20 @@ async function finalizePendingMessages(
       result: { status: "failed", error: reason },
     });
   }
+}
+
+// Best-effort wrappers — failure inside cleanup/reporting must never escape
+// past runInRunSpan, or the user is left with a stuck pending message and no
+// surface for the original error.
+async function safeFinalizePending(ctx: ActionCtx, threadId: string, reason: string) {
+  try {
+    await finalizePendingMessages(ctx, threadId, reason);
+  } catch {}
+}
+async function safeReportError(ctx: ActionCtx, report: ErrorReport) {
+  try {
+    await reportError(ctx, report);
+  } catch {}
 }
 
 async function tryReportByok(ctx: ActionCtx, report: ErrorReport): Promise<boolean> {
@@ -352,7 +375,7 @@ async function reportError(ctx: ActionCtx, report: ErrorReport): Promise<void> {
 
   const transientKind = classifyTransientError(report.error);
   const content = transientKind
-    ? buildProviderTransientMessage(transientKind, report.provider)
+    ? buildProviderTransientMessage(transientKind, report.provider, report.isByok)
     : AI_ERROR_MESSAGE;
 
   await saveMessage(ctx, components.agent, {

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -160,15 +160,14 @@ export async function streamWithRetry(
           await attemptStream({ ctx, agent, promptArgs, telemetry, accumulator });
           return { done: true };
         } catch (error) {
-          if (await tryReportByok(ctx, { ...errorReport, error })) {
+          if (await safeTryReportByok(ctx, { ...errorReport, error })) {
             const cls = classifyByokError(error) ?? "byok_unknown_error";
             accumulator.setTerminalErrorClass(cls);
             span.recordError(cls);
             return { done: true };
           }
-          // Quota errors are technically retryable per HTTP semantics (429),
-          // but RPM/RPD/input-token quotas won't clear in the 3s retry window
-          // — treat as terminal so we don't burn 2 wasted attempts + ~6s.
+          // Quota errors are technically retryable (429), but RPM/RPD/input-token
+          // quotas won't clear in 3s — treat as terminal to avoid wasted retries.
           if (isQuotaError(error) || !isTransientError(error)) {
             const cls = errorClassName(error);
             accumulator.setTerminalErrorClass(cls);
@@ -181,11 +180,10 @@ export async function streamWithRetry(
       };
 
       if ((await runAttempt(primaryAgent)).done) return accumulator;
-      // Finalize any pending assistant messages from the failed attempt before
-      // retrying. Otherwise the next attempt's history loader picks up
-      // orphaned tool-call / tool-result fragments and Gemini rejects with
-      // "function call turn must follow user/function-response turn".
-      // Cleanup must never abort the retry — best-effort only.
+      // Clear pending rows before retry — otherwise the next attempt's
+      // history loader picks up orphaned tool-call/tool-result fragments
+      // and Gemini rejects with "function call turn must follow user/
+      // function-response turn".
       await safeFinalizePending(ctx, threadId, "transient_retry");
       accumulator.markRetry();
       await delay(RETRY_DELAY_MS);
@@ -196,8 +194,6 @@ export async function streamWithRetry(
       accumulator.markFallback("transient_exhaustion");
       const final = await runAttempt(fallbackAgent);
       if (final.done) return accumulator;
-      // Fallback also hit a transient error — surface a provider-attributed
-      // message via reportError (falls back to generic on classification miss).
       const cls = errorClassName(final.error);
       accumulator.setTerminalErrorClass(cls);
       span.recordError(cls);
@@ -337,18 +333,13 @@ async function finalizePendingMessages(
 }
 
 // Best-effort wrappers — failure inside cleanup/reporting must never escape
-// past runInRunSpan, or the user is left with a stuck pending message and no
-// surface for the original error.
-async function safeFinalizePending(ctx: ActionCtx, threadId: string, reason: string) {
-  try {
-    await finalizePendingMessages(ctx, threadId, reason);
-  } catch {}
-}
-async function safeReportError(ctx: ActionCtx, report: ErrorReport) {
-  try {
-    await reportError(ctx, report);
-  } catch {}
-}
+// runInRunSpan or the user is left with a stuck pending message.
+const safeFinalizePending = (ctx: ActionCtx, threadId: string, reason: string) =>
+  finalizePendingMessages(ctx, threadId, reason).catch(() => undefined);
+const safeReportError = (ctx: ActionCtx, report: ErrorReport) =>
+  reportError(ctx, report).catch(() => undefined);
+const safeTryReportByok = (ctx: ActionCtx, report: ErrorReport) =>
+  tryReportByok(ctx, report).catch(() => false);
 
 async function tryReportByok(ctx: ActionCtx, report: ErrorReport): Promise<boolean> {
   if (!report.isByok) return false;

--- a/convex/ai/stripOrphanedToolCalls.test.ts
+++ b/convex/ai/stripOrphanedToolCalls.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+import type { ModelMessage } from "ai";
+import { stripOrphanedToolCalls } from "./contextWindow";
+
+describe("stripOrphanedToolCalls", () => {
+  it("passes through messages with no tool calls", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ];
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("keeps paired tool-call and tool-result", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "check scores" },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "tc1", toolName: "get_scores", input: {} }],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "get_scores",
+            output: { type: "text", value: "done" },
+          },
+        ],
+      },
+      { role: "assistant", content: "Your scores are great." },
+    ];
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("keeps tool-calls that were resolved by an approval response", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Approve this push?" },
+          { type: "tool-call", toolCallId: "tc1", toolName: "approve_week_plan", input: {} },
+          { type: "tool-approval-request", approvalId: "ap1", toolCallId: "tc1" },
+        ],
+      },
+      {
+        role: "tool",
+        content: [{ type: "tool-approval-response", approvalId: "ap1", approved: true }],
+      },
+      { role: "user", content: "Looks good" },
+    ];
+
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("keeps tool-calls that have a pending approval request", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Approve this push?" },
+          { type: "tool-call", toolCallId: "tc1", toolName: "approve_week_plan", input: {} },
+          { type: "tool-approval-request", approvalId: "ap1", toolCallId: "tc1" },
+        ],
+      },
+      { role: "user", content: "What does this change?" },
+    ];
+
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("removes orphaned tool-call with no matching tool-result", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "check scores" },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "tc-orphan", toolName: "get_scores", input: {} },
+        ],
+      },
+      { role: "user", content: "try again" },
+    ];
+    const result = stripOrphanedToolCalls(msgs);
+    expect(result).toEqual([
+      { role: "user", content: "check scores" },
+      { role: "user", content: "try again" },
+    ]);
+  });
+
+  it("keeps text parts when only some tool-calls are orphaned", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "tool-call", toolCallId: "tc-good", toolName: "get_scores", input: {} },
+          { type: "tool-call", toolCallId: "tc-orphan", toolName: "search", input: {} },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-good",
+            toolName: "get_scores",
+            output: { type: "text", value: "ok" },
+          },
+        ],
+      },
+    ];
+    const result = stripOrphanedToolCalls(msgs);
+    expect(result).toHaveLength(3);
+    const assistantContent = result[1].content as Array<{ type: string; toolCallId?: string }>;
+    expect(assistantContent).toHaveLength(2);
+    expect(assistantContent[0]).toEqual({ type: "text", text: "Let me check." });
+    expect(assistantContent[1].toolCallId).toBe("tc-good");
+  });
+
+  it("handles string content on assistant messages", () => {
+    const msgs: ModelMessage[] = [{ role: "assistant", content: "just text" }];
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("removes orphaned tool-result whose tool-call was already stripped", () => {
+    // A partially-persisted retry left a tool role message with a tool-result
+    // that has no preceding assistant tool-call in the history.
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "check scores" },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-orphan",
+            toolName: "get_scores",
+            output: { type: "text", value: "leftover" },
+          },
+        ],
+      },
+      { role: "user", content: "try again" },
+    ];
+
+    const result = stripOrphanedToolCalls(msgs);
+
+    expect(result).toEqual([
+      { role: "user", content: "check scores" },
+      { role: "user", content: "try again" },
+    ]);
+  });
+
+  it("keeps tool messages whose tool-result references a paired assistant tool-call", () => {
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "check scores" },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "tc1", toolName: "get_scores", input: {} }],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "get_scores",
+            output: { type: "text", value: "done" },
+          },
+        ],
+      },
+      { role: "assistant", content: "Your scores are great." },
+    ];
+
+    expect(stripOrphanedToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("preserves tool-approval-response parts even when no toolCallId reference matches", () => {
+    // tool-approval-response is keyed by approvalId, not toolCallId,
+    // so it must survive even if no paired assistant tool-call is present.
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Approve this push?" },
+          { type: "tool-call", toolCallId: "tc1", toolName: "approve_week_plan", input: {} },
+          { type: "tool-approval-request", approvalId: "ap1", toolCallId: "tc1" },
+        ],
+      },
+      {
+        role: "tool",
+        content: [{ type: "tool-approval-response", approvalId: "ap1", approved: true }],
+      },
+      { role: "user", content: "Looks good" },
+    ];
+
+    const result = stripOrphanedToolCalls(msgs);
+
+    // The tool-approval-response message must survive intact
+    const toolMsg = result.find((m) => m.role === "tool");
+    expect(toolMsg).toBeDefined();
+    const parts = toolMsg!.content as Array<{ type: string; approvalId: string }>;
+    expect(parts).toHaveLength(1);
+    expect(parts[0].type).toBe("tool-approval-response");
+    expect(parts[0].approvalId).toBe("ap1");
+  });
+
+  it("strips only orphaned tool-result parts when message has mixed parts", () => {
+    // One tool-result references a kept assistant tool-call (tc-kept);
+    // another references a tool-call that was never emitted (tc-orphan).
+    // The orphaned part must be removed; the kept part must stay.
+    const msgs: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "tc-kept", toolName: "get_scores", input: {} }],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-kept",
+            toolName: "get_scores",
+            output: { type: "text", value: "ok" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc-orphan",
+            toolName: "search",
+            output: { type: "text", value: "stale" },
+          },
+        ],
+      },
+      { role: "assistant", content: "Here you go." },
+    ];
+
+    const result = stripOrphanedToolCalls(msgs);
+
+    const toolMsg = result.find((m) => m.role === "tool");
+    expect(toolMsg).toBeDefined();
+    const parts = toolMsg!.content as Array<{ type: string; toolCallId?: string }>;
+    expect(parts).toHaveLength(1);
+    expect(parts[0].toolCallId).toBe("tc-kept");
+  });
+});

--- a/convex/ai/transientErrors.ts
+++ b/convex/ai/transientErrors.ts
@@ -16,6 +16,65 @@ const TRANSIENT_MESSAGE_PATTERNS = [
 
 const OVERLOAD_MESSAGE_PATTERNS = ["high demand", "unavailable", "overloaded", "try again later"];
 
+// Vercel AI SDK wraps provider errors: .message is generic, the real text
+// lives on .responseBody / .cause.message. Pattern-match across all of them.
+function gatherErrorText(error: Error): string {
+  const parts: string[] = [error.message];
+  if ("responseBody" in error && typeof error.responseBody === "string") {
+    parts.push(error.responseBody);
+  }
+  if ("cause" in error && error.cause instanceof Error) {
+    parts.push(error.cause.message);
+  }
+  if ("data" in error && error.data && typeof error.data === "object") {
+    try {
+      parts.push(JSON.stringify(error.data));
+    } catch {
+      // Circular refs or BigInts in error.data must not crash classification —
+      // we still have .message + .responseBody to work with.
+    }
+  }
+  return parts.join(" ").toLowerCase();
+}
+
+/**
+ * Quota errors are technically retryable per HTTP semantics (status 429),
+ * but Gemini's RPM/RPD/input-token quotas don't clear in the 3s retry window.
+ * Treat them as terminal so we don't waste two extra attempts + ~6s.
+ */
+export function isQuotaError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const text = gatherErrorText(error);
+  if (isInputTokenCountQuota(text)) return true;
+  if (text.includes("you exceeded your current quota")) return true;
+  if (text.includes("resource_exhausted") && text.includes("quota")) return true;
+  if (text.includes("insufficient_quota")) return true;
+  return false;
+}
+
+/**
+ * Distinguishes Gemini's input-token quota (context too large) from other
+ * quota variants. Surfaces a "start a fresh thread" message instead of the
+ * generic rate-limit one.
+ */
+export function isContextLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return isInputTokenCountQuota(gatherErrorText(error));
+}
+
+// Require both the metric name AND an exceed/quota signal — a hypothetical
+// malformed-prompt error that mentions `input_token_count` shouldn't be
+// reclassified as a transient quota error and silently swallow Discord pages.
+function isInputTokenCountQuota(text: string): boolean {
+  if (!text.includes("input_token_count")) return false;
+  return (
+    text.includes("quota") ||
+    text.includes("exceed") || // matches exceed / exceeds / exceeded
+    text.includes("limit") || // Gemini sometimes phrases as "limit reached" / "limit exceeded"
+    text.includes("resource_exhausted")
+  );
+}
+
 export function isTransientError(error: unknown): boolean {
   // Prefer the SDK's own retry decision — it knows provider-specific cases
   // like Anthropic 529 "overloaded" that our pattern list would miss.
@@ -46,6 +105,7 @@ export function isTransientError(error: unknown): boolean {
 export type TransientErrorKind =
   | "provider_overload"
   | "rate_limit"
+  | "context_limit"
   | "timeout"
   | "network"
   | "server_error";
@@ -57,7 +117,13 @@ function extractStatus(error: unknown): number | undefined {
 }
 
 export function classifyTransientError(error: unknown): TransientErrorKind | null {
-  if (!isTransientError(error)) return null;
+  // Context-limit quota is checked before isTransientError because we treat
+  // it as terminal (skip retries) but still want a transient-style message.
+  // isContextLimitError already requires a quota signal, so unrelated errors
+  // mentioning "input_token_count" won't reach this branch.
+  if (isContextLimitError(error)) return "context_limit";
+
+  if (!isTransientError(error) && !isQuotaError(error)) return null;
 
   if (error instanceof TypeError && error.message.includes("fetch")) return "network";
 
@@ -68,6 +134,8 @@ export function classifyTransientError(error: unknown): TransientErrorKind | nul
     if (OVERLOAD_MESSAGE_PATTERNS.some((p) => lower.includes(p))) return "provider_overload";
     if (lower.includes("rate limit") || lower.includes("resource_exhausted")) return "rate_limit";
   }
+
+  if (isQuotaError(error)) return "rate_limit";
 
   const status = extractStatus(error);
   if (status === 429) return "rate_limit";
@@ -87,13 +155,21 @@ const SETTINGS_LINK = "[Settings](/settings)";
 export function buildProviderTransientMessage(
   kind: TransientErrorKind,
   provider: ProviderId,
+  isByok?: boolean,
 ): string {
   const label = getProviderConfig(provider).label;
   switch (kind) {
     case "provider_overload":
       return `**${label} is experiencing high demand right now** — this is on their end, not Roni. Try again in a moment, or switch providers in ${SETTINGS_LINK} if it keeps happening.`;
-    case "rate_limit":
-      return `**${label} rate-limited this request.** Give it a minute and try again.`;
+    case "rate_limit": {
+      const base = `**${label} rate-limited this request.** Give it a minute and try again.`;
+      if (isByok === false) {
+        return `${base} If this keeps happening, add your own ${label} API key in ${SETTINGS_LINK} to avoid the shared quota.`;
+      }
+      return base;
+    }
+    case "context_limit":
+      return `**This conversation has gotten too long for ${label}.** Start a fresh chat thread to continue.`;
     case "timeout":
       return `**That request timed out on ${label}'s side.** Try again — a shorter message sometimes helps.`;
     case "network":


### PR DESCRIPTION
## Summary

Batch fix for two production AI bugs surfaced in PostHog (project 360337). All ~17 active issues that share these root causes are addressed by these two changes.

- **g1 — Gemini "function call turn must follow user/function-response turn"** (158 occurrences, 57 users): Failed/aborted streaming attempts left orphaned `tool` role messages in the agent component's persisted history. On retry, history shape became `user → tool → user`, which Gemini rejects. Fixed by extending `stripOrphanedToolCalls` to also drop `tool` role messages whose `tool-result` parts reference no kept assistant tool-call.
- **g2 — Gemini quota / "high demand" / input-token-count retry exhaustion** (~125 occurrences, ~40 users): Quota errors were being retried 3× over ~6s, burning extra API calls without any chance of recovery. Fixed by classifying quota and `input_token_count` errors as terminal in `runAttempt`, surfacing a clean BYOK hint to house-key users when they're rate-limited, and showing a "start a fresh thread" message when the input-token quota is hit.

Additional defensive changes:
- `finalizePendingMessages` now runs between retry attempts (best-effort) so the next attempt's loaded history isn't polluted by partial pending rows from a failed prior attempt — directly reduces the g1 surface independently of the orphan-stripping fix.
- `safeFinalizePending` / `safeReportError` ensure cleanup or reporting failures never escape past `runInRunSpan` and leave users with stuck pending messages.
- `gatherErrorText`'s `JSON.stringify` is now circular-ref-safe.
- `isContextLimitError` requires both the metric name AND a quota/exceed signal so unrelated errors that happen to mention `input_token_count` don't get misclassified.

## PostHog issues addressed

| PostHog issue | Group | Occurrences | Users | Specialist |
|---|---|---|---|---|
| [019d510a](https://us.posthog.com/project/360337/error_tracking/019d510a-43f2-7b32-b574-9fc28c3d0fd4) | g1 | 158 | 57 | convex |
| [019d7fcc](https://us.posthog.com/project/360337/error_tracking/019d7fcc-bf4e-7173-bd13-bbe80cf51ff6) | g4 (downstream of g2) | 50 | 19 | convex |
| [019d7fd4-619c](https://us.posthog.com/project/360337/error_tracking/019d7fd4-619c-7910-b238-e78c23dbabe3) | g2 | 49 | 19 | convex |
| [019d4bce](https://us.posthog.com/project/360337/error_tracking/019d4bce-e4fa-79a1-bc5f-851ac720fc93) | g4 | 28 | 4 | convex |
| [019d88ad](https://us.posthog.com/project/360337/error_tracking/019d88ad-71dc-7510-8fb9-51b267043b5a) | g2 | 20 | 8 | convex |
| [019d7fd4-619d](https://us.posthog.com/project/360337/error_tracking/019d7fd4-619d-7632-a7d7-38fc4882f04a) | g4 | 12 | 7 | convex |
| [019d8244-288f](https://us.posthog.com/project/360337/error_tracking/019d8244-288f-73a1-b188-b4150a886c22) | g2 | 10 | 3 | convex |
| [019d8ddb](https://us.posthog.com/project/360337/error_tracking/019d8ddb-8367-7400-a105-44f86a1445e1) | g2 | 10 | 2 | convex |
| [019d9493](https://us.posthog.com/project/360337/error_tracking/019d9493-c839-7882-9c55-195e3e40f52a) | g2 | 10 | 7 | convex |
| [019da66b](https://us.posthog.com/project/360337/error_tracking/019da66b-ffd2-7170-b135-52d75dff4d4b) | g2 | 13 | 4 | convex |
| [019d9197-edb1](https://us.posthog.com/project/360337/error_tracking/019d9197-edb1-7c51-98d1-43115e5a9ca0) | g2 | 8 | 2 | convex |
| [019d930b](https://us.posthog.com/project/360337/error_tracking/019d930b-429b-71a3-9abf-8f8b72e275b0) | g2 | 6 | 2 | convex |
| [019db5af](https://us.posthog.com/project/360337/error_tracking/019db5af-6533-7903-8e58-516ac7627896) | g2 | 6 | 3 | convex |
| [019d8244-288e](https://us.posthog.com/project/360337/error_tracking/019d8244-288e-7971-ae93-09f9dcc3328f) | g4 | 5 | 1 | convex |
| [019d8337](https://us.posthog.com/project/360337/error_tracking/019d8337-d102-7d90-addc-ee0a936a28cb) | g4 | 6 | 2 | convex |
| [019d8842](https://us.posthog.com/project/360337/error_tracking/019d8842-400e-7d92-9149-b3182e9de7b8) | g2 | 4 | 3 | convex |

Files modified:
- `convex/ai/contextWindow.ts` — orphaned `tool` role message stripping (g1)
- `convex/ai/resilience.ts` — quota-as-terminal short-circuit, finalize-between-retries, safe error wrappers (g2)
- `convex/ai/transientErrors.ts` — `isQuotaError`, `isContextLimitError`, `context_limit` kind, BYOK hint in rate-limit message
- `convex/ai/contextWindow.test.ts` — moved `stripOrphanedToolCalls` block out (file-size cap)
- `convex/ai/stripOrphanedToolCalls.test.ts` (new) — covers existing + new tool-message stripping
- `convex/ai/quotaClassification.test.ts` (new) — covers `isQuotaError`, `isContextLimitError`, new `context_limit` kind, BYOK hint variant of `buildProviderTransientMessage`

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes (max-warnings=0)
- [x] `npm test` — 1460 tests pass / 13 skipped, 0 fail
- [x] New regression tests verify orphaned `tool` role messages are dropped while `tool-approval-response` parts are preserved
- [x] New regression tests verify quota errors are detected via message, responseBody, and APICallError shapes
- [x] New regression tests verify the BYOK hint appears only when `isByok === false`
- [x] All file-size caps (300 soft / 400 hard) respected after splitting tests by responsibility
- [ ] Manual verification on prod after deploy: confirm Gemini "function call turn" error stops appearing in PostHog within 24h

## Skipped

- 3rd-party browser-extension noise (~17 issues from a single Brave-on-iOS user with `__firefox__` injection): suppressed at the source isn't possible in this PR, but recommend adding a PostHog suppression rule on `value icontains __firefox__` to declutter the dashboard.
- `Script error.` (47 occ) and `runtime.sendMessage Tab not found` (27 occ): cross-origin extension noise with no actionable stack.
- ChunkLoadError (3 occ across 2 users): transient stale-deploy noise; self-resolves on reload.
- `ResizeObserver loop completed with undelivered notifications.` (4 occ, 1 user): benign Radix/shadcn noise.
- React #418 hydration mismatch (1 occ, 1 user): low-volume; deferred until reproducible.
- Single-user network errors (`Failed to fetch`, `Load failed`) on convex.cloud (~7 issues, all <5 occ each): transient client-side network failures.

## Deferred — needs human input

- [019d96f1](https://us.posthog.com/project/360337/error_tracking/019d96f1-d164-7d92-91fd-6bee070bf670) — Anthropic "credit balance is too low" error (2 occ, 1 user): suggests Anthropic is reachable as a BYOK provider, which is worth confirming against the Gemini-only language in AGENTS.md. Either way the BYOK error UX should sanitize this via `convex/ai/byokErrors.ts` rather than tracking it as an unhandled exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of orphaned AI tool interactions in conversation history
  * Enhanced quota and context limit error detection to prevent ineffective retries
  * Strengthened retry logic with better finalization of pending messages

* **New Features**
  * Better error messaging for context limits and quota issues, including guidance for API key configuration when using bring-your-own-key

<!-- end of auto-generated comment: release notes by coderabbit.ai -->