### PR TITLE
perf: halve refresh-tonal-cache cadence to cut Convex billing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,16 +107,17 @@ User (chat) --> send message --> AI Coach Agent (Gemini, 31 tools) --> reads con
 
 ### Scheduled Jobs (`crons.ts`)
 
-- Every 15m: recover stuck workout pushes
 - Every 30m: refresh Tonal tokens
 - Every 1h: refresh active user cache (tiered by `appLastActiveAt` recency)
 - Every 1h: health check
 - Every 1h: activation checks
+- Every 1h: sweep expired Garmin OAuth states
 - Every 6h: check-in trigger evaluation (missed sessions, milestones)
 - Every 6h: garbage-collect orphaned chat-image storage (`internal.fileGc.vacuumUnusedFiles`)
+- Every 6h: sweep expired Garmin webhook events
 - Cron `0 3 * * *`: sync movement catalog
 - Cron `0 4 * * 0`: sync Tonal workout catalog
-- Cron `0 2 * * 0`: data retention cleanup
+- Cron `0 2 * * *`: data retention cleanup
 - All crons are disabled when `DISABLE_CRONS=true` is set (see `convex/lib/env.ts`)
 
 ### Frontend Routes (`src/app/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ User (chat) --> send message --> AI Coach Agent (Gemini, 31 tools) --> reads con
 
 - Every 15m: recover stuck workout pushes
 - Every 30m: refresh Tonal tokens
