### PR TITLE
fix(tonal): reject empty estimate payloads + return structured error to LLM

### DIFF
--- a/convex/ai/tools.ts
+++ b/convex/ai/tools.ts
@@ -371,13 +371,25 @@ export const estimateDurationTool = createTool({
   }),
   execute: withToolTracking(
     "estimate_duration",
-    async (ctx, input, _options): Promise<{ estimatedMinutes: number }> => {
+    async (
+      ctx,
+      input,
+      _options,
+    ): Promise<{ success: true; estimatedMinutes: number } | { success: false; error: string }> => {
       const userId = requireUserId(ctx);
-      const result = (await ctx.runAction(internal.tonal.mutations.estimateWorkout, {
-        userId,
-        blocks: input.blocks,
-      })) as { duration: number };
-      return { estimatedMinutes: Math.round(result.duration / 60) };
+      try {
+        const result = (await ctx.runAction(internal.tonal.mutations.estimateWorkout, {
+          userId,
+          blocks: input.blocks,
+        })) as { duration: number };
+        return { success: true, estimatedMinutes: Math.round(result.duration / 60) };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          success: false,
+          error: `Could not estimate duration: ${msg}. Verify every movementId came from search_exercises and that each exercise has sets ≥ 1.`,
+        };
+      }
     },
   ),
 });

--- a/convex/tonal/mutations.ts
+++ b/convex/tonal/mutations.ts
@@ -379,9 +379,15 @@ export const estimateWorkout = internalAction({
   handler: async (ctx, { userId, blocks }): Promise<WorkoutEstimate> => {
     const catalog = await ctx.runQuery(internal.tonal.movementSync.getAllMovements);
     const sets = expandBlocksToSets(blocks as BlockInput[], catalog);
-    // Tonal's /v6/user-workouts/estimate expects a bare SetList array, not
-    // a wrapper object. Sending { sets: [...] } produces a 400 with
-    // "cannot unmarshal object into Go value of type content.SetList".
+    // Reject empty payloads up front; Tonal would otherwise return its
+    // misleading "cannot unmarshal object into Go value of type content.SetList"
+    // 400 for both empty arrays and JSON-object wrappers.
+    if (sets.length === 0) {
+      throw new Error(
+        "estimateWorkout: no sets to estimate. Verify every exercise has a valid movementId resolvable in the catalog.",
+      );
+    }
+    // Endpoint expects a bare SetList array, not a wrapper object.
     return withTokenRetry(ctx, userId, async (token) =>
       tonalFetch<WorkoutEstimate>(token, "/v6/user-workouts/estimate", {
         method: "POST",


### PR DESCRIPTION
## Summary

- `estimateWorkout` now throws early with a clear message when expanded sets are empty (instead of letting Tonal return its misleading 400).
- `estimate_duration` tool wraps the action in try/catch and returns `{success, error}` so the LLM gets actionable text instead of an uncaught throw.

## Why

30-day audit of `estimate_duration`: 8 calls, **4 failed (50%)** — every failure was Tonal's `cannot unmarshal object into Go value of type content.SetList`, which Tonal returns for both empty arrays and JSON-object wrappers (we send a bare array, so the empty case is the live failure).

The model has no signal to recover from this — the failure is opaque, the tool throws, and the user sees a generic error.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] No new tests — defensive validation + already-typed tool return shape change
- [ ] Re-check failure rate in 30 days; expect estimate_duration success rate → ~100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)