### PR TITLE
Guard check-in cron deadline

### DIFF
--- a/convex/checkIns.test.ts
+++ b/convex/checkIns.test.ts
@@ -143,4 +143,18 @@ describe("runCheckInTriggerEvaluation", () => {
 
     await t.action(internal.checkIns.runCheckInTriggerEvaluation, {});
   });
+
+  test("exits before scheduling users when deadline is already past", async () => {
+    const t = convexTest(schema, modules);
+    await insertUserWithProfile(t);
+
+    await t.action(internal.checkIns.runCheckInTriggerEvaluation, {
+      _deadlineOffsetMs: -1,
+    });
+
+    const scheduled = await t.run(async (ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect(),
+    );
+    expect(scheduled.some((fn) => fn.name.includes("evaluateCheckInForUser"))).toBe(false);
+  });
 });

--- a/convex/checkIns.ts
+++ b/convex/checkIns.ts
@@ -272,6 +272,9 @@ async function evaluateUserCheckIn(
 }
 
 const ELIGIBLE_USERS_PAGE_SIZE = 100;
+const ACTION_LIMIT_MS = 600_000;
+const SAFETY_BUFFER_MS = 60_000;
+const DEADLINE_OFFSET_MS = ACTION_LIMIT_MS - SAFETY_BUFFER_MS;
 
 /**
  * Evaluates check-in triggers for a single user and sends any due check-ins.
@@ -308,18 +311,35 @@ export const evaluateCheckInForUser = internalAction({
  * approach the 600 s hard cap as the user base grows.
  */
 export const runCheckInTriggerEvaluation = internalAction({
-  args: {},
-  handler: async (ctx) => {
+  args: {
+    /** Override the deadline budget for tests (omit in production). */
+    _deadlineOffsetMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const deadline = Date.now() + (args._deadlineOffsetMs ?? DEADLINE_OFFSET_MS);
     let cursor: string | null = null;
     let totalScheduled = 0;
 
-    while (true) {
+    pages: while (true) {
+      if (Date.now() >= deadline) {
+        console.warn(
+          "[check-in] Deadline reached - stopping early. Remaining users will be evaluated in the next cron run.",
+        );
+        break;
+      }
+
       const result: { page: Id<"users">[]; isDone: boolean; continueCursor: string } =
         await ctx.runQuery(internal.checkIns.getEligibleUserIdsPage, {
           paginationOpts: { cursor, numItems: ELIGIBLE_USERS_PAGE_SIZE },
         });
 
       for (const userId of result.page) {
+        if (Date.now() >= deadline) {
+          console.warn(
+            "[check-in] Deadline reached - stopping early. Remaining users will be evaluated in the next cron run.",
+          );
+          break pages;
+        }
         await ctx.scheduler.runAfter(0, internal.checkIns.evaluateCheckInForUser, { userId });
         totalScheduled++;
       }


### PR DESCRIPTION
## Summary
- Add a deadline budget to the check-in trigger scheduler action, matching the activation and token refresh cron guards.
- Stop before fetching another page or scheduling another per-user check when the action budget is exhausted.
- Cover the expired-deadline path with a regression test that confirms no evaluateCheckInForUser jobs are scheduled.

## Root cause
Commit 851f6dc guarded activation and token refresh cron loops, but runCheckInTriggerEvaluation still paginated all eligible users and awaited one scheduler call per user without a deadline cutoff.

## Test plan
- npx vitest run convex/checkIns.test.ts
- npx tsc --noEmit
- npm test
- npm run lint