### PR TITLE
feat(coach): surface degenerate exercise selection from program_week

### DIFF
--- a/convex/ai/weekTools.ts
+++ b/convex/ai/weekTools.ts
@@ -84,6 +84,12 @@ Returns a summary of the full week plan with exercises, sets, reps/duration, and
           weekPlanId: string;
           summary: DraftWeekSummary;
           reasoningHints: string;
+          degenerateDays?: {
+            dayIndex: number;
+            dayName: string;
+            eliminatedByInjury: number;
+            eliminatedByAccessory: number;
+          }[];
         }
       | { success: false; error: string }
     > => {
@@ -114,7 +120,17 @@ Returns a summary of the full week plan with exercises, sets, reps/duration, and
         sessionDurationMinutes: sessionDuration,
         trainingDayIndicesOverride: input.trainingDays ?? saved?.trainingDays,
       })) as
-        | { success: true; weekPlanId: Id<"weekPlans">; summary: DraftWeekSummary }
+        | {
+            success: true;
+            weekPlanId: Id<"weekPlans">;
+            summary: DraftWeekSummary;
+            degenerateDays: {
+              dayIndex: number;
+              dayName: string;
+              eliminatedByInjury: number;
+              eliminatedByAccessory: number;
+            }[];
+          }
         | { success: false; error: string };
 
       if (!result.success) return result;
@@ -133,7 +149,12 @@ Returns a summary of the full week plan with exercises, sets, reps/duration, and
         isDeload: false,
       });
 
-      return { ...result, reasoningHints };
+      const degenerateNote =
+        result.degenerateDays.length > 0
+          ? `\n\nWARNING: ${result.degenerateDays.length} day(s) had to be programmed with a heavily-restricted exercise pool because of injury filters. Affected days: ${result.degenerateDays.map((d) => d.dayName).join(", ")}. The plan may feel monotonous. Consider asking the user to relax their injury list or use search_exercises to find alternative compound movements.`
+          : "";
+
+      return { ...result, reasoningHints: reasoningHints + degenerateNote };
     },
   ),
 });

--- a/convex/coach/exerciseSelection.ts
+++ b/convex/coach/exerciseSelection.ts
@@ -109,6 +109,101 @@ export function selectExercises(input: ExerciseSelectionInput): string[] {
   return ordered.slice(0, maxExercises).map((m) => m.id);
 }
 
