### PR TITLE
fix: weight AI budget tokens for Claude cache pricing

### DIFF
--- a/convex/ai/budget.test.ts
+++ b/convex/ai/budget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { calculateWeightedUsageTokens } from "../aiUsage";
 import { BUDGET_WARNING_THRESHOLD, DAILY_TOKEN_BUDGET } from "../aiUsage";
 import { shouldNotifyBudgetWarning } from "./budget";
 
@@ -12,5 +13,26 @@ describe("shouldNotifyBudgetWarning", () => {
 
   it("does not notify when the user was already above the threshold before the latest usage", () => {
     expect(shouldNotifyBudgetWarning(WARNING_THRESHOLD_TOKENS + 1000, 100)).toBe(false);
+  });
+
+  it("reaches the warning threshold later for cache-read-heavy Claude usage than fresh usage", () => {
+    const freshUsage = calculateWeightedUsageTokens({
+      provider: "claude",
+      inputTokens: WARNING_THRESHOLD_TOKENS + 1,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    const cachedUsage = calculateWeightedUsageTokens({
+      provider: "claude",
+      inputTokens: WARNING_THRESHOLD_TOKENS + 1,
+      outputTokens: 0,
+      cacheReadTokens: WARNING_THRESHOLD_TOKENS + 1,
+      cacheWriteTokens: 0,
+    });
+
+    expect(shouldNotifyBudgetWarning(freshUsage, freshUsage)).toBe(true);
+    expect(cachedUsage).toBeLessThan(WARNING_THRESHOLD_TOKENS);
+    expect(shouldNotifyBudgetWarning(cachedUsage, cachedUsage)).toBe(false);
   });
 });

--- a/convex/ai/budget.ts
+++ b/convex/ai/budget.ts
@@ -8,9 +8,12 @@ const BUDGET_EXCEEDED_MESSAGE =
   "I've hit my daily thinking limit -- let's pick this up tomorrow. Your limit resets at midnight UTC.";
 const WARNING_THRESHOLD_TOKENS = DAILY_TOKEN_BUDGET * BUDGET_WARNING_THRESHOLD;
 
-export function shouldNotifyBudgetWarning(todayUsage: number, latestUsageTokens: number): boolean {
-  const previousUsage = Math.max(0, todayUsage - latestUsageTokens);
-  return previousUsage < WARNING_THRESHOLD_TOKENS && todayUsage >= WARNING_THRESHOLD_TOKENS;
+export function shouldNotifyBudgetWarning(
+  todayWeightedUsage: number,
+  latestWeightedUsageTokens: number,
+): boolean {
+  const previousUsage = Math.max(0, todayWeightedUsage - latestWeightedUsageTokens);
+  return previousUsage < WARNING_THRESHOLD_TOKENS && todayWeightedUsage >= WARNING_THRESHOLD_TOKENS;
 }
 
 export async function checkDailyBudget(
@@ -18,14 +21,14 @@ export async function checkDailyBudget(
   userId: string,
   threadId: string,
 ): Promise<boolean> {
-  const { totalTokens: todayUsage, latestUsageTokens } = await ctx.runQuery(
+  const { totalTokens: todayWeightedUsage, latestUsageTokens } = await ctx.runQuery(
     internal.aiUsage.getDailyTokenUsageStats,
     {
       userId: userId as Id<"users">,
     },
   );
 
-  if (todayUsage >= DAILY_TOKEN_BUDGET) {
+  if (todayWeightedUsage >= DAILY_TOKEN_BUDGET) {
     await saveMessage(ctx, components.agent, {
       threadId,
       userId,
@@ -34,7 +37,7 @@ export async function checkDailyBudget(
     return true;
   }
 
-  if (!shouldNotifyBudgetWarning(todayUsage, latestUsageTokens)) return false;
+  if (!shouldNotifyBudgetWarning(todayWeightedUsage, latestUsageTokens)) return false;
 
   const warningDate = new Date().toISOString().slice(0, 10);
   const claimed = await ctx.runMutation(internal.aiUsage.claimDailyBudgetWarning, {
@@ -45,7 +48,7 @@ export async function checkDailyBudget(
 
   await ctx.scheduler.runAfter(0, internal.discord.notifyError, {
     source: "aiBudget",
-    message: `User ${userId} at ${Math.round((todayUsage / DAILY_TOKEN_BUDGET) * 100)}% of daily token budget (${todayUsage.toLocaleString()} / ${DAILY_TOKEN_BUDGET.toLocaleString()})`,
+    message: `User ${userId} at ${Math.round((todayWeightedUsage / DAILY_TOKEN_BUDGET) * 100)}% of daily token budget (${todayWeightedUsage.toLocaleString()} / ${DAILY_TOKEN_BUDGET.toLocaleString()})`,
     userId,
   });
 

--- a/convex/aiUsage.test.ts
+++ b/convex/aiUsage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   aggregateCacheHitsByProvider,
   BUDGET_WARNING_THRESHOLD,
+  calculateWeightedUsageTokens,
   DAILY_TOKEN_BUDGET,
 } from "./aiUsage";
 
@@ -68,5 +69,30 @@ describe("aggregateCacheHitsByProvider", () => {
       cacheWriteTokens: 0,
       cacheReadRatio: 0,
     });
+  });
+});
+
+describe("calculateWeightedUsageTokens", () => {
+  it("applies Claude cache and output multipliers", () => {
+    expect(
+      calculateWeightedUsageTokens({
+        provider: "claude",
+        inputTokens: 1_000,
+        outputTokens: 200,
+        cacheReadTokens: 600,
+        cacheWriteTokens: 100,
+      }),
+    ).toBe(1_485);
+  });
+
+  it("falls back to stored totalTokens for historical rows without cache fields", () => {
+    expect(
+      calculateWeightedUsageTokens({
+        provider: "claude",
+        inputTokens: 800,
+        outputTokens: 200,
+        totalTokens: 1_000,
+      }),
+    ).toBe(1_000);
   });
 });

--- a/convex/aiUsage.ts
+++ b/convex/aiUsage.ts
@@ -116,8 +116,54 @@ export interface CacheHitRateRow {
 export interface AiUsageTokenRow {
   provider: string;
   inputTokens: number;
+  outputTokens?: number;
+  totalTokens?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+}
+
+interface UsageCostMultipliers {
+  cacheRead: number;
+  cacheWrite: number;
+  output: number;
+}
+
+const DEFAULT_USAGE_COST_MULTIPLIERS: UsageCostMultipliers = {
+  cacheRead: 1,
+  cacheWrite: 1,
+  output: 1,
+};
+
+const USAGE_COST_MULTIPLIERS_BY_PROVIDER: Partial<Record<string, UsageCostMultipliers>> = {
+  claude: {
+    cacheRead: 0.1,
+    cacheWrite: 1.25,
+    output: 5,
+  },
+};
+
+function getUsageCostMultipliers(provider?: string) {
+  if (!provider) return DEFAULT_USAGE_COST_MULTIPLIERS;
+  return USAGE_COST_MULTIPLIERS_BY_PROVIDER[provider] ?? DEFAULT_USAGE_COST_MULTIPLIERS;
+}
+
+export function calculateWeightedUsageTokens(row: AiUsageTokenRow): number {
+  const cacheReadTokens = row.cacheReadTokens ?? 0;
+  const cacheWriteTokens = row.cacheWriteTokens ?? 0;
+  const outputTokens = row.outputTokens ?? 0;
+
+  if (row.cacheReadTokens === undefined && row.cacheWriteTokens === undefined) {
+    return row.totalTokens ?? row.inputTokens + outputTokens;
+  }
+
+  const freshInputTokens = Math.max(0, row.inputTokens - cacheReadTokens - cacheWriteTokens);
+  const multipliers = getUsageCostMultipliers(row.provider);
+  return (
+    freshInputTokens +
+    cacheWriteTokens * multipliers.cacheWrite +
+    cacheReadTokens * multipliers.cacheRead +
+    outputTokens * multipliers.output
+  );
 }
 
 export function aggregateCacheHitsByProvider(rows: AiUsageTokenRow[]): CacheHitRateRow[] {
@@ -228,7 +274,7 @@ export const claimDailyBudgetWarning = internalMutation({
   },
 });
 
-/** Get total tokens used by a user today (UTC day boundary). */
+/** Get weighted budget tokens used by a user today (UTC day boundary). */
 export const getDailyTokenUsage = internalQuery({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
@@ -243,7 +289,7 @@ export const getDailyTokenUsage = internalQuery({
       )
       .collect();
 
-    return records.reduce((sum, r) => sum + r.totalTokens, 0);
+    return records.reduce((sum, record) => sum + calculateWeightedUsageTokens(record), 0);
   },
 });
 
@@ -265,10 +311,11 @@ export const getDailyTokenUsageStats = internalQuery({
     let latestUsageTokens = 0;
     let totalTokens = 0;
     for (const record of records) {
-      totalTokens += record.totalTokens;
-      if (record.totalTokens > 0 && record.createdAt >= latestCreatedAt) {
+      const weightedTokens = calculateWeightedUsageTokens(record);
+      totalTokens += weightedTokens;
+      if (weightedTokens > 0 && record.createdAt >= latestCreatedAt) {
         latestCreatedAt = record.createdAt;
-        latestUsageTokens = record.totalTokens;
+        latestUsageTokens = weightedTokens;
       }
     }
 


### PR DESCRIPTION
## Summary
- switch daily AI budget enforcement to weighted cost-equivalent tokens so Claude cache reads count at 10%, cache writes at 125%, and Claude output at 5x
- preserve historical aiUsage rows by falling back to stored totalTokens when cache fields are absent
- add regression coverage for the weighting helper and cache-read-heavy warning-threshold behavior

## Issue
Refs #188

## Tests
- npm run typecheck
- npx vitest run convex/aiUsage.test.ts convex/ai/budget.test.ts
- npm test

## Residual Risk
- weighted output pricing is modeled explicitly for Claude; other providers still use the existing 1x output/input budget behavior until broader pricing-based budgeting is introduced
