### PR TITLE
feat(tonal): real push verification — diff stored workout against intent

### DIFF
--- a/convex/ai/coach.ts
+++ b/convex/ai/coach.ts
@@ -53,12 +53,12 @@ import {
   setWarmupBlockTool,
   swapExerciseTool,
 } from "./weekModificationTools";
+import { programWeekTool } from "./programWeekTool";
 import {
   approveWeekPlanTool,
   deleteWeekPlanTool,
   getWeekPlanDetailsTool,
   getWorkoutPerformanceTool,
-  programWeekTool,
 } from "./weekTools";
 import {
   advanceTrainingBlockTool,

--- a/convex/ai/divergenceNote.ts
+++ b/convex/ai/divergenceNote.ts
@@ -1,0 +1,18 @@
+import type { PushDivergence } from "../tonal/mutations";
+
+export interface DayDivergence {
+  dayName: string;
+  divergence: PushDivergence;
+}
+
+/**
+ * Build a one-line LLM warning that summarizes any per-day push divergence.
+ * Returns empty string when there's nothing to report.
+ */
+export function formatPushDivergenceNote(perDay: DayDivergence[]): string {
+  if (perDay.length === 0) return "";
+  const days = perDay.map((d) => d.dayName).join(", ");
+  const totalMissing = perDay.reduce((s, d) => s + d.divergence.missingMovements.length, 0);
+  const totalMismatches = perDay.reduce((s, d) => s + d.divergence.setCountMismatches.length, 0);
+  return `\n\nWARNING: Tonal stored ${perDay.length} workout(s) differently than sent (${days}). Missing movements across all days: ${totalMissing}. Set-count mismatches: ${totalMismatches}. Tell the user to spot-check these on their Tonal.`;
+}

--- a/convex/ai/programWeekTool.ts
+++ b/convex/ai/programWeekTool.ts
@@ -1,0 +1,147 @@
+/**
+ * AI agent tool for generating a draft week plan.
+ *
+ * Wraps `internal.coach.weekProgramming.generateDraftWeekPlan` and surfaces
+ * any per-day degenerate exercise selection back to the LLM via reasoningHints.
+ */
+
+import { createTool } from "@convex-dev/agent";
+import { z } from "zod";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { DraftWeekSummary } from "../coach/weekProgrammingHelpers";
+import { getWeekStartDateString } from "../weekPlanHelpers";
+import { requireUserId, withToolTracking } from "./helpers";
+import { buildReasoningPrompt } from "./weekReasoning";
+
+const ALLOWED_SESSION_DURATIONS = [30, 45, 60] as const;
+type SessionDuration = (typeof ALLOWED_SESSION_DURATIONS)[number];
+
+function validateSessionDuration(value: unknown): SessionDuration | undefined {
+  const parsed =
+    typeof value === "number" ? value : typeof value === "string" ? parseInt(value, 10) : undefined;
+  if (Number.isInteger(parsed) && ALLOWED_SESSION_DURATIONS.includes(parsed as SessionDuration)) {
+    return parsed as SessionDuration;
+  }
+  return undefined;
+}
+
+export const programWeekTool = createTool({
+  description: `Program the user's full training week. Creates draft workouts for each training day based on their split, available days, and session duration.
+
+IMPORTANT: The backend algorithm selects the exact exercises, sets, and reps — you do NOT. Your job is to call this tool, then faithfully describe what it returned in the \`summary\` field. Never pre-announce specific exercises before calling this tool (e.g. "I'll program bench press, rows, and squats..."), because the algorithm may pick differently based on user history, muscle readiness, injuries, and progressive overload. Never describe exercise names, sets, or reps that are not present in the returned \`summary\`.
+
+Duration-based movements in the summary use a duration (seconds) instead of reps. Describe them in seconds (e.g. "30s hold") — never as "4x10".
+
+Returns a summary of the full week plan with exercises, sets, reps/duration, and progressive overload targets. The plan is NOT pushed to Tonal yet — present it to the user for approval first, then use approve_week_plan. If the user already has saved preferences, you can omit the parameters to use their saved preferences.`,
+  inputSchema: z.object({
+    preferredSplit: z
+      .enum(["ppl", "upper_lower", "full_body", "bro_split"])
+      .optional()
+      .describe(
+        "Training split. ppl = Push/Pull/Legs, upper_lower = Upper/Lower, full_body = Full Body, bro_split = Bodybuilding body-part split (Chest/Back/Shoulders/Arms/Legs). Omit to use saved preferences.",
+      ),
+    trainingDays: z
+      .array(z.number().int().min(0).max(6))
+      .optional()
+      .describe(
+        "Day indices: 0=Monday, 1=Tuesday, ..., 6=Sunday. Omit to auto-space based on count.",
+      ),
+    targetDays: z
+      .number()
+      .int()
+      .min(1)
+      .max(7)
+      .optional()
+      .describe("Number of training days per week (used if trainingDays is omitted)."),
+    sessionDurationMinutes: z
+      .enum(["30", "45", "60"])
+      .optional()
+      .describe("Session duration. Omit to use saved preferences."),
+  }),
+  execute: withToolTracking(
+    "program_week",
+    async (
+      ctx,
+      input,
+      _options,
+    ): Promise<
+      | {
+          success: true;
+          weekPlanId: string;
+          summary: DraftWeekSummary;
+          reasoningHints: string;
+          degenerateDays?: {
+            dayIndex: number;
+            dayName: string;
+            eliminatedByInjury: number;
+            eliminatedByAccessory: number;
+          }[];
+        }
+      | { success: false; error: string }
+    > => {
+      const userId = requireUserId(ctx);
+
+      // Load saved preferences as defaults
+      const saved = (await ctx.runQuery(internal.userProfiles.getTrainingPreferencesInternal, {
+        userId,
+      })) as {
+        preferredSplit?: "ppl" | "upper_lower" | "full_body" | "bro_split";
+        trainingDays?: number[];
+        sessionDurationMinutes?: number;
+      } | null;
+
+      const preferredSplit = input.preferredSplit ?? saved?.preferredSplit ?? "ppl";
+      const inputDuration = validateSessionDuration(input.sessionDurationMinutes);
+      const savedDuration = validateSessionDuration(saved?.sessionDurationMinutes);
+      const sessionDuration = inputDuration ?? savedDuration ?? 45;
+
+      const targetDays =
+        input.trainingDays?.length ?? input.targetDays ?? saved?.trainingDays?.length ?? 3;
+
+      const result = (await ctx.runAction(internal.coach.weekProgramming.generateDraftWeekPlan, {
+        userId,
+        weekStartDate: getWeekStartDateString(new Date()),
+        preferredSplit,
+        targetDays,
+        sessionDurationMinutes: sessionDuration,
+        trainingDayIndicesOverride: input.trainingDays ?? saved?.trainingDays,
+      })) as
+        | {
+            success: true;
+            weekPlanId: Id<"weekPlans">;
+            summary: DraftWeekSummary;
+            degenerateDays: {
+              dayIndex: number;
+              dayName: string;
+              eliminatedByInjury: number;
+              eliminatedByAccessory: number;
+            }[];
+          }
+        | { success: false; error: string };
+
+      if (!result.success) return result;
+
+      // Build lightweight reasoning hints from data already in scope.
+      // The AI agent has the full training snapshot (muscle readiness,
+      // injuries, feedback) in its context — no need to duplicate here.
+      const reasoningHints = buildReasoningPrompt({
+        split: preferredSplit,
+        targetDays,
+        sessionDuration,
+        muscleReadiness: {},
+        recentWorkouts: [],
+        activeInjuries: [],
+        recentFeedback: null,
+        isDeload: false,
+      });
+
+      const degenerateNote =
+        result.degenerateDays.length > 0
+          ? `\n\nWARNING: ${result.degenerateDays.length} day(s) had to be programmed with a heavily-restricted exercise pool because of injury filters. Affected days: ${result.degenerateDays.map((d) => d.dayName).join(", ")}. The plan may feel monotonous. Consider asking the user to relax their injury list or use search_exercises to find alternative compound movements.`
+          : "";
+
+      return { ...result, reasoningHints: reasoningHints + degenerateNote };
+    },
+  ),
+});

--- a/convex/ai/runTelemetry.ts
+++ b/convex/ai/runTelemetry.ts
@@ -1,5 +1,6 @@
 import type { StepResult, ToolSet } from "ai";
 import type { Id } from "../_generated/dataModel";
+import type { PushDivergence } from "../tonal/mutations";
 
 /** Row shape produced by `RunAccumulator.toRow()`. Matches the `aiRun` table validator. */
 export interface AiRunRow {
@@ -50,6 +51,7 @@ export interface AiRunRow {
   approvalPauses: number;
   workoutPlanCreatedId?: Id<"workoutPlans">;
   workoutPushOutcome?: "pushed" | "failed" | "none";
+  pushDivergence?: PushDivergence;
   createdAt: number;
 }
 
@@ -101,11 +103,18 @@ type CreateWorkoutOutput =
       title: string;
       setCount: number;
       planId: Id<"workoutPlans">;
+      pushDivergence?: PushDivergence | null;
     }
   | { success: false; error: string; planId?: Id<"workoutPlans"> };
 
 type ApproveWeekPlanOutput =
-  | { success: boolean; pushed: number; failed: number; skipped: number; results: unknown[] }
+  | {
+      success: boolean;
+      pushed: number;
+      failed: number;
+      skipped: number;
+      results: { pushDivergence?: PushDivergence | null }[];
+    }
   | { error: string };
 
 function isCreateWorkoutOutput(value: unknown): value is CreateWorkoutOutput {
@@ -144,6 +153,7 @@ export class RunAccumulator {
   private approvalPauses = 0;
   private workoutPlanCreatedId?: Id<"workoutPlans">;
   private workoutPushOutcome?: AiRunRow["workoutPushOutcome"];
+  private pushDivergence?: PushDivergence;
   private readonly startedAt: number;
   private readonly scheduledAt?: number;
   private readonly processingStartedAt?: number;
@@ -248,6 +258,11 @@ export class RunAccumulator {
     this.workoutPushOutcome = outcome;
   }
 
+  /** Record push divergence from the Tonal read-back; last-write-wins (one push per run). */
+  recordPushDivergence(div: PushDivergence | null): void {
+    this.pushDivergence = div ?? undefined;
+  }
+
   setContextTiming(metrics: ContextTimingMetrics): void {
     this.contextBuildMs = metrics.contextBuildMs;
     this.snapshotBuildMs = metrics.snapshotBuildMs;
@@ -308,6 +323,7 @@ export class RunAccumulator {
       approvalPauses: this.approvalPauses,
       workoutPlanCreatedId: this.workoutPlanCreatedId,
       workoutPushOutcome: this.workoutPushOutcome,
+      pushDivergence: this.pushDivergence,
       createdAt: this.startedAt,
     };
   }
@@ -319,6 +335,9 @@ export class RunAccumulator {
       if (result.toolName === "create_workout" && isCreateWorkoutOutput(result.output)) {
         if (result.output.success) {
           this.workoutPlanCreatedId = result.output.planId;
+          if (result.output.pushDivergence !== undefined) {
+            this.recordPushDivergence(result.output.pushDivergence);
+          }
           // A successful create_workout leaves a draft needing user approval.
           this.markApprovalPause();
         }
@@ -340,6 +359,13 @@ export class RunAccumulator {
           this.workoutPushOutcome = "failed";
         } else {
           this.workoutPushOutcome = "pushed";
+        }
+        // Record first non-null divergence encountered across pushed days.
+        if (!("error" in out)) {
+          const firstDivergent = out.results.find((r) => r.pushDivergence != null);
+          if (firstDivergent?.pushDivergence !== undefined) {
+            this.recordPushDivergence(firstDivergent.pushDivergence);
+          }
         }
       }
     }

--- a/convex/ai/tools.ts
+++ b/convex/ai/tools.ts
@@ -256,7 +256,14 @@ export const createWorkoutTool = createTool({
       input,
       _options,
     ): Promise<
-      | { success: true; workoutId: string; title: string; setCount: number; planId: string }
+      | {
+          success: true;
+          workoutId: string;
+          title: string;
+          setCount: number;
+          planId: string;
+          divergenceWarning?: string;
+        }
       | { success: false; error: string }
     > => {
       const userId = requireUserId(ctx);
@@ -296,11 +303,32 @@ export const createWorkoutTool = createTool({
         }),
       }));
 
-      return ctx.runAction(internal.tonal.mutations.createWorkout, {
+      const pushed = await ctx.runAction(internal.tonal.mutations.createWorkout, {
         userId,
         title: input.title,
         blocks: correctedBlocks,
       });
+
+      if (!pushed.success) return pushed;
+
+      // Strip pushDivergence from the LLM-visible return; it is a structured object
+      // the LLM has no schema for. Surface only a human-readable warning when needed.
+      const { pushDivergence: _pushDivergence, ...pushedSummary } = pushed;
+
+      if (
+        _pushDivergence &&
+        (_pushDivergence.missingMovements.length > 0 ||
+          _pushDivergence.extraMovements.length > 0 ||
+          _pushDivergence.setCountMismatches.length > 0)
+      ) {
+        console.warn(`createWorkoutTool: divergence on ${pushed.workoutId}`, _pushDivergence);
+        return {
+          ...pushedSummary,
+          divergenceWarning: `WARNING: Tonal stored the workout differently than sent. Missing movements: ${_pushDivergence.missingMovements.length}. Set-count mismatches: ${_pushDivergence.setCountMismatches.length}. Tell the user to verify the workout on their Tonal.`,
+        };
+      }
+
+      return pushedSummary;
     },
   ),
 });

