### PR TITLE
fix: exclude aborted streams from listMessages to silence TONALCOACH-1C client rejections

### DIFF
--- a/convex/chat.test.ts
+++ b/convex/chat.test.ts
@@ -1,0 +1,135 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.*s");
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const syncStreamsMock = vi.fn(async () => ({}));
+const listUIMessagesMock = vi.fn(async () => ({
+  page: [],
+  isDone: true,
+  continueCursor: "",
+}));
+
+// Keep the real @convex-dev/agent exports (validators, types, etc.) but replace
+// the two I/O functions that hit the agent component's tables.
+vi.mock("@convex-dev/agent", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@convex-dev/agent")>();
+  return {
+    ...original,
+    syncStreams: syncStreamsMock,
+    listUIMessages: listUIMessagesMock,
+  };
+});
+
+// assertThreadOwnership calls ctx.runQuery(components.agent.threads.getThread)
+// which is an external component unavailable in the test environment. Replace it
+// with a no-op so the listMessages handler can be exercised without the component.
+vi.mock("./chatHelpers", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./chatHelpers")>();
+  return {
+    ...original,
+    assertThreadOwnership: vi.fn(async () => {}),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const THREAD_ID = "test-thread-id";
+const PAGINATION_OPTS = { numItems: 10, cursor: null } as const;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("listMessages", () => {
+  beforeEach(() => {
+    syncStreamsMock.mockClear();
+    listUIMessagesMock.mockClear();
+  });
+
+  test("rejects unauthenticated access", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.query(api.chat.listMessages, {
+        threadId: THREAD_ID,
+        paginationOpts: PAGINATION_OPTS,
+        streamArgs: { kind: "list" },
+      }),
+    ).rejects.toThrow("Not authenticated");
+  });
+
+  test("excludes aborted streams (TONALCOACH-1C regression)", async () => {
+    // Root cause: syncStreams returns "aborted" streams by default. These contain
+    // error deltas from failed LLM attempts that the Vercel AI SDK client re-throws
+    // as unhandled promise rejections via the void (async () => {...})() pattern
+    // in useStreamingUIMessages.js. Passing includeStatuses: ["streaming", "finished"]
+    // prevents aborted streams from reaching the client entirely.
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+    const authed = t.withIdentity({ subject: `${userId}|session` });
+
+    await authed.query(api.chat.listMessages, {
+      threadId: THREAD_ID,
+      paginationOpts: PAGINATION_OPTS,
+      streamArgs: { kind: "list" },
+    });
+
+    expect(syncStreamsMock).toHaveBeenCalledOnce();
+
+    const syncStreamsOptions = syncStreamsMock.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(syncStreamsOptions?.includeStatuses).toEqual(["streaming", "finished"]);
+    expect(syncStreamsOptions?.includeStatuses).not.toContain("aborted");
+  });
+
+  test("merges paginated messages and stream data in the response", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+    const authed = t.withIdentity({ subject: `${userId}|session` });
+
+    listUIMessagesMock.mockResolvedValueOnce({
+      page: [{ id: "msg-1", role: "user" }],
+      isDone: true,
+      continueCursor: "cursor-abc",
+    });
+    syncStreamsMock.mockResolvedValueOnce({ activeStreams: [] });
+
+    const result = await authed.query(api.chat.listMessages, {
+      threadId: THREAD_ID,
+      paginationOpts: PAGINATION_OPTS,
+      streamArgs: { kind: "list" },
+    });
+
+    expect(result).toMatchObject({
+      page: [{ id: "msg-1", role: "user" }],
+      continueCursor: "cursor-abc",
+      streams: { activeStreams: [] },
+    });
+  });
+
+  test("forwards threadId and paginationOpts to listUIMessages", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+    const authed = t.withIdentity({ subject: `${userId}|session` });
+
+    await authed.query(api.chat.listMessages, {
+      threadId: THREAD_ID,
+      paginationOpts: PAGINATION_OPTS,
+      streamArgs: { kind: "list" },
+    });
+
+    expect(listUIMessagesMock).toHaveBeenCalledOnce();
+    const listUIMessagesOptions = listUIMessagesMock.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(listUIMessagesOptions?.threadId).toBe(THREAD_ID);
+    expect(listUIMessagesOptions?.paginationOpts).toEqual(PAGINATION_OPTS);
+  });
+});

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -130,9 +130,14 @@ export const listMessages = query({
       threadId: args.threadId,
       paginationOpts: args.paginationOpts,
     });
