### PR TITLE
fix(workoutDetail): split into internal+public actions to fix LLM tool auth

### DIFF
--- a/convex/ai/tools.ts
+++ b/convex/ai/tools.ts
@@ -1,6 +1,6 @@
 import { createTool } from "@convex-dev/agent";
 import { z } from "zod";
-import { api, internal } from "../_generated/api";
+import { internal } from "../_generated/api";
 import type {
   Activity,
   Movement,
@@ -173,11 +173,16 @@ export const getWorkoutDetailTool = createTool({
   }),
   execute: withToolTracking(
     "get_workout_detail",
-    async (ctx, input, _options): Promise<EnrichedWorkoutDetail> => {
-      // Use the enriched action that joins movement IDs with names from the catalog
-      const detail = (await ctx.runAction(api.workoutDetail.getWorkoutDetail, {
+    async (ctx, input, _options): Promise<EnrichedWorkoutDetail | null> => {
+      // Call the internal action with explicit userId. Calling the public
+      // action via `api.workoutDetail.getWorkoutDetail` from the agent runtime
+      // failed ~46% of the time with "Not authenticated" — the agent runtime
+      // doesn't reliably propagate auth context through runAction.
+      const userId = requireUserId(ctx);
+      const detail = (await ctx.runAction(internal.workoutDetail.getWorkoutDetailInternal, {
+        userId,
         activityId: input.activityId,
-      })) as EnrichedWorkoutDetail;
+      })) as EnrichedWorkoutDetail | null;
       return detail;
     },
   ),

--- a/convex/workoutDetail.ts
+++ b/convex/workoutDetail.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { action, internalQuery } from "./_generated/server";
+import { action, internalAction, internalQuery } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { normalizeTargetArea } from "./lib/targetArea";
 import type {
@@ -97,17 +97,23 @@ export const getCompletedWorkoutMeta = internalQuery({
   },
 });
 
-export const getWorkoutDetail = action({
-  args: { activityId: v.string() },
+/**
+ * Inner action: takes an explicit `userId`. Used by both the public
+ * `getWorkoutDetail` (which resolves userId from auth) and the LLM tool
+ * wrapper (which already has the userId via `requireUserId`).
+ *
+ * The 30-day audit on `get_workout_detail` showed a 46% success rate — every
+ * failure was "Not authenticated". The agent runtime doesn't reliably
+ * propagate auth through `ctx.runAction(api.publicAction)`, so the tool
+ * wrapper now calls this internal version with the userId it already has.
+ */
+export const getWorkoutDetailInternal = internalAction({
+  args: { userId: v.id("users"), activityId: v.string() },
   handler: async (ctx, args): Promise<EnrichedWorkoutDetail | null> => {
     if (!UUID_RE.test(args.activityId)) {
       console.warn(`getWorkoutDetail: invalid activityId format "${args.activityId}"`);
       return null;
     }
-    const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
-    // Session expired or user not signed in — AppShell will redirect to /login.
-    // Returning null keeps this out of Sentry (vs. throwing "Not authenticated").
-    if (!userId) return null;
 
     const [detail, movements, formattedSummary, workoutMeta, prMovementIdList]: [
       unknown,
@@ -118,23 +124,23 @@ export const getWorkoutDetail = action({
     ] = await Promise.all([
       ctx
         .runAction(internal.tonal.proxy.fetchWorkoutDetail, {
-          userId,
+          userId: args.userId,
           activityId: args.activityId,
         })
         .catch((): null => null),
       ctx.runQuery(internal.tonal.movementSync.getAllMovements),
       ctx
         .runAction(internal.tonal.proxyProjected.fetchFormattedSummary, {
-          userId,
+          userId: args.userId,
           summaryId: args.activityId,
         })
         .catch((): null => null),
       ctx.runQuery(internal.workoutDetail.getCompletedWorkoutMeta, {
-        userId,
+        userId: args.userId,
         activityId: args.activityId,
       }),
       ctx.runQuery(internal.workoutDetail.getPRMovementIdsForActivity, {
-        userId,
+        userId: args.userId,
         activityId: args.activityId,
       }),
     ]);
@@ -176,6 +182,25 @@ export const getWorkoutDetail = action({
       workoutTitle: workoutMeta?.title ?? undefined,
       targetArea: workoutMeta ? normalizeTargetArea(workoutMeta.targetArea) : undefined,
     };
+  },
+});
+
+/**
+ * Public action for frontend use (`useAction` in `(app)/activity/[id]/page.tsx`).
+ * Resolves the authenticated user from the request context, then delegates.
+ */
+export const getWorkoutDetail = action({
+  args: { activityId: v.string() },
+  handler: async (ctx, args): Promise<EnrichedWorkoutDetail | null> => {
+    const userId = await ctx.runQuery(internal.lib.auth.resolveEffectiveUserId, {});
+    // Session expired or user not signed in — AppShell will redirect to /login.
+    // Returning null keeps this out of Sentry (vs. throwing "Not authenticated").
+    if (!userId) return null;
+
+    return ctx.runAction(internal.workoutDetail.getWorkoutDetailInternal, {
+      userId,
+      activityId: args.activityId,
+    });
   },
 });
 


### PR DESCRIPTION
## Summary

Refactor `convex/workoutDetail.ts` into:
- `getWorkoutDetailInternal` (`internalAction`) — takes explicit `userId`, all the heavy lifting lives here
- `getWorkoutDetail` (public `action`, kept for frontend `useAction`) — resolves auth user, delegates

The `get_workout_detail` LLM tool now calls the internal version with `requireUserId(ctx)`.

## Why

30-day audit on `get_workout_detail`: **46% success rate** (162 of 304 calls fail). Every failure was `Uncaught Error: Not authenticated` from `ctx.runAction(api.workoutDetail.getWorkoutDetail)` inside the tool wrapper.

The agent runtime doesn't reliably propagate auth context through `runAction` calls to public actions — the public action calls `resolveEffectiveUserId` which returns `null`, and downstream handlers throw. Internal actions bypass that auth resolution because the caller (the tool) hands them the userId it already has.

The system prompt explicitly says **"ALWAYS call get_workout_detail when asked about specific exercises in a workout"** — half of those mandated calls were silently failing.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest --project backend run` 1140 passing
- [x] Frontend `(app)/activity/[activityId]/page.tsx` `useAction(api.workoutDetail.getWorkoutDetail)` is unchanged — public action still exists with the same signature
- [ ] Re-check 30-day stats: expect `get_workout_detail` success rate → ~100%

## Refs

Tool audit findings; companion to #309 (push gap), #310 (estimate_duration), #311 (tool descriptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)