--- a/convex/ai/weekTools.ts
+++ b/convex/ai/weekTools.ts
@@ -1,163 +1,26 @@
 /**
  * AI agent tools for weekly training programming.
  *
- * - programWeekTool: generates a draft week plan (no Tonal push)
  * - getWeekPlanDetailsTool: retrieves current week plan with resolved exercise names
  * - deleteWeekPlanTool: deletes the current week plan and its draft workouts
+ * - getWorkoutPerformanceTool: PR / plateau / volume summary for a movement
+ * - approveWeekPlanTool: pushes all draft day workouts to Tonal
+ *
+ * programWeekTool lives in `./programWeekTool.ts` (split for file-size budget).
  */
 
 import { createTool } from "@convex-dev/agent";
 import { z } from "zod";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
-import type { DraftWeekSummary } from "../coach/weekProgrammingHelpers";
 import { DAY_NAMES } from "../coach/weekProgrammingHelpers";
 import type { WorkoutPerformanceSummary } from "../coach/prDetection";
 import type { WeekPushResult } from "../coach/pushAndVerify";
 import type { Movement } from "../tonal/types";
+import type { PushDivergence } from "../tonal/mutations";
 import { getWeekStartDateString } from "../weekPlanHelpers";
 import { requireUserId, withToolTracking } from "./helpers";