+    // Exclude aborted streams: they contain error deltas from failed LLM
+    // attempts that the Vercel AI SDK client re-throws as unhandled promise
+    // rejections (TONALCOACH-1C). Failed messages are already visible through
+    // the paginated query; aborted stream data is noise on the client.
     const streams = await syncStreams(ctx, components.agent, {
       threadId: args.threadId,
       streamArgs: args.streamArgs,
+      includeStatuses: ["streaming", "finished"],
     });
     return { ...paginated, streams };
   },


### PR DESCRIPTION
## Summary

- **TONALCOACH-1C (root-cause fix):** `listMessages` now passes `includeStatuses: ["streaming", "finished"]` to `syncStreams`, preventing aborted streams from reaching the client
- **TONALCOACH-3P / 1H / 3M / 3N / 9 / 12 / 11 / 17:** All resolved in the previous commit (`3af0285`); closed in Sentry
- Adds `convex/chat.test.ts` with four regression/contract tests for `listMessages`

## Root cause — TONALCOACH-1C

When a Gemini call fails, `@convex-dev/agent` writes the raw error text as a delta into the stream, then marks the stream `"aborted"`. By default, `syncStreams` returns all three statuses — `"streaming"`, `"finished"`, and `"aborted"`.

On the client, `useStreamingUIMessages` picks up those aborted stream deltas and feeds them to `readUIMessageStream({ terminateOnError: true })` (inside `updateFromUIMessageChunks`). When the error chunk is processed, `onError` fires, the loop breaks, the catch re-throws, and the whole thing lands as an **unhandled promise rejection** from the `void (async () => {...})()` wrapper in `useStreamingUIMessages.js`.

The failed message is already visible through the paginated query — the aborted stream adds nothing useful on the client and causes 552+ Sentry events.

## Fix

```ts
// convex/chat.ts — listMessages
const streams = await syncStreams(ctx, components.agent, {
  threadId: args.threadId,
  streamArgs: args.streamArgs,
  includeStatuses: ["streaming", "finished"], // ← exclude "aborted"
});
```

`syncStreams` already accepts `includeStatuses` as a first-class parameter. No client-side changes needed.

## Tests

`convex/chat.test.ts` covers:

| Test | What it guards |
|---|---|
| rejects unauthenticated access | auth guard stays in place |
| excludes aborted streams (TONALCOACH-1C regression) | `syncStreams` is called with `["streaming", "finished"]` and never `"aborted"` |
| merges paginated messages and stream data | response shape is correct |
| forwards threadId and paginationOpts to listUIMessages | query args are forwarded correctly |

The tests use `vi.mock` to replace `syncStreams`/`listUIMessages` (external agent component calls) and `assertThreadOwnership` (requires agent component tables unavailable in test env), while keeping all real validators via `importOriginal`.

## Test plan

- [x] `npx vitest run convex/chat.test.ts` — 4/4 pass
- [x] `npx vitest run --project backend` — 1093/1093 pass (no regressions)
- [x] Sentry issues 3P, 1H, 3M, 3N, 9, 12, 11, 17 marked resolved
- [ ] Deploy to production and confirm TONALCOACH-1C stops generating new events

https://claude.ai/code/session_019K4ewJkjGTY3JajYygeiHY

---
_Generated by [Claude Code](https://claude.ai/code/session_019K4ewJkjGTY3JajYygeiHY)_