### PR TITLE
feat(coach-tools): expose warmUp flag on add_exercise tool

### DIFF
--- a/convex/ai/weekModificationTools.test.ts
+++ b/convex/ai/weekModificationTools.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { addExerciseTool } from "./weekModificationTools";
+
+describe("addExerciseTool input schema", () => {
+  test("accepts warmUp:true as a valid argument", () => {
+    // inputSchema is a ZodObject at runtime; cast needed because FlexibleSchema
+    // is a union type that doesn't uniformly expose safeParse.
+    const schema = addExerciseTool.inputSchema as z.ZodObject<z.ZodRawShape>;
+    const parsed = schema.safeParse({
+      dayIndex: 0,
+      movementId: "mov-test",
+      sets: 2,
+      duration: 30,
+      warmUp: true,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.warmUp).toBe(true);
+    }
+  });
+});

--- a/convex/ai/weekModificationTools.ts
+++ b/convex/ai/weekModificationTools.ts
@@ -83,7 +83,7 @@ export const swapExerciseTool = createTool({
 
 export const addExerciseTool = createTool({
   description:
-    "Add an exercise to a specific day's draft workout. Use this when the user wants to include an extra exercise (e.g., a finisher, an isolation move) without rebuilding the week. The exercise is added as a new straight-set block before the cooldown. The movementId MUST come from a prior search_exercises result.",
+    "Add an exercise to a specific day's draft workout. Use this when the user wants to include an extra exercise (e.g., a finisher, an isolation move) without rebuilding the week. The exercise is added as a new straight-set block before the cooldown. Pass warmUp:true to mark the exercise as a warmup. The movementId MUST come from a prior search_exercises result.",
   inputSchema: z.object({
     dayIndex: z.number().int().min(0).max(6).describe("Day of the week: 0=Monday..6=Sunday"),
     movementId: z.string().describe("The movement ID to add (from search_exercises)"),
@@ -98,6 +98,12 @@ export const addExerciseTool = createTool({
     chains: z.boolean().optional().describe("Enable chains mode"),
     burnout: z.boolean().optional().describe("Enable burnout/AMRAP on this exercise"),
     dropSet: z.boolean().optional().describe("Enable drop set mode"),
+    warmUp: z
+      .boolean()
+      .optional()
+      .describe(
+        "Mark this exercise as a warmup. Sets warmUp:true on the persisted exercise so Tonal renders it as a warmup. Use for mobility, activation, and prep movements at the top of the session.",
+      ),
   }),
   execute: withToolTracking(
     "add_exercise",

--- a/convex/coach/weekModifications.test.ts
+++ b/convex/coach/weekModifications.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from "vitest";
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, it, test } from "vitest";
+import { internal } from "../_generated/api";
+import schema from "../schema";
 import type { BlockInput } from "../tonal/transforms";
+
+// Vite normalizes same-directory glob keys to "./foo.ts" instead of
+// "../coach/foo.ts", which breaks convex-test module resolution.
+// Remap ./foo.ts -> ../coach/foo.ts to match the expected path format.
+const rawModules = import.meta.glob("../**/*.*s");
+const modules: typeof rawModules = {};
+for (const [key, value] of Object.entries(rawModules)) {
+  modules[key.startsWith("./") ? "../coach/" + key.slice(2) : key] = value;
+}
 
 /** Pure version of the swap logic from weekModifications.ts for unit testing. */
 function swapMovementInBlocks(
@@ -101,5 +114,62 @@ describe("day slot swap (pure logic)", () => {
     const days: DaySlot[] = [{ sessionType: "push", status: "programmed", workoutPlanId: "wp1" }];
     const result = swapDays(days, 0, 0);
     expect(result).toEqual(days);
+  });
+});
+
+describe("addExerciseToDraft warmUp passthrough", () => {
+  test("persists warmUp:true on the new exercise when the arg is set", async () => {
+    const t = convexTest(schema, modules);
+
+    const userId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {});
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("movements", {
+        tonalId: "mov-warmup-1",
+        name: "Cat-Cow",
+        shortName: "Cat-Cow",
+        muscleGroups: ["Back"],
+        skillLevel: 1,
+        publishState: "published",
+        sortOrder: 1,
+        onMachine: false,
+        inFreeLift: true,
+        countReps: false,
+        isTwoSided: false,
+        isBilateral: false,
+        isAlternating: false,
+        descriptionHow: "On all fours, alternate between arching and rounding your back.",
+        descriptionWhy: "Improves spinal mobility.",
+        lastSyncedAt: Date.now(),
+      });
+    });
+
+    const planId = await t.run(async (ctx) => {
+      return ctx.db.insert("workoutPlans", {
+        userId,
+        title: "Test",
+        blocks: [{ exercises: [{ movementId: "mov-other", sets: 3, reps: 10 }] }],
+        status: "draft",
+        createdAt: Date.now(),
+      });
+    });
+
+    const result = await t.mutation(internal.coach.weekModifications.addExerciseToDraft, {
+      userId,
+      workoutPlanId: planId,
+      movementId: "mov-warmup-1",
+      sets: 2,
+      duration: 30,
+      warmUp: true,
+    });
+
+    expect(result.ok).toBe(true);
+
+    const wp = await t.run((ctx) => ctx.db.get(planId));
+    const lastBlockExercise = wp!.blocks.at(-1)!.exercises[0];
+    expect(lastBlockExercise.movementId).toBe("mov-warmup-1");
+    expect(lastBlockExercise.warmUp).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `warmUp: z.boolean().optional()` to `addExerciseTool.inputSchema`.
- Updates the tool description to explain warmup semantics.
- Mutation `internal.coach.weekModifications.addExerciseToDraft` already accepted `warmUp` and forwarded it via `...opts` — only the tool-layer schema needed the field.

## Why

Production trace (David Goldsmith, run `b1d3b8ba…`): the LLM called `add_exercise × 3` to add Cat-Cow / Glute Bridge / Dead Bug as warmups. All persisted with `warmUp: false` because the tool schema didn't expose the flag, even though the underlying mutation supported it. Result: Tonal didn't render them as warmups.

## Recommended ship order

7-PR series fixing the AI coach's "what it says vs. what shows up on Tonal" mismatch. Each PR is independently shippable. Suggested order, lowest-risk first:

1. 👉 **this PR** — `feat/add-exercise-warmup-flag` — expose existing `warmUp` field on `add_exercise` tool
2. `feat/tighten-search-exercises` — strict name-only matching by default + `trainingType` allowlist
3. `fix/add-exercise-silent-drop` — integrity guard against silent block drops
4. `feat/program-week-injury-filter-diagnostics` — surface degenerate exercise selection
5. `feat/set-warmup-block-tool` — new tool for multi-exercise warmups
6. `feat/rebuild-day-tool` — new tool for full-block authoring inside the week plan
7. `feat/push-verification` — real Tonal read-back + diff against intent (schema widening)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest --project backend run` passes (1112 tests, +2 new)
- [x] Schema test: `safeParse({warmUp:true})` succeeds and round-trips
- [x] Mutation regression test: persisted exercise actually has `warmUp: true`
- [ ] Smoke check on staging: ask Roni to "add Cat-Cow as a warmup to Monday" → verify the persisted block has `warmUp: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exercises can now be marked as warm-ups when added to your workout plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->