### PR TITLE
feat(coach-tools): tighten search_exercises (name-strict mode + trainingType allowlist)

### DIFF
--- a/convex/ai/tools.test.ts
+++ b/convex/ai/tools.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { KNOWN_TRAINING_TYPES, searchExercisesTool } from "./tools";
+
+describe("searchExercisesTool input schema", () => {
+  it("rejects 'Warm-up' as trainingType (not a real catalog tag)", () => {
+    const parsed = (searchExercisesTool.inputSchema as z.ZodObject<z.ZodRawShape>).safeParse({
+      trainingType: "Warm-up",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts the known catalog trainingTypes", () => {
+    for (const t of KNOWN_TRAINING_TYPES) {
+      const parsed = (searchExercisesTool.inputSchema as z.ZodObject<z.ZodRawShape>).safeParse({
+        trainingType: t,
+      });
+      expect(parsed.success).toBe(true);
+    }
+  });
+});

--- a/convex/ai/tools.ts
+++ b/convex/ai/tools.ts
@@ -11,24 +11,42 @@ import type {
 import type { EnrichedWorkoutDetail } from "../workoutDetail";
 import { requireUserId, withToolTracking } from "./helpers";
 
+export const KNOWN_TRAINING_TYPES = [
+  "Strength",
+  "High Intensity",
+  "Mobility",
+  "Recovery",
+  "Yoga",
+  "Pilates",
+  "Pre & Postnatal",
+] as const;
+
 export const searchExercisesTool = createTool({
   description:
-    "Search Tonal's exercise catalog by name, muscle group, and/or training type. Use this before naming, suggesting, swapping, or programming exercises; results include canonical Tonal names, movement IDs, accessory requirements, and duration-vs-rep behavior.",
+    "Search Tonal's exercise catalog by name, muscle group, and/or training type. Use this before naming, suggesting, swapping, or programming exercises; results include canonical Tonal names, movement IDs, accessory requirements, and duration-vs-rep behavior. Default match is name-strict (matches name/shortName only) — set looseMatch:true to also match in descriptions if a strict search returns nothing.",
   inputSchema: z.object({
     name: z
       .string()
       .optional()
       .describe(
-        "Exercise name or common name (e.g. 'Romanian Deadlift', 'RDL'). Use shorter names when an exact search misses.",
+        "Exercise name or common name (e.g. 'Romanian Deadlift', 'RDL'). Match is on name and shortName by default — descriptions are not searched.",
       ),
     muscleGroup: z
       .string()
       .optional()
       .describe("Use when exploring options for a body part, e.g. Chest, Back, Quads, Shoulders."),
     trainingType: z
-      .string()
+      .enum(KNOWN_TRAINING_TYPES)
       .optional()
-      .describe("Use to narrow by type: Warm-up, Mobility, Recovery, Yoga, Strength, etc."),
+      .describe(
+        `Use to narrow by type. Valid values: ${KNOWN_TRAINING_TYPES.join(", ")}. Note: there is NO 'Warm-up' tag — Tonal warmups are tagged 'Mobility'.`,
+      ),
+    looseMatch: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, fall back to matching in exercise descriptions in addition to name/shortName. Use only if a strict search returns no results. Default: false (strict, name-only).",
+      ),
   }),
   execute: withToolTracking("search_exercises", async (ctx, input, _options) => {
     const results = (await ctx.runQuery(internal.tonal.movementSearchQueries.searchMovements, {
@@ -36,6 +54,7 @@ export const searchExercisesTool = createTool({
       muscleGroup: input.muscleGroup,
       trainingType: input.trainingType,
       limit: 30,
+      matchMode: input.looseMatch ? "loose" : "strict",
     })) as Movement[];
 
     return results.map((m) => ({

--- a/convex/tonal/movementSearch.test.ts
+++ b/convex/tonal/movementSearch.test.ts
@@ -3,6 +3,7 @@ import {
   buildListSearchText,
   buildMovementSearchFields,
   matchesNameSearch,
+  matchesNameSearchStrict,
 } from "./movementSearch";
 
 const rdl = {
@@ -134,6 +135,49 @@ describe("matchesNameSearch", () => {
   it("matches hamstring curl → prone bench hamstring curl", () => {
     const pbhc = { name: "Prone Bench Hamstring Curl", shortName: "Prone Bench Hamstring Curl" };
     expect(matchesNameSearch(pbhc, "hamstring curl")).toBe(true);
+  });
+});
+
+describe("matchesNameSearchStrict", () => {
+  const cat = {
+    name: "Single Leg Chop",
+    shortName: "SL Chop",
+    descriptionHow: "Brace glutes and bridge core to maintain stability",
+    descriptionWhy: "Trains anti-rotation",
+  };
+
+  it("does NOT match on description-only hits", () => {
+    expect(matchesNameSearchStrict(cat, "Glute Bridge")).toBe(false);
+  });
+
+  it("matches on direct name substring", () => {
+    expect(matchesNameSearchStrict({ ...cat, name: "Resisted Glute Bridge" }, "Glute Bridge")).toBe(
+      true,
+    );
+  });
+
+  it("matches on alias group within name only", () => {
+    const sldlMovement = {
+      name: "Single Leg Romanian Deadlift",
+      shortName: "SL RDL",
+      descriptionHow: "",
+      descriptionWhy: "",
+    };
+    expect(matchesNameSearchStrict(sldlMovement, "RDL")).toBe(true);
+  });
+
+  it("returns false when query has no name overlap even if descriptions hint at it", () => {
+    expect(
+      matchesNameSearchStrict(
+        {
+          name: "Standing Chop",
+          shortName: "Std Chop",
+          descriptionHow: "Hip thrust pattern",
+          descriptionWhy: "",
+        },
+        "Hip Thrust",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/convex/tonal/movementSearch.ts
+++ b/convex/tonal/movementSearch.ts
@@ -168,6 +168,31 @@ export function matchesNameSearch(movement: SearchableMovement, query: string): 
   return false;
 }
 
+/**
+ * Strict name-only matcher. Identical to matchesNameSearch except descriptions
+ * are excluded — name and shortName only. Aliases still expand. Use when callers
+ * want a low-false-positive search (e.g. LLM tools picking a specific movement).
+ */
+export function matchesNameSearchStrict(movement: SearchableMovement, query: string): boolean {
+  const q = query.toLowerCase().trim();
+  if (!q) return true;
+
+  const fields = [movement.name.toLowerCase(), movement.shortName.toLowerCase()];
+
+  if (fields.some((f) => f.includes(q))) return true;
+
+  const queryWords = q.split(/[\s\-]+/).filter((w) => w.length >= 3);
+  if (queryWords.some((w) => fields.some((f) => f.includes(w)))) return true;
+
+  const termsToExpand = [q, ...queryWords, ...buildSubphrases(queryWords)];
+  for (const term of termsToExpand) {
+    const aliases = ALIAS_LOOKUP.get(term);
+    if (aliases?.some((a) => fields.some((f) => f.includes(a)))) return true;
+  }
+
+  return false;
+}
+
 function addSearchTerm(terms: Set<string>, value: string) {
   const normalized = normalizeSearchText(value);
   if (normalized) terms.add(normalized);

--- a/convex/tonal/movementSearchQueries.test.ts
+++ b/convex/tonal/movementSearchQueries.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import { internal } from "../_generated/api";
 import schema from "../schema";
 import { buildListSearchText } from "./movementSearch";
@@ -221,6 +221,51 @@ describe("searchMovements", () => {
     expect(second).toMatchObject({ scanned: 1, patched: 1, hasMore: false });
     expect(stateAfterDone?.version).toBe(1);
     expect(docs.every((doc) => doc.nameSearchText && doc.muscleGroupsSearchText)).toBe(true);
+  });
+
+  it("with matchMode:strict, ignores description matches", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.run(async (ctx) => {
+      // m-chop: name has no "glute bridge" but description mentions "glutes" and "bridge"
+      await ctx.db.insert(
+        "movements",
+        makeDoc({
+          id: "m-chop",
+          name: "Single Leg Chop",
+          shortName: "SL Chop",
+          descriptionHow: "Brace glutes and bridge core to maintain stability",
+          descriptionWhy: "Trains anti-rotation",
+        }),
+      );
+      // m-gb: name is "Resisted Glute Bridge" — should match strict search
+      await ctx.db.insert(
+        "movements",
+        makeDoc({
+          id: "m-gb",
+          name: "Resisted Glute Bridge",
+          shortName: "Glute Bridge",
+          descriptionHow: "",
+          descriptionWhy: "",
+        }),
+      );
+      await ctx.db.insert("movementSearchState", {
+        key: "movement_search_fields",
+        version: 1,
+        completedAt: Date.now(),
+      });
+    });
+
+    const strict = await t.query(internal.tonal.movementSearchQueries.searchMovements, {
+      name: "Glute Bridge",
+      matchMode: "strict",
+    });
+    expect(strict.map((m) => m.id)).toEqual(["m-gb"]);
+
+    const loose = await t.query(internal.tonal.movementSearchQueries.searchMovements, {
+      name: "Glute Bridge",
+    });
+    expect(loose.map((m) => m.id).sort()).toEqual(["m-chop", "m-gb"].sort());
   });
 
   test("movement sync preserves derived training type search fields", async () => {

--- a/convex/tonal/movementSearchQueries.ts
+++ b/convex/tonal/movementSearchQueries.ts
@@ -10,6 +10,7 @@ import {
   buildListSearchText,
   buildMovementSearchFields,
   matchesNameSearch,
+  matchesNameSearchStrict,
 } from "./movementSearch";
 import { mapDocToMovement } from "./movementMapping";
 import type { Movement } from "./types";
@@ -22,6 +23,7 @@ const SEARCH_FIELDS_VERSION = 1;
 
 type MovementDoc = Doc<"movements">;
 type SearchIndexKind = "name" | "muscleGroup" | "trainingType";
+type MatchMode = "loose" | "strict";
 
 type MovementSearchFilters = {
   name?: string;
@@ -36,10 +38,12 @@ export const searchMovements = internalQuery({
     muscleGroup: v.optional(v.string()),
     trainingType: v.optional(v.string()),
     limit: v.optional(v.number()),
+    matchMode: v.optional(v.union(v.literal("loose"), v.literal("strict"))),
   },
   handler: async (ctx, args): Promise<Movement[]> => {
     const limit = clampLimit(args.limit);
     const filters = normalizeFilters(args);
+    const matchMode: MatchMode = args.matchMode ?? "loose";
     const indexKind = selectIndexKind(filters);
 
     if (!indexKind) {
@@ -49,11 +53,11 @@ export const searchMovements = internalQuery({
 
     if (!(await searchFieldsAreReady(ctx))) {
       // Existing catalogs may lack the indexed fields; preserve search results until backfill marks them ready.
-      const fallbackMatches = await loadFallbackMatches(ctx, filters, limit);
+      const fallbackMatches = await loadFallbackMatches(ctx, filters, limit, matchMode);
       return fallbackMatches.map(mapDocToMovement);
     }
 
-    const exactResults = await loadIndexedMatches(ctx, filters, indexKind, limit);
+    const exactResults = await loadIndexedMatches(ctx, filters, indexKind, limit, matchMode);
     return exactResults.map(mapDocToMovement);
   },
 });
@@ -136,6 +140,7 @@ async function loadIndexedMatches(
   filters: MovementSearchFilters,
   indexKind: SearchIndexKind,
   limit: number,
+  matchMode: MatchMode,
 ): Promise<MovementDoc[]> {
   if (indexKind === "name" && filters.name) {
     return collectMatches(
@@ -146,6 +151,7 @@ async function loadIndexedMatches(
         ),
       filters,
       limit,
+      matchMode,
     );
   }
 
@@ -158,6 +164,7 @@ async function loadIndexedMatches(
         ),
       filters,
       limit,
+      matchMode,
     );
   }
 
@@ -170,6 +177,7 @@ async function loadIndexedMatches(
         ),
       filters,
       limit,
+      matchMode,
     );
   }
 
@@ -180,18 +188,20 @@ async function loadFallbackMatches(
   ctx: QueryCtx,
   filters: MovementSearchFilters,
   limit: number,
+  matchMode: MatchMode,
 ): Promise<MovementDoc[]> {
-  return collectMatches(ctx.db.query("movements"), filters, limit);
+  return collectMatches(ctx.db.query("movements"), filters, limit, matchMode);
 }
 
 async function collectMatches(
   query: AsyncIterable<MovementDoc>,
   filters: MovementSearchFilters,
   limit: number,
+  matchMode: MatchMode,
 ): Promise<MovementDoc[]> {
   const matches: MovementDoc[] = [];
   for await (const doc of query) {
-    if (matchesFilters(doc, filters)) {
+    if (matchesFilters(doc, filters, matchMode)) {
       matches.push(doc);
       if (matches.length >= limit) break;
     }
@@ -199,8 +209,18 @@ async function collectMatches(
   return matches;
 }
 
-function matchesFilters(doc: MovementDoc, filters: MovementSearchFilters): boolean {
-  if (filters.name && !matchesNameSearch(doc, filters.name)) return false;
+function matchesFilters(
+  doc: MovementDoc,
+  filters: MovementSearchFilters,
+  matchMode: MatchMode,
+): boolean {
+  if (filters.name) {
+    const nameMatches =
+      matchMode === "strict"
+        ? matchesNameSearchStrict(doc, filters.name)
+        : matchesNameSearch(doc, filters.name);
+    if (!nameMatches) return false;
+  }
 
   if (filters.muscleGroup) {
     const muscleGroup = filters.muscleGroup.toLowerCase();


### PR DESCRIPTION
## Summary

- New helper `matchesNameSearchStrict` in `convex/tonal/movementSearch.ts` — matches `name` and `shortName` only, no description fields.
- New `matchMode: \"loose\" | \"strict\"` arg on `internal.tonal.movementSearchQueries.searchMovements`. Default `\"loose\"` (backwards compat for existing internal callers).
- `searchExercisesTool` now defaults to `matchMode: \"strict\"` for LLM calls, exposes `looseMatch?: boolean` escape hatch, and validates `trainingType` against a `z.enum(KNOWN_TRAINING_TYPES)` allowlist.
- `KNOWN_TRAINING_TYPES` exported so the schema test iterates the canonical list.

## Why

Production trace evidence (run `b1d3b8ba…`):

- `search_exercises({trainingType: \"Warm-up\"})` returned `[]` for every call — the catalog has no \"Warm-up\" tag (real values: Strength, High Intensity, Mobility, Recovery, Yoga, Pilates, Pre & Postnatal). The model was filtering on a tag that doesn't exist, with no schema-level signal.
- `search_exercises({name: \"Glute Bridge\"})` returned 19 movements, **none of which were Glute Bridge** — the matcher substring-matches against `descriptionHow`/`descriptionWhy`, so movements that *mention* \"glute\" or \"bridge\" in their descriptions ranked alongside actual Glute Bridge variants.

## Recommended ship order

7-PR series. Each independently shippable:

1. `feat/add-exercise-warmup-flag`
2. 👉 **this PR** — `feat/tighten-search-exercises`
3. `fix/add-exercise-silent-drop`
4. `feat/program-week-injury-filter-diagnostics`
5. `feat/set-warmup-block-tool`
6. `feat/rebuild-day-tool`
7. `feat/push-verification`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full backend suite: 1116 tests passing
- [x] 4 unit tests for `matchesNameSearchStrict` (name match, alias, description-only miss, no-overlap)
- [x] 1 integration test for `searchMovements({matchMode:\"strict\"})` vs loose
- [x] 2 schema tests: rejects \"Warm-up\", accepts all 7 known training types
- [ ] Manual: ask Roni to search \"Glute Bridge\" — strict default should return only actual Glute Bridge variants

⚠️ Behavior change for the LLM tool: default match mode flips loose→strict. Existing eval scenarios were checked against this branch (no eval failures); but if any user prompt in the wild relied on description-substring matches to discover related exercises, they'll now need `looseMatch: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)