### PR TITLE
fix: update expired Discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,4 +89,4 @@ The README's [GitHub Actions secrets](README.md#github-actions-secrets) table ha
 
 - The iOS app is not in this repository (it stays in a private fork).
 - Adding support for fitness machines other than Tonal is not on the roadmap right now, though the coach engine is mostly machine-agnostic. File an issue to discuss before starting work.
-- There is a [Discord server](https://discord.gg/Sa5ewWP5M) for casual discussion, but GitHub issues remain the primary channel for bugs, features, and support.
+- There is a [Discord server](https://discord.gg/24phpduVbx) for casual discussion, but GitHub issues remain the primary channel for bugs, features, and support.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <a href="tsconfig.json"><img src="https://img.shields.io/badge/TypeScript-strict-3178c6.svg" alt="TypeScript" /></a>
   <a href="#testing"><img src="https://img.shields.io/badge/tests-Vitest-6E9F18.svg" alt="Vitest" /></a>
-  <a href="https://discord.gg/Sa5ewWP5M"><img src="https://img.shields.io/discord/1482942052898574336?logo=discord&logoColor=white&label=Discord&color=5865F2" alt="Discord" /></a>
+  <a href="https://discord.gg/24phpduVbx"><img src="https://img.shields.io/discord/1482942052898574336?logo=discord&logoColor=white&label=Discord&color=5865F2" alt="Discord" /></a>
   <img src="https://img.shields.io/coderabbit/prs/github/JeffOtano/roni?utm_source=oss&utm_medium=github&utm_campaign=JeffOtano%2Froni&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews" alt="CodeRabbit Pull Request Reviews" />
 </p>
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -41,7 +41,7 @@ guaranteed SLA for general support, issue triage, or feature requests.
 
 ## Community
 
-There is a [Discord server](https://discord.gg/Sa5ewWP5M) for casual discussion.
+There is a [Discord server](https://discord.gg/24phpduVbx) for casual discussion.
 GitHub issues remain the primary channel for bugs, features, and support.
 
 ## What support is not

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -3,4 +3,4 @@ export const SITE_NAME = "Roni";
 export const REPO_URL = "https://github.com/JeffOtano/roni";
 export const REPO_ISSUES_URL = `${REPO_URL}/issues`;
 export const REPO_SUPPORT_URL = `${REPO_URL}/blob/main/SUPPORT.md`;
-export const DISCORD_URL = "https://discord.gg/Sa5ewWP5M";
+export const DISCORD_URL = "https://discord.gg/24phpduVbx";


### PR DESCRIPTION
## Summary
- Replaces the expired Discord invite (`Sa5ewWP5M`) with the new permalink (`24phpduVbx`) in `src/lib/urls.ts` so all in-app and footer links work again
- Updates the matching links in `README.md`, `SUPPORT.md`, and `CONTRIBUTING.md`

## Test plan
- [ ] Click the Discord link from the site footer / settings / contact / FAQ pages and confirm it opens a valid Discord invite
- [ ] Verify the README Discord badge links to the new invite
- [ ] `npm run typecheck` and `npm run lint` pass

https://claude.ai/code/session_01KQcKcVc8azsxbZh5eYtnko

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQcKcVc8azsxbZh5eYtnko)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Discord server invite link across documentation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->