### PR TITLE
fix(coachState): widen aiRun.snapshotSource validator to unblock prod deploy

### DIFF
--- a/convex/aiUsage.ts
+++ b/convex/aiUsage.ts
@@ -61,7 +61,15 @@ const aiRunArgs = {
   snapshotBuildMs: v.optional(v.number()),
   contextBuildCount: v.optional(v.number()),
   contextMessageCount: v.optional(v.number()),
-  snapshotSource: v.optional(v.literal("live_rebuild")),
+  // Hotfix: widened to accept legacy literals (matches schema.ts). Re-narrow
+  // once the narrowSnapshotSource migration completes on prod.
+  snapshotSource: v.optional(
+    v.union(
+      v.literal("live_rebuild"),
+      v.literal("coach_state_fresh"),
+      v.literal("coach_state_stale"),
+    ),
+  ),
   retrievalEnabled: v.optional(v.boolean()),
   approvalPauses: v.number(),
   workoutPlanCreatedId: v.optional(v.id("workoutPlans")),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -525,7 +525,16 @@ export default defineSchema({
     snapshotBuildMs: v.optional(v.number()),
     contextBuildCount: v.optional(v.number()),
     contextMessageCount: v.optional(v.number()),
-    snapshotSource: v.optional(v.literal("live_rebuild")),
+    // Hotfix: widened to accept legacy literals so existing aiRun rows validate
+    // until the narrowSnapshotSource migration backfills them. Re-narrow to
+    // v.literal("live_rebuild") in a follow-up commit once the migration completes.
+    snapshotSource: v.optional(
+      v.union(
+        v.literal("live_rebuild"),
+        v.literal("coach_state_fresh"),
+        v.literal("coach_state_stale"),
+      ),
+    ),
     retrievalEnabled: v.optional(v.boolean()),
 
     approvalPauses: v.number(),


### PR DESCRIPTION
## Summary

Hotfix for the prod deploy failure after #295 merged:

```
Schema validation failed.
Document with ID "px70168fa0g7p3j0q2d1ffa37s85jdka" in table "aiRun" does not match the schema:
"coach_state_fresh" does not match literal validator v.literal("live_rebuild"). Path: .snapshotSource
```

#295 narrowed `aiRun.snapshotSource` to `v.literal("live_rebuild")` on the assumption that the `narrowSnapshotSource` migration would run before the schema deploy. Vercel auto-deployed on merge before anyone could invoke the migration. Existing aiRun rows still hold `"coach_state_fresh"` / `"coach_state_stale"`, so the deploy is now stuck.

This widens the validator on `aiRun.snapshotSource` (`convex/schema.ts:528` + `convex/aiUsage.ts:64`) back to the 3-literal union so the deploy proceeds. The TS narrowing in `runTelemetry.ts` and `trainingSnapshotCache.ts` is intentionally left in place — only `"live_rebuild"` is produced post-T1, so the type narrow is correct for new writes; the validator widening just lets old data validate during the transition.

## Recovery runbook

1. Merge this PR. Vercel re-deploys with the widened validator → schema validation passes → prod is unstuck.
2. Run on prod (now possible because the migration code is deployed):
   ```bash
   npx convex run migrations:run '{"fn": "migrations/dropCoachStateCache:narrowSnapshotSource"}' --prod
   # Loop until result.complete === true:
   npx convex run migrations/dropCoachStateCache:runDropCoachStateRows --prod
   ```
3. Once both migrations report complete, I'll push a follow-up commit re-narrowing `snapshotSource` to `v.literal("live_rebuild")` only.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Vercel deploy succeeds (the actual gate)
- [ ] `narrowSnapshotSource` migration runs on prod
- [ ] `runDropCoachStateRows` migration runs on prod (loop until complete)
- [ ] Follow-up PR re-narrows the validator and deploys cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend compatibility to support legacy data formats during system maintenance and data migration transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->