### PR TITLE
chore(convex): add convex:smoke pre-push gate for schema changes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Smoke-test Convex schema/validator changes against the dev deployment before
+# they hit a remote that auto-deploys to prod (Vercel).
+#
+# Why: schema-narrowing PRs can pass tsc, lint, and unit tests yet still fail
+# on prod because Convex schema validation runs against existing rows at deploy
+# time, not in CI. Pushing to dev (`convex dev --once`) reproduces the same
+# validation against dev data — fails locally if the new schema rejects rows
+# that exist in dev.
+#
+# Caveat: dev is shared across workspaces (see AGENTS.md). The push to dev
+# briefly changes its schema. If you're working alongside others, coordinate.
+# Skip with `git push --no-verify` if needed.
+
+# Determine the commit range about to be pushed.
+range="@{upstream}..HEAD"
+if ! git rev-parse "$range" >/dev/null 2>&1; then
+  range="origin/main..HEAD"
+fi
+
+# Only run smoke when the push touches schema or validator files.
+if git diff --name-only "$range" 2>/dev/null | grep -qE '^convex/(schema|aiUsage)\.ts$'; then
+  echo "[pre-push] Convex schema/validator change detected. Running convex:smoke..."
+  if ! npm run convex:smoke; then
+    echo ""
+    echo "[pre-push] convex:smoke failed. Common causes:"
+    echo "  - new validator narrower than existing data → widen-migrate-narrow"
+    echo "  - new required field on existing table → add as optional first"
+    echo "Bypass with 'git push --no-verify' if you understand the risk."
+    exit 1
+  fi
+fi
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,12 @@ npm run build               # Production build
 npx convex env set KEY value   # Set backend environment variable
 npx convex deploy              # Deploy to production
 
+# Smoke-test schema changes against the dev deployment before pushing.
+# Pushes the branch's schema to dev once; fails locally if any existing row
+# fails validation under the new shape. Auto-runs via the pre-push hook on
+# any push that touches convex/schema.ts or convex/aiUsage.ts.
+npm run convex:smoke
+
 # Silence cron jobs on dev (optional, recommended)
 npx convex env set DISABLE_CRONS true
 ```
@@ -253,6 +259,7 @@ When principles conflict, the higher number always wins.
 - Every new mutation/action: check if it needs rate limiting (see `convex/rateLimits.ts`).
 - Validate external input with Zod at the action boundary. Internal functions receive typed data.
 - The Tonal API integration uses `cachedFetch` pattern -- check cache, fetch if expired, update cache.
+- **Schema narrows that could reject existing rows must use widen → migrate → narrow.** Convex validates schema against existing data on `npx convex deploy` (Vercel runs this on every merge to main). A narrowing PR that ships before its data backfill migration runs will fail the deploy and lock prod until recovered. Pattern: PR 1 ships the migration code with the validator still wide; operator runs the migration; PR 2 ships the narrow. The `npm run convex:smoke` pre-push hook catches this against the dev deployment if dev has the same data shape.
 
 ## Key Type Locations
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
+    "convex:smoke": "convex dev --once --typecheck enable",
     "setup": "tsx scripts/setup.ts",
     "knip": "knip",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary

Catches the class of failure that bit #295 → #298: a schema narrow that rejects existing rows passed tsc, lint, and unit tests but failed Convex deploy on Vercel because Convex validates the schema against live data on push. Recovery required widen → migrate → narrow across two PRs.

## What's added

- **`npm run convex:smoke`** — runs `convex dev --once --typecheck enable`. Pushes the branch's schema to the shared dev deployment (free, ~10s). Schema validation fails locally if dev has any row the new schema rejects.
- **`.husky/pre-push`** — auto-runs the smoke when a push touches `convex/schema.ts` or `convex/aiUsage.ts`. Skips otherwise. Bypassable with `git push --no-verify`.
- **AGENTS.md** — documents the smoke command and the standing widen → migrate → narrow rule for schema narrows.

## Why not `convex deploy --dry-run`?

Verified locally: `--dry-run` only runs typecheck + codegen + prints generated config. It never pushes to any deployment, so schema-vs-data validation never runs. It would not have caught the #295 incident.

## Tradeoffs (in commit body and AGENTS.md)

1. The smoke pushes to the **shared dev deployment**, briefly changing its schema. AGENTS.md already warns about parallel schema work; this gate inherits the same constraint.
2. Catches only what dev data exposes. If dev is wiped or never had rows matching the failing pattern, the smoke passes a narrow that would still fail prod. Two-PR widen → migrate → narrow remains the safe pattern; the gate is defense in depth.

## Test plan

- [x] `npm run convex:smoke` runs locally in 7.4s, schema validation passes against dev.
- [x] Pre-push gate logic verified: a diff touching only `package.json`/`AGENTS.md`/`.husky/pre-push` skips the smoke (this PR's push); a diff range touching `convex/schema.ts` (e.g. 0ca0696..3b87ecd) triggers it.
- [ ] Reviewer pushes a no-op schema change to confirm the hook fires and the bypass (`--no-verify`) works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic schema validation on code push to prevent invalid changes from being submitted.

* **Documentation**
  * Updated development guidelines with schema modification procedures and validation workflows.

* **Chores**
  * Added npm script for schema validation with TypeScript checking enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->