-import { buildReasoningPrompt } from "./weekReasoning";
-
-// ---------------------------------------------------------------------------
-// Session duration validation
-// ---------------------------------------------------------------------------
-
-const ALLOWED_SESSION_DURATIONS = [30, 45, 60] as const;
-type SessionDuration = (typeof ALLOWED_SESSION_DURATIONS)[number];
-
-function validateSessionDuration(value: unknown): SessionDuration | undefined {
-  const parsed =
-    typeof value === "number" ? value : typeof value === "string" ? parseInt(value, 10) : undefined;
-  if (Number.isInteger(parsed) && ALLOWED_SESSION_DURATIONS.includes(parsed as SessionDuration)) {
-    return parsed as SessionDuration;
-  }
-  return undefined;
-}
-
-// ---------------------------------------------------------------------------
-// programWeekTool
-// ---------------------------------------------------------------------------
-
-export const programWeekTool = createTool({
-  description: `Program the user's full training week. Creates draft workouts for each training day based on their split, available days, and session duration.
-
-IMPORTANT: The backend algorithm selects the exact exercises, sets, and reps — you do NOT. Your job is to call this tool, then faithfully describe what it returned in the \`summary\` field. Never pre-announce specific exercises before calling this tool (e.g. "I'll program bench press, rows, and squats..."), because the algorithm may pick differently based on user history, muscle readiness, injuries, and progressive overload. Never describe exercise names, sets, or reps that are not present in the returned \`summary\`.
-
-Duration-based movements in the summary use a duration (seconds) instead of reps. Describe them in seconds (e.g. "30s hold") — never as "4x10".
-
-Returns a summary of the full week plan with exercises, sets, reps/duration, and progressive overload targets. The plan is NOT pushed to Tonal yet — present it to the user for approval first, then use approve_week_plan. If the user already has saved preferences, you can omit the parameters to use their saved preferences.`,
-  inputSchema: z.object({
-    preferredSplit: z
-      .enum(["ppl", "upper_lower", "full_body", "bro_split"])
-      .optional()
-      .describe(
-        "Training split. ppl = Push/Pull/Legs, upper_lower = Upper/Lower, full_body = Full Body, bro_split = Bodybuilding body-part split (Chest/Back/Shoulders/Arms/Legs). Omit to use saved preferences.",
-      ),
-    trainingDays: z
-      .array(z.number().int().min(0).max(6))
-      .optional()
-      .describe(
-        "Day indices: 0=Monday, 1=Tuesday, ..., 6=Sunday. Omit to auto-space based on count.",
-      ),
-    targetDays: z
-      .number()
-      .int()
-      .min(1)
-      .max(7)
-      .optional()
-      .describe("Number of training days per week (used if trainingDays is omitted)."),
-    sessionDurationMinutes: z
-      .enum(["30", "45", "60"])
-      .optional()
-      .describe("Session duration. Omit to use saved preferences."),
-  }),
-  execute: withToolTracking(
-    "program_week",
-    async (
-      ctx,
-      input,
-      _options,
-    ): Promise<
-      | {
-          success: true;
-          weekPlanId: string;
-          summary: DraftWeekSummary;
-          reasoningHints: string;
-          degenerateDays?: {
-            dayIndex: number;
-            dayName: string;
-            eliminatedByInjury: number;
-            eliminatedByAccessory: number;
-          }[];
-        }
-      | { success: false; error: string }
-    > => {
-      const userId = requireUserId(ctx);
-
-      // Load saved preferences as defaults
-      const saved = (await ctx.runQuery(internal.userProfiles.getTrainingPreferencesInternal, {
-        userId,
-      })) as {
-        preferredSplit?: "ppl" | "upper_lower" | "full_body" | "bro_split";
-        trainingDays?: number[];
-        sessionDurationMinutes?: number;
-      } | null;
-
-      const preferredSplit = input.preferredSplit ?? saved?.preferredSplit ?? "ppl";
-      const inputDuration = validateSessionDuration(input.sessionDurationMinutes);
-      const savedDuration = validateSessionDuration(saved?.sessionDurationMinutes);
-      const sessionDuration = inputDuration ?? savedDuration ?? 45;
-
-      const targetDays =
-        input.trainingDays?.length ?? input.targetDays ?? saved?.trainingDays?.length ?? 3;
-
-      const result = (await ctx.runAction(internal.coach.weekProgramming.generateDraftWeekPlan, {
-        userId,
-        weekStartDate: getWeekStartDateString(new Date()),
-        preferredSplit,
-        targetDays,
-        sessionDurationMinutes: sessionDuration,
-        trainingDayIndicesOverride: input.trainingDays ?? saved?.trainingDays,
-      })) as
-        | {
-            success: true;
-            weekPlanId: Id<"weekPlans">;
-            summary: DraftWeekSummary;
-            degenerateDays: {
-              dayIndex: number;
-              dayName: string;
-              eliminatedByInjury: number;
-              eliminatedByAccessory: number;
-            }[];
-          }
-        | { success: false; error: string };
-
-      if (!result.success) return result;
-
-      // Build lightweight reasoning hints from data already in scope.
-      // The AI agent has the full training snapshot (muscle readiness,
-      // injuries, feedback) in its context — no need to duplicate here.
-      const reasoningHints = buildReasoningPrompt({
-        split: preferredSplit,
-        targetDays,
-        sessionDuration,
-        muscleReadiness: {},
-        recentWorkouts: [],
-        activeInjuries: [],
-        recentFeedback: null,
-        isDeload: false,
-      });
-
-      const degenerateNote =
-        result.degenerateDays.length > 0
-          ? `\n\nWARNING: ${result.degenerateDays.length} day(s) had to be programmed with a heavily-restricted exercise pool because of injury filters. Affected days: ${result.degenerateDays.map((d) => d.dayName).join(", ")}. The plan may feel monotonous. Consider asking the user to relax their injury list or use search_exercises to find alternative compound movements.`
-          : "";
-
-      return { ...result, reasoningHints: reasoningHints + degenerateNote };
-    },
-  ),
-});
+import { type DayDivergence, formatPushDivergenceNote } from "./divergenceNote";
 
 // ---------------------------------------------------------------------------
 // getWeekPlanDetailsTool
