### PR TITLE
hotfix(test): replace .at(-1) with bracket access to fix Vercel deploy

### DIFF
--- a/convex/coach/weekModifications.test.ts
+++ b/convex/coach/weekModifications.test.ts
@@ -168,7 +168,9 @@ describe("addExerciseToDraft warmUp passthrough", () => {
     expect(result.ok).toBe(true);
 
     const wp = await t.run((ctx) => ctx.db.get(planId));
-    const lastBlockExercise = wp!.blocks.at(-1)!.exercises[0];
+    // Bracket access (not .at(-1)) to stay under Convex's tsc lib target,
+    // which lacks Array.prototype.at — the Vercel deploy typecheck rejects it.
+    const lastBlockExercise = wp!.blocks[wp!.blocks.length - 1]!.exercises[0];
     expect(lastBlockExercise.movementId).toBe("mov-warmup-1");
     expect(lastBlockExercise.warmUp).toBe(true);
   });


### PR DESCRIPTION
Vercel build on main is failing because Convex's deploy-time tsc lib lacks `Array.prototype.at` (ES2022). The line was added in #302 and never deployed cleanly.

Verified the fix locally: `npx vitest --project backend run` still passes the `warmUp passthrough` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)