### PR TITLE
refactor(coachState): re-narrow aiRun.snapshotSource to live_rebuild

### DIFF
--- a/convex/aiUsage.ts
+++ b/convex/aiUsage.ts
@@ -61,15 +61,7 @@ const aiRunArgs = {
   snapshotBuildMs: v.optional(v.number()),
   contextBuildCount: v.optional(v.number()),
   contextMessageCount: v.optional(v.number()),
-  // Hotfix: widened to accept legacy literals (matches schema.ts). Re-narrow
-  // once the narrowSnapshotSource migration completes on prod.
-  snapshotSource: v.optional(
-    v.union(
-      v.literal("live_rebuild"),
-      v.literal("coach_state_fresh"),
-      v.literal("coach_state_stale"),
-    ),
-  ),
+  snapshotSource: v.optional(v.literal("live_rebuild")),
   retrievalEnabled: v.optional(v.boolean()),
   approvalPauses: v.number(),
   workoutPlanCreatedId: v.optional(v.id("workoutPlans")),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -525,16 +525,7 @@ export default defineSchema({
     snapshotBuildMs: v.optional(v.number()),
     contextBuildCount: v.optional(v.number()),
     contextMessageCount: v.optional(v.number()),
-    // Hotfix: widened to accept legacy literals so existing aiRun rows validate
-    // until the narrowSnapshotSource migration backfills them. Re-narrow to
-    // v.literal("live_rebuild") in a follow-up commit once the migration completes.
-    snapshotSource: v.optional(
-      v.union(
-        v.literal("live_rebuild"),
-        v.literal("coach_state_fresh"),
-        v.literal("coach_state_stale"),
-      ),
-    ),
+    snapshotSource: v.optional(v.literal("live_rebuild")),
     retrievalEnabled: v.optional(v.boolean()),
 
     approvalPauses: v.number(),


### PR DESCRIPTION
## Summary

Closes the loop on the #295 → #298 widen → migrate → narrow recovery. Both migrations have completed on prod:

- **`narrowSnapshotSource`**: 614 aiRun rows scanned, all legacy `coach_state_fresh` / `coach_state_stale` values rewritten to `live_rebuild`. State `success`, `isDone: true`.
- **`runDropCoachStateRows`**: 209 coachState rows dropped across 2 batches. `complete: true`.

With the data clean, this PR reverts the temporary widening from #298. `aiRun.snapshotSource` returns to the post-T3 intended shape: `v.optional(v.literal("live_rebuild"))` in both `convex/schema.ts` and `convex/aiUsage.ts`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Vercel deploys cleanly (the actual gate — convex schema deploy validates against current data, which no longer contains legacy literals)

## Note

This unblocks the original goal of #295: the schema reflects "lazy snapshot only, one literal" and the runtime values produced post-T1 (always `"live_rebuild"`) match the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)