@@ -368,7 +231,11 @@ export const approveWeekPlanTool = createTool({
   inputSchema: z.object({}),
   execute: withToolTracking(
     "approve_week_plan",
-    async (ctx, _input, _options): Promise<WeekPushResult | { error: string }> => {
+    async (
+      ctx,
+      _input,
+      _options,
+    ): Promise<(WeekPushResult & { divergenceNote?: string }) | { error: string }> => {
       const userId = requireUserId(ctx);
       const weekStartDate = getWeekStartDateString(new Date());
 
@@ -385,6 +252,23 @@ export const approveWeekPlanTool = createTool({
         userId,
         weekPlanId: plan._id,
       })) as WeekPushResult;
+
+      // Aggregate per-day divergence and surface to LLM.
+      const dayDivergences: DayDivergence[] = result.results
+        .filter(
+          (r): r is typeof r & { pushDivergence: PushDivergence } =>
+            r.status === "pushed" &&
+            r.pushDivergence != null &&
+            (r.pushDivergence.missingMovements.length > 0 ||
+              r.pushDivergence.extraMovements.length > 0 ||
+              r.pushDivergence.setCountMismatches.length > 0),
+        )
+        .map((r) => ({ dayName: r.dayName, divergence: r.pushDivergence }));
+
+      const divergenceNote = formatPushDivergenceNote(dayDivergences);
+      if (divergenceNote) {
+        return { ...result, divergenceNote };
+      }
 
       return result;
     },

--- a/convex/aiUsage.ts
+++ b/convex/aiUsage.ts
@@ -68,6 +68,19 @@ const aiRunArgs = {
   workoutPushOutcome: v.optional(
     v.union(v.literal("pushed"), v.literal("failed"), v.literal("none")),
   ),
+  pushDivergence: v.optional(
+    v.object({
+      missingMovements: v.array(v.string()),
+      extraMovements: v.array(v.string()),
+      setCountMismatches: v.array(
+        v.object({
+          movementId: v.string(),
+          intended: v.number(),
+          stored: v.number(),
+        }),
+      ),
+    }),
+  ),
   createdAt: v.number(),
 };
 

--- a/convex/coach/pushAndVerify.ts
+++ b/convex/coach/pushAndVerify.ts
@@ -11,6 +11,7 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { DAY_NAMES } from "./weekProgrammingHelpers";
 import type { BlockInput } from "../tonal/transforms";
+import type { PushDivergence } from "../tonal/mutations";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,6 +26,7 @@ interface PushResult {
   tonalWorkoutId?: string;
   error?: string;
   exerciseCount?: number;
+  pushDivergence?: PushDivergence | null;
 }
 
 export interface WeekPushResult {
@@ -46,6 +48,7 @@ type CreateWorkoutResult =
       title: string;
       setCount: number;
       planId: Id<"workoutPlans">;
+      pushDivergence: PushDivergence | null;
     }
   | { success: false; error: string; planId: Id<"workoutPlans"> };
 
@@ -189,6 +192,7 @@ export const pushWeekPlanToTonal = internalAction({
           title: result.title,
           tonalWorkoutId: result.workoutId,
           exerciseCount: countExercises(wp.blocks),
+          pushDivergence: result.pushDivergence,
         });
         pushed++;
       } else {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -533,6 +533,19 @@ export default defineSchema({
     workoutPushOutcome: v.optional(
       v.union(v.literal("pushed"), v.literal("failed"), v.literal("none")),
     ),
+    pushDivergence: v.optional(
+      v.object({
+        missingMovements: v.array(v.string()),
+        extraMovements: v.array(v.string()),
+        setCountMismatches: v.array(
+          v.object({
+            movementId: v.string(),
+            intended: v.number(),
+            stored: v.number(),
+          }),
+        ),
+      }),
+    ),
 
     createdAt: v.number(),
   })

--- a/convex/tonal/mutations.test.ts
+++ b/convex/tonal/mutations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  computePushDivergence,
   correctDurationRepsMismatch,
   enrichPushErrorMessage,
   formatTonalTitle,
@@ -302,5 +303,63 @@ describe("correctDurationRepsMismatch", () => {
     expect(sets[0].prescribedReps).toBeUndefined();
     expect(sets[1].prescribedReps).toBe(8);
     expect(sets[2].prescribedReps).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePushDivergence
+// ---------------------------------------------------------------------------
+
+describe("computePushDivergence", () => {
+  it("returns null when intended and stored sets match exactly", () => {
+    const intended = [
+      { movementId: "a", sets: 3 },
+      { movementId: "b", sets: 2 },
+    ];
+    const storedSets = [
+      { movementId: "a", prescribedReps: 10 },
+      { movementId: "a", prescribedReps: 10 },
+      { movementId: "a", prescribedReps: 10 },
+      { movementId: "b", prescribedDuration: 30 },
+      { movementId: "b", prescribedDuration: 30 },
+    ];
+    expect(computePushDivergence(intended, storedSets)).toBeNull();
+  });
+
+  it("flags a missing movement", () => {
+    const intended = [
+      { movementId: "a", sets: 3 },
+      { movementId: "b", sets: 2 },
+    ];
+    const storedSets = [
+      { movementId: "a", prescribedReps: 10 },
+      { movementId: "a", prescribedReps: 10 },
+      { movementId: "a", prescribedReps: 10 },
+    ];
+    const div = computePushDivergence(intended, storedSets);
+    expect(div).not.toBeNull();
+    expect(div!.missingMovements).toContain("b");
+  });
+
+  it("flags a set-count mismatch", () => {
+    const intended = [{ movementId: "a", sets: 3 }];
+    const storedSets = [
+      { movementId: "a", prescribedReps: 10 },
+      { movementId: "a", prescribedReps: 10 },
+    ];
+    const div = computePushDivergence(intended, storedSets);
+    expect(div).not.toBeNull();
+    expect(div!.setCountMismatches).toEqual([{ movementId: "a", intended: 3, stored: 2 }]);
+  });
+
+  it("flags an extra movement that wasn't sent", () => {
+    const intended = [{ movementId: "a", sets: 1 }];
+    const storedSets = [
+      { movementId: "a", prescribedReps: 10 },
+      { movementId: "z", prescribedReps: 10 },
+    ];
+    const div = computePushDivergence(intended, storedSets);
+    expect(div).not.toBeNull();
+    expect(div!.extraMovements).toContain("z");
   });
 });

--- a/convex/tonal/mutations.ts
+++ b/convex/tonal/mutations.ts
@@ -12,6 +12,72 @@ import { WORKOUT_SOURCE } from "../workoutPlans";
 import { withTokenRetry } from "./tokenRetry";
 import { blockInputValidator } from "../validators";
 
+export interface PushDivergence {
+  missingMovements: string[];
+  extraMovements: string[];
+  setCountMismatches: { movementId: string; intended: number; stored: number }[];
+}
+
+interface IntendedSet {
+  movementId: string;
+  sets: number;
+}
+
+interface StoredSet {
+  movementId: string;
+  prescribedReps?: number;
+  prescribedDuration?: number;
+}
+
+/**
+ * Compare intended (what we sent to Tonal) vs stored (what Tonal actually saved).
+ * Returns null when they match exactly. Returns a structured divergence object
+ * listing missing movements, extra movements, and per-movement set-count mismatches
+ * when they don't.
+ *
+ * "Intended" is in (movementId, sets) compact form. "Stored" is one entry per
+ * actual set in Tonal's response. The function expands intended into per-set
+ * counts internally for comparison.
+ */
+export function computePushDivergence(
+  intended: IntendedSet[],
+  storedSets: StoredSet[],
+): PushDivergence | null {
+  const intendedCounts = new Map<string, number>();
+  for (const it of intended) {
+    intendedCounts.set(it.movementId, (intendedCounts.get(it.movementId) ?? 0) + it.sets);
+  }
+  const storedCounts = new Map<string, number>();
+  for (const s of storedSets) {
+    storedCounts.set(s.movementId, (storedCounts.get(s.movementId) ?? 0) + 1);
+  }
+
+  const missingMovements: string[] = [];
+  const setCountMismatches: PushDivergence["setCountMismatches"] = [];
+  for (const [movementId, intendedSetCount] of intendedCounts) {
+    const storedCount = storedCounts.get(movementId) ?? 0;
+    if (storedCount === 0) missingMovements.push(movementId);
+    else if (storedCount !== intendedSetCount) {
+      setCountMismatches.push({ movementId, intended: intendedSetCount, stored: storedCount });
+    }
+  }
+
+  const extraMovements: string[] = [];
+  for (const movementId of storedCounts.keys()) {
+    if (!intendedCounts.has(movementId)) extraMovements.push(movementId);
+  }
+
+  if (
+    missingMovements.length === 0 &&
+    extraMovements.length === 0 &&
+    setCountMismatches.length === 0
+  ) {
+    return null;
+  }
+
+  return { missingMovements, extraMovements, setCountMismatches };
+}
+
 /** Mutates `sets` in place; returns the number of corrections made. */
 export function correctDurationRepsMismatch(
   sets: WorkoutSetInput[],
@@ -67,7 +133,10 @@ export const pushWorkoutToTonal = internalAction({
     title: v.string(),
     blocks: blockInputValidator,
   },
-  handler: async (ctx, { userId, title, blocks }): Promise<{ id: string }> => {
+  handler: async (
+    ctx,
+    { userId, title, blocks },
+  ): Promise<{ id: string; pushDivergence: PushDivergence | null }> => {
     const catalog = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
     if (catalog.length === 0) {
       throw new Error(
@@ -107,17 +176,30 @@ export const pushWorkoutToTonal = internalAction({
       }
       const tonalWorkoutId = workout.id;
 
-      // Best-effort verification; never throws — the push itself already succeeded.
+      // Real verification: fetch the stored workout and diff against intent.
+      let pushDivergence: PushDivergence | null = null;
       try {
-        const customWorkouts = await tonalFetch<Array<{ id: string }>>(token, `/v6/user-workouts`);
-        if (!customWorkouts?.some((w) => w.id === tonalWorkoutId)) {
-          console.warn(`Push verification: workout ${tonalWorkoutId} not found in read-back`);
+        const stored = await tonalFetch<{
+          id: string;
+          sets?: { movementId: string; prescribedReps?: number; prescribedDuration?: number }[];
+        }>(token, `/v6/user-workouts/${tonalWorkoutId}`);
+        if (stored.sets !== undefined) {
+          // sets[] in the request is already expanded one-per-set, so each row counts as 1.
+          const intended = sets.map((s) => ({ movementId: s.movementId, sets: 1 }));
+          pushDivergence = computePushDivergence(intended, stored.sets);
+          if (pushDivergence) {
+            console.warn(
+              `Push divergence on workout ${tonalWorkoutId}:`,
+              JSON.stringify(pushDivergence),
+            );
+          }
         }
-      } catch {
-        console.warn(`Push verification: could not read back custom workouts list`);
+        // If stored.sets is undefined, we cannot verify; leave pushDivergence null.
+      } catch (err) {
+        console.warn(`Push verification: read-back failed for ${tonalWorkoutId}`, err);
       }
 
-      return { id: tonalWorkoutId };
+      return { id: tonalWorkoutId, pushDivergence };
     });
   },
 });
@@ -197,6 +279,7 @@ export const createWorkout = internalAction({
         title: string;
         setCount: number;
         planId: Id<"workoutPlans">;
+        pushDivergence: PushDivergence | null;
       }
     | { success: false; error: string; planId: Id<"workoutPlans"> }
   > => {
@@ -204,11 +287,14 @@ export const createWorkout = internalAction({
     const sets = expandBlocksToSets(blocks as BlockInput[]);
     try {
       const tonalTitle = title;
-      const { id } = await ctx.runAction(internal.tonal.mutations.pushWorkoutToTonal, {
-        userId,
-        title: tonalTitle,
-        blocks,
-      });
+      const { id, pushDivergence } = await ctx.runAction(
+        internal.tonal.mutations.pushWorkoutToTonal,
+        {
+          userId,
+          title: tonalTitle,
+          blocks,
+        },
+      );
       const now = Date.now();
       const planId = await ctx.runMutation(internal.workoutPlans.create, {
         userId,
@@ -234,6 +320,7 @@ export const createWorkout = internalAction({
         title,
         setCount: sets.length,
         planId,
+        pushDivergence,
       };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## Summary

- New pure helper `computePushDivergence(intended, stored)` in `convex/tonal/mutations.ts` — returns `PushDivergence | null` describing missing movements, extra movements, and per-movement set-count mismatches.
- `pushWorkoutToTonal` now does a real `GET /v6/user-workouts/{id}` after every successful POST and runs the diff. Read-back failure is caught and logs a `console.warn` — never breaks the push.
- `createWorkout` action threads `pushDivergence` through its return; `pushAndVerify.WeekPushResult.results[].pushDivergence` carries per-day divergence to `approveWeekPlanTool`.
- Schema widening: optional `pushDivergence` field on `aiRun` (passes `npm run convex:smoke`).
- `RunAccumulator.pushDivergence` + `recordPushDivergence()` write the field on the per-turn `aiRun` row.
- `createWorkoutTool` returns `divergenceWarning?: string` to the LLM when divergence is non-null and non-empty (the structured `pushDivergence` itself is destructured out of the tool result so it doesn't leak as undeclared output).
- New helper `convex/ai/divergenceNote.ts` (pure) — `formatPushDivergenceNote(perDay)` builds the multi-day aggregate warning that `approveWeekPlanTool` appends to its message.

## Why

Despite its name, the previous \"push verification\" only checked that the new workout id appeared in the post-push list — it never compared block structure or set count. If Tonal silently truncates, normalizes, or rejects part of a payload, the action returned `success` and the LLM narrated from the request, not the stored state. This was the infrastructural reason \"what coach says\" could drift from \"what shows up on Tonal.\"

## Recommended ship order

7-PR series. Each independently shippable. Suggested order, lowest-risk first:

1. `feat/add-exercise-warmup-flag`
2. `feat/tighten-search-exercises`
3. `fix/add-exercise-silent-drop`
4. `feat/program-week-injury-filter-diagnostics`
5. `feat/set-warmup-block-tool`
6. `feat/rebuild-day-tool`
7. 👉 **this PR** — `feat/push-verification`

This PR is last in the order because it has the schema widening and the largest behavioral surface. Soaking after the smaller fixes land lets the divergence telemetry start collecting useful signal early.

## ⚠️ Outstanding concern: Tonal response shape

`GET /v6/user-workouts/{id}` is not exercised anywhere else in the codebase (only `GET /v6/user-workouts` list is). The read-back assumes `{ id, sets: [...] }` based on the `TonalWorkoutDetail` type in `tonal/types.ts`, but no live response has been validated against that shape yet.

**Mitigation in this PR:** the read-back guards against `stored.sets === undefined` and treats it as \"unable to verify\" — `pushDivergence` stays `null` rather than running the diff against `[]`. So if the response shape is wrong, divergence detection silently no-ops; it does NOT produce false-positive WARNINGs that would degrade the signal.

**Suggested follow-up before relying on the divergence signal in prod:** in staging, log the raw `GET /v6/user-workouts/{id}` response once and confirm the shape. If `sets` is present, this PR works as designed. If not, update the read-back path to match Tonal's actual shape.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run convex:smoke` passes (schema widening doesn't break existing rows)
- [x] Full backend suite: 1113 tests passing (+4 new)
- [x] Helper unit tests: match → null, missing movement, set-count mismatch, extra movement
- [x] Read-back guard: when `stored.sets` is undefined, `pushDivergence` stays `null`
- [x] LLM tool result: `pushDivergence` is destructured out (not leaked as raw object)
- [ ] **Staging only:** push a workout and inspect Convex logs for the divergence WARNING shape; if false positives appear, the response-shape assumption is wrong (see Mitigation above)
- [ ] **Staging only:** a divergent push (e.g. send 3 sets, Tonal stores 2) should produce a `pushDivergence` row on `aiRun` and a `divergenceWarning` in the chat tool result

## Cleanup note

The diagnostic file `convex/_traceUserRuns.ts` (used during the original investigation) was deployed to prod earlier and is not in any branch's source tree. It will be removed from prod automatically the next time *any* of these 7 PRs is deployed (or by deploying `main` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)