+export interface ExerciseSelectionDiagnostics {
+  catalogSize: number;
+  matchedTarget: number;
+  eliminatedByInjury: number;
+  eliminatedByAccessory: number;
+  eliminatedByLastUsed: number;
+  eliminatedBySkillCap: number;
+  eligibleCount: number;
+  fellThroughDiversity: boolean;
+  eligibleMuscleGroupCount: number;
+}
+
+export interface ExerciseSelectionWithDiagnostics {
+  ids: string[];
+  diagnostics: ExerciseSelectionDiagnostics;
+}
+
+/**
+ * Same as selectExercises, but also returns per-stage filter counts and
+ * a `fellThroughDiversity` flag (true when the eligible set covers fewer than
+ * 2 of the requested target muscle groups). Use from the week-programming
+ * pipeline to surface degenerate plans to the caller.
+ */
+export function selectExercisesWithDiagnostics(
+  input: ExerciseSelectionInput,
+): ExerciseSelectionWithDiagnostics {
+  const { catalog, targetMuscleGroups, userLevel, lastUsedMovementIds, constraints } = input;
+  const targetSet = new Set(targetMuscleGroups.map((g) => g.toLowerCase()));
+  const lastUsedSet = new Set(lastUsedMovementIds);
+  const excludeSubstrings = (constraints?.excludeNameSubstrings ?? []).map((s) => s.toLowerCase());
+  const excludeAccessorySet = new Set(constraints?.excludeAccessories ?? []);
+
+  let matchedTarget = 0;
+  let eliminatedByInjury = 0;
+  let eliminatedByAccessory = 0;
+  let eliminatedByLastUsed = 0;
+  let eliminatedBySkillCap = 0;
+
+  const eligible: Movement[] = [];
+  for (const m of catalog) {
+    if (lastUsedSet.has(m.id)) {
+      eliminatedByLastUsed++;
+      continue;
+    }
+    const matchesTarget = m.muscleGroups.some((g) => targetSet.has(g.toLowerCase()));
+    if (!matchesTarget) continue;
+    matchedTarget++;
+    if (excludeSubstrings.length > 0) {
+      const nameLower = m.name.toLowerCase();
+      if (excludeSubstrings.some((sub) => nameLower.includes(sub))) {
+        eliminatedByInjury++;
+        continue;
+      }
+    }
+    if (excludeAccessorySet.size > 0 && m.onMachineInfo?.accessory) {
+      if (excludeAccessorySet.has(m.onMachineInfo.accessory)) {
+        eliminatedByAccessory++;
+        continue;
+      }
+    }
+    if (m.skillLevel > userLevel + MAX_SKILL_LEVEL_DELTA) {
+      eliminatedBySkillCap++;
+      continue;
+    }
+    eligible.push(m);
+  }
+
+  // Reuse selectExercises for the sort/slice path so IDs are identical.
+  const ids = selectExercises(input);
+
+  // Diversity floor: count distinct target muscle groups across all eligible
+  // movements. Fewer than 2 groups means the filter degenerated (e.g. all lunges).
+  const groupsCovered = new Set<string>();
+  for (const m of eligible) {
+    for (const g of m.muscleGroups) {
+      if (targetSet.has(g.toLowerCase())) groupsCovered.add(g.toLowerCase());
+    }
+  }
+
+  return {
+    ids,
+    diagnostics: {
+      catalogSize: catalog.length,
+      matchedTarget,
+      eliminatedByInjury,
+      eliminatedByAccessory,
+      eliminatedByLastUsed,
+      eliminatedBySkillCap,
+      eligibleCount: eligible.length,
+      fellThroughDiversity: groupsCovered.size < 2,
+      eligibleMuscleGroupCount: groupsCovered.size,
+    },
+  };
+}
+
 export interface WarmupCooldownInput {
   catalog: Movement[];
   targetMuscleGroups: string[];

--- a/convex/coach/exerciseSelectionDiagnostics.test.ts
+++ b/convex/coach/exerciseSelectionDiagnostics.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { selectExercises, selectExercisesWithDiagnostics } from "./exerciseSelection";
+import type { Movement } from "../tonal/types";
+
+const movementDefaults: Omit<
+  Movement,
+  "id" | "name" | "shortName" | "muscleGroups" | "skillLevel"
+> = {
+  inFreeLift: false,
+  onMachine: true,
+  countReps: true,
+  isTwoSided: false,
+  isBilateral: true,
+  isAlternating: false,
+  descriptionHow: "",
+  descriptionWhy: "",
+  thumbnailMediaUrl: "",
+  publishState: "published",
+  sortOrder: 0,
+};
+
+function movement(
+  overrides: Partial<Movement> & Pick<Movement, "id" | "name" | "muscleGroups" | "skillLevel">,
+): Movement {
+  return {
+    ...movementDefaults,
+    shortName: overrides.shortName ?? overrides.name,
+    ...overrides,
+  };
+}
+
+const mk = (id: string, name: string, groups: string[]) =>
+  movement({ id, name, muscleGroups: groups, skillLevel: 1 });
+
+describe("selectExercisesWithDiagnostics", () => {
+  it("flags degeneration when injury keywords strip catalog to a single muscle group", () => {
+    const catalog = [
+      mk("m1", "Bench Press", ["Chest"]),
+      mk("m2", "Overhead Press", ["Shoulders"]),
+      mk("m3", "Dip", ["Triceps"]),
+      mk("m4", "Fly Machine", ["Chest"]),
+      mk("m5", "Reverse Lunge", ["Quads"]),
+    ];
+    const result = selectExercisesWithDiagnostics({
+      catalog,
+      targetMuscleGroups: ["Chest", "Shoulders", "Triceps", "Quads"],
+      userLevel: 2,
+      maxExercises: 5,
+      lastUsedMovementIds: [],
+      constraints: { excludeNameSubstrings: ["bench", "overhead", "dip", "fly"] },
+    });
+    expect(result.ids).toEqual(["m5"]);
+    expect(result.diagnostics.eliminatedByInjury).toBe(4);
+    expect(result.diagnostics.eligibleCount).toBe(1);
+    expect(result.diagnostics.fellThroughDiversity).toBe(true);
+  });
+
+  it("does not flag degeneration when the filter leaves at least 2 muscle groups", () => {
+    const catalog = [
+      mk("m1", "Goblet Squat", ["Quads", "Glutes"]),
+      mk("m2", "Romanian Deadlift", ["Hamstrings"]),
+      mk("m3", "Walking Lunge", ["Quads"]),
+    ];
+    const result = selectExercisesWithDiagnostics({
+      catalog,
+      targetMuscleGroups: ["Quads", "Glutes", "Hamstrings"],
+      userLevel: 2,
+      maxExercises: 3,
+      lastUsedMovementIds: [],
+    });
+    expect(result.diagnostics.fellThroughDiversity).toBe(false);
+    expect(result.diagnostics.eligibleCount).toBe(3);
+  });
+
+  it("counts lastUsed eliminations regardless of muscle group match", () => {
+    const catalog = [
+      mk("m-quads-1", "Squat", ["Quads"]),
+      mk("m-other", "Bench Press", ["Chest"]), // Different muscle group
+    ];
+    const result = selectExercisesWithDiagnostics({
+      catalog,
+      targetMuscleGroups: ["Quads"],
+      userLevel: 2,
+      maxExercises: 5,
+      lastUsedMovementIds: ["m-quads-1", "m-other"], // Both flagged as last-used
+    });
+    expect(result.diagnostics.eliminatedByLastUsed).toBe(2); // Both counted
+  });
+
+  it("returns the same ids as selectExercises for equivalent input", () => {
+    const catalog = [
+      mk("c1", "Bench Press", ["Chest", "Triceps"]),
+      mk("c2", "Overhead Press", ["Shoulders", "Triceps"]),
+      mk("iso1", "Fly", ["Chest"]),
+    ];
+    const input = {
+      catalog,
+      targetMuscleGroups: ["Chest", "Triceps", "Shoulders"],
+      userLevel: 2,
+      maxExercises: 5,
+      lastUsedMovementIds: [],
+    };
+    expect(selectExercisesWithDiagnostics(input).ids).toEqual(selectExercises(input));
+  });
+});

--- a/convex/coach/weekProgramming.ts
+++ b/convex/coach/weekProgramming.ts
@@ -15,7 +15,7 @@ import {
 } from "../weekPlans";
 import {
   selectCooldownExercises,
-  selectExercises,
+  selectExercisesWithDiagnostics,
   selectWarmupExercises,
 } from "./exerciseSelection";
 import type { ExerciseSelectionInput } from "./exerciseSelection";
@@ -120,7 +120,17 @@ export const generateDraftWeekPlan = internalAction({
     ctx,
     args,
   ): Promise<
-    | { success: true; weekPlanId: Id<"weekPlans">; summary: DraftWeekSummary }
+    | {
+        success: true;
+        weekPlanId: Id<"weekPlans">;
+        summary: DraftWeekSummary;
+        degenerateDays: {
+          dayIndex: number;
+          dayName: string;
+          eliminatedByInjury: number;
+          eliminatedByAccessory: number;
+        }[];
+      }
     | { success: false; error: string }
   > => {
     const weekStartDate = args.weekStartDate ?? getWeekStartDateString(new Date());
@@ -171,6 +181,12 @@ export const generateDraftWeekPlan = internalAction({
     // Build drafts for each training day (sequential to avoid movement reuse)
     const daySummaries: DraftDaySummary[] = [];
     const catalog = data.catalog;
+    const degenerateDays: {
+      dayIndex: number;
+      dayName: string;
+      eliminatedByInjury: number;
+      eliminatedByAccessory: number;
+    }[] = [];
 
     for (const { dayIndex, sessionType } of daySessions) {
       const targetMuscleGroups =
@@ -180,7 +196,7 @@ export const generateDraftWeekPlan = internalAction({
       const wcCounts = WARMUP_COOLDOWN_COUNTS[sessionDurationMinutes] ?? DEFAULT_WARMUP_COOLDOWN;
       const mainMaxExercises = maxExercises - wcCounts.warmup - wcCounts.cooldown;
 
-      const rawMovementIds = selectExercises({
+      const selection = selectExercisesWithDiagnostics({
         catalog,
         targetMuscleGroups,
         userLevel: data.userLevel,
@@ -188,6 +204,15 @@ export const generateDraftWeekPlan = internalAction({
         lastUsedMovementIds: data.lastUsedMovementIds,
         constraints: data.constraints,
       });
+      if (selection.diagnostics.fellThroughDiversity) {
+        degenerateDays.push({
+          dayIndex,
+          dayName: DAY_NAMES[dayIndex],
+          eliminatedByInjury: selection.diagnostics.eliminatedByInjury,
+          eliminatedByAccessory: selection.diagnostics.eliminatedByAccessory,
+        });
+      }
+      const rawMovementIds = selection.ids;
       if (rawMovementIds.length === 0) continue;
 
       // Sort exercises to minimize equipment switching and arm adjustments
@@ -307,6 +332,7 @@ export const generateDraftWeekPlan = internalAction({
         sessionDurationMinutes,
         days: daySummaries,
       },
+      degenerateDays,
     };
   },
 });


### PR DESCRIPTION
## Summary

- New helper `selectExercisesWithDiagnostics` in `convex/coach/exerciseSelection.ts` returning `{ ids, diagnostics }`. Same `ids` as `selectExercises` (delegates sort/slice). Adds per-stage elimination counters and a `fellThroughDiversity` flag (true when the eligible set covers fewer than 2 of the requested target muscle groups).
- `generateDraftWeekPlan` collects `degenerateDays[]` and threads it through to `programWeekTool.execute`.
- `programWeekTool` appends a `WARNING:` block to `reasoningHints` when any day fell through the diversity floor — names affected days and tells the LLM to consider relaxing the injury list or running `search_exercises` for alternatives.

## Why

Production trace (run `b1d3b8ba…`): user has injury keywords flagged: `overhead`, `press`, `bench`, `fly`, `dip`. `program_week({split: \"full_body\", trainingDays: [Mon, Wed, Fri]})` returned **identical** output for all three days — five lunges each. The injury filter stripped ~90% of the catalog. The model presented the result faithfully because no diagnostic signal was surfaced.

## Recommended ship order

7-PR series. Each independently shippable:

1. `feat/add-exercise-warmup-flag`
2. `feat/tighten-search-exercises`
3. `fix/add-exercise-silent-drop`
4. 👉 **this PR** — `feat/program-week-injury-filter-diagnostics`
5. `feat/set-warmup-block-tool`
6. `feat/rebuild-day-tool`
7. `feat/push-verification`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full backend suite: 1113 tests passing (+4 new)
- [x] Diagnostic test: filter that strips catalog to 1 muscle group flags `fellThroughDiversity: true`
- [x] Diagnostic test: filter that leaves ≥2 muscle groups does NOT flag
- [x] ID-equivalence test: returns identical IDs to `selectExercises` for same input
- [x] LastUsed-counting test: `eliminatedByLastUsed` counts ALL last-used movements, not just target-matching ones (predicate matches `selectExercises`'s order)
- [ ] Manual: reproduce David's injury list in dev, run `program_week`, verify the WARNING appears in chat output

⚠️ Note: existing tests were not modified; the action's return type adds `degenerateDays` as a new field. If any caller spreads the action's return into a typed object, they'll get the new field by inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)