-- Every 30m: refresh active user cache (tiered by `appLastActiveAt` recency)
+- Every 1h: refresh active user cache (tiered by `appLastActiveAt` recency)
 - Every 1h: health check
 - Every 1h: activation checks
 - Every 6h: check-in trigger evaluation (missed sessions, milestones)

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -15,7 +15,7 @@ if (cronsEnabled()) {
 
   crons.interval(
     "refresh-tonal-cache",
-    { minutes: 30 },
+    { hours: 1 },
     internal.tonal.cacheRefresh.refreshActiveUsers,
   );
 

--- a/convex/tonal/cacheRefreshTiering.test.ts
+++ b/convex/tonal/cacheRefreshTiering.test.ts
@@ -57,7 +57,7 @@ describe("isEligibleForRefresh", () => {
     expect(isEligibleForRefresh(NOW, NOW - 48 * HOUR, undefined)).toBe(true);
   });
 
-  test("active-tier users sync at the 30-minute cadence with cron slack", () => {
+  test("active-tier users sync at the hourly cadence with cron slack", () => {
     const appActive = NOW - 30 * MIN;
     expect(isEligibleForRefresh(NOW, appActive, NOW - (TIER_INTERVALS_MS.active - 30 * 1000))).toBe(
       true,
@@ -65,19 +65,19 @@ describe("isEligibleForRefresh", () => {
     expect(isEligibleForRefresh(NOW, appActive, NOW - 5 * MIN)).toBe(false);
   });
 
-  test("recent-tier users wait an hour between syncs", () => {
+  test("recent-tier users wait two hours between syncs", () => {
     const appActive = NOW - 6 * HOUR;
-    expect(isEligibleForRefresh(NOW, appActive, NOW - 30 * MIN)).toBe(false);
-    expect(isEligibleForRefresh(NOW, appActive, NOW - (HOUR - 30 * 1000))).toBe(true);
-    expect(isEligibleForRefresh(NOW, appActive, NOW - 90 * MIN)).toBe(true);
+    expect(isEligibleForRefresh(NOW, appActive, NOW - 1 * HOUR)).toBe(false);
+    expect(isEligibleForRefresh(NOW, appActive, NOW - (2 * HOUR - 30 * 1000))).toBe(true);
+    expect(isEligibleForRefresh(NOW, appActive, NOW - 3 * HOUR)).toBe(true);
   });
 
-  test("lapsing-tier users wait six hours between syncs", () => {
+  test("lapsing-tier users wait twelve hours between syncs", () => {
     const appActive = NOW - 36 * HOUR;
     expect(isEligibleForRefresh(NOW, appActive, NOW - 1 * HOUR)).toBe(false);
-    expect(isEligibleForRefresh(NOW, appActive, NOW - 5 * HOUR)).toBe(false);
-    expect(isEligibleForRefresh(NOW, appActive, NOW - 6 * HOUR)).toBe(true);
+    expect(isEligibleForRefresh(NOW, appActive, NOW - 11 * HOUR)).toBe(false);
     expect(isEligibleForRefresh(NOW, appActive, NOW - 12 * HOUR)).toBe(true);
+    expect(isEligibleForRefresh(NOW, appActive, NOW - 24 * HOUR)).toBe(true);
   });
 });
 

--- a/convex/tonal/cacheRefreshTiering.ts
+++ b/convex/tonal/cacheRefreshTiering.ts
@@ -1,8 +1,8 @@
 /**
  * Pure helpers for tiering the refresh-tonal-cache cron by recent app activity.
  *
- * Active users get the existing 30-minute cadence; less-active cohorts back
- * off so the cron stops fanning out a sync to every connected user every run.
+ * Active users get an hourly cadence; less-active cohorts back off so the cron
+ * stops fanning out a sync to every connected user every run.
  */
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -16,9 +16,9 @@ export const TIER_THRESHOLDS_MS = {
 
 /** Minimum interval between cron-driven syncs for each tier. */
 export const TIER_INTERVALS_MS = {
-  active: HOUR_MS / 2,
-  recent: HOUR_MS,
-  lapsing: 6 * HOUR_MS,
+  active: HOUR_MS,
+  recent: 2 * HOUR_MS,
+  lapsing: 12 * HOUR_MS,
 } as const;
 
 // Cron interval scheduling skews by a few seconds; without slack a tier-1 user

--- a/convex/tonal/historySync.ts
+++ b/convex/tonal/historySync.ts
@@ -277,7 +277,7 @@ export const startSyncUserHistory = internalMutation({
 
     // Record the attempt unconditionally so the cron's tier gate throttles
     // the next pass — otherwise a profile with `lastTonalSyncAt === undefined`
-    // and a fresh cache stays eligible every 30 minutes forever.
+    // and a fresh cache stays eligible every cron run forever.
     await ctx.db.patch(profile._id, {
       lastTonalSyncAt: now,
       nextTonalSyncAt: computeNextSyncAt(now, profile.appLastActiveAt, now),

--- a/convex/tonal/historySyncPreflight.ts
+++ b/convex/tonal/historySyncPreflight.ts
@@ -1,10 +1,10 @@
 /**
  * Pure helper that decides whether to skip a cron-driven history sync.
  *
- * The cron runs every 30 minutes for active users; when the last sync just
- * happened and we already have a recent activity high-water mark, kicking off
- * the workflow again is wasted work. Conservative: when we cannot prove
- * freshness, return false so the sync proceeds.
+ * The cron runs hourly for active users; when the last sync just happened and
+ * we already have a recent activity high-water mark, kicking off the workflow
+ * again is wasted work. Conservative: when we cannot prove freshness, return
+ * false so the sync proceeds.
  */
 
 import { CACHE_TTLS } from "./cache";


### PR DESCRIPTION
## Summary

Apr invoice context: ~37 M function calls and ~247 GB of database bandwidth in 27 days, ~$64 for the period. The biggest single driver is the `refresh-tonal-cache` cron, which fans a 4-action sync workflow out to every "active" user every 30 minutes.

This PR halves the per-user refresh cadence across all tiers and bumps the cron polling interval to match.

| tier    | before  | after   |
|---------|---------|---------|
| active  | 30 min  | 60 min  |
| recent  | 60 min  | 2 h     |
| lapsing | 6 h     | 12 h    |
| cron    | 30 min  | 60 min  |

User-facing freshness is unchanged when someone is actively in the app: `recordAppActivity` recomputes `nextTonalSyncAt` the moment they open it, and onboarding/reconnect still trigger `backfillUserHistoryWorkflow` directly. Only background warming for users who aren't currently using the app slows down.

Expected impact: roughly halves the cron's contribution to function calls and database bandwidth.

## Files

- `convex/crons.ts` — refresh-tonal-cache interval 30m → 1h
- `convex/tonal/cacheRefreshTiering.ts` — TIER_INTERVALS_MS halved
- `convex/tonal/cacheRefreshTiering.test.ts` — test names + assertions updated
- `convex/tonal/historySync.ts`, `convex/tonal/historySyncPreflight.ts` — doc comments

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest --project backend run` — 1113 passed, 13 skipped
- [ ] Verify Convex usage drops in the next billing cycle
- [ ] Confirm chat / dashboard data freshness still acceptable for users who weren't in active tier

## Follow-ups (not in this PR)

From the same investigation, the next-highest-leverage cuts:

1. Replace `.collect()` on `movements` in `prs.ts:127` and `prs.ts:164` with a targeted lookup
2. Add compound index on `personalRecords` by `(userId, movementId)` so `workoutDetail.ts:80` doesn't scan all PRs
3. Audit `aiToolCalls` row size — `argsJson` and `resultPreview` may be carrying multi-KB payloads per tool call

https://claude.ai/code/session_018eHH2tPkEsSc1feT3RbjdG

---
_Generated by [Claude Code](https://claude.ai/code/session_018eHH2tPkEsSc1feT3RbjdG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized sync operation scheduling. Background data synchronization now runs at extended intervals (hourly for active users, with longer intervals for less active users) to improve system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->