### PR TITLE
chore: bump convex to 1.37.0 + refresh ai-files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,8 +302,12 @@ The following are enforced by tooling -- you don't need to remember them:
 
 This project uses [Convex](https://convex.dev) as its backend.
 
-When working on Convex code, **always read `convex/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
+When working on Convex code, **always read
+`convex/_generated/ai/guidelines.md` first** for important guidelines on
+how to correctly use Convex APIs and patterns. The file contains rules that
+override what you may have learned about Convex from training data.
 
-Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+Convex agent skills for common tasks can be installed by running
+`npx convex ai-files install`.
 
 <!-- convex-ai-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,12 @@
 
 This project uses [Convex](https://convex.dev) as its backend.
 
-When working on Convex code, **always read `convex/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
+When working on Convex code, **always read
+`convex/_generated/ai/guidelines.md` first** for important guidelines on
+how to correctly use Convex APIs and patterns. The file contains rules that
+override what you may have learned about Convex from training data.
 
-Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+Convex agent skills for common tasks can be installed by running
+`npx convex ai-files install`.
 
 <!-- convex-ai-end -->

--- a/convex/_generated/ai/ai-files.state.json
+++ b/convex/_generated/ai/ai-files.state.json
@@ -1,14 +1,6 @@
 {
   "guidelinesHash": "62d72acb9afcc18f658d88dd772f34b5b1da5fa60ef0402e57a784d97c458e57",
-  "agentsMdSectionHash": "bbf30bd25ceea0aefd279d62e1cb2b4c207fcb712b69adf26f3d02b296ffc7b2",
-  "claudeMdHash": "bbf30bd25ceea0aefd279d62e1cb2b4c207fcb712b69adf26f3d02b296ffc7b2",
-  "agentSkillsSha": "231a67aa8a5b29cc2794cbc8298335a71aaa6d0e",
-  "installedSkillNames": [
-    "convex",
-    "convex-create-component",
-    "convex-migration-helper",
-    "convex-performance-audit",
-    "convex-quickstart",
-    "convex-setup-auth"
-  ]
+  "agentsMdSectionHash": "5934f676ea9a332e7cd4a4f64aa23b59d926e9faca026c758d4b1f87d2101cc3",
+  "claudeMdHash": "5934f676ea9a332e7cd4a4f64aa23b59d926e9faca026c758d4b1f87d2101cc3",
+  "agentSkillsSha": "b86618b5c3c4789c9fed98e84bbc34b3e8e70f20"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "convex": "^1.36.1",
+        "convex": "^1.37.0",
         "convex-helpers": "^0.1.115",
         "lucide-react": "^1.11.0",
         "next": "^16.2.4",
@@ -9781,9 +9781,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.36.1.tgz",
-      "integrity": "sha512-NVnwNqU+h8jyPuS0Itvj4MPH9c2yF+tA/RNoSDpCqiLhmYD4+kZxm0dDkVM0QDzz66wem9NqheBb9YQGsHwzBQ==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.37.0.tgz",
+      "integrity": "sha512-xGSx5edIsXCEex3OU2U2N0oyB/cOa9qGwKiImF9yOWqjqZgOkx39idtpdlwNBTBSt4S30oAvs4yeXY5xxPIX3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "convex": "^1.36.1",
+    "convex": "^1.37.0",
     "convex-helpers": "^0.1.115",
     "lucide-react": "^1.11.0",
     "next": "^16.2.4",


### PR DESCRIPTION
## Summary
- Upgrade `convex` from 1.36.1 → 1.37.0 ([changelog](https://github.com/get-convex/convex-js/blob/main/CHANGELOG.md#changelog))
- Re-run `npx convex ai-files update` to refresh `convex/_generated/ai/ai-files.state.json`, `AGENTS.md`, and `CLAUDE.md` (line-wrap reflow only; no semantic changes to the convex-ai sections)

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] CI green (lint, tests, knip, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)