### PR TITLE
fix: combine production Sentry fixes

### DIFF
--- a/convex/ai/quotaClassification.test.ts
+++ b/convex/ai/quotaClassification.test.ts
@@ -179,3 +179,32 @@ describe("buildProviderTransientMessage with isByok flag", () => {
     expect(msg).toContain("fresh chat thread");
   });
 });
+
+describe("finalize reason normalization for provider errors", () => {
+  it("maps Gemini free-tier quota messages to rate_limit", () => {
+    const geminiQuotaError = new Error(
+      "You exceeded your current quota, please check your plan and billing details. " +
+        "For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. " +
+        "Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, " +
+        "limit: 20, model: gemini-3-flash\nPlease retry in 18.825585699s.",
+    );
+    expect(classifyTransientError(geminiQuotaError) ?? "error").toBe("rate_limit");
+  });
+
+  it("maps non-classifiable errors to the 'error' fallback", () => {
+    const unknownError = new Error("Something completely unexpected exploded");
+    expect(classifyTransientError(unknownError) ?? "error").toBe("error");
+  });
+
+  it("maps a transient 500 to server_error", () => {
+    const serverError = Object.assign(new Error("Internal server error"), { status: 500 });
+    expect(classifyTransientError(serverError) ?? "error").toBe("server_error");
+  });
+
+  it("maps a context-window overflow to context_limit", () => {
+    const contextError = Object.assign(new Error("API error"), {
+      responseBody: "input_token_count exceeds limit quota",
+    });
+    expect(classifyTransientError(contextError) ?? "error").toBe("context_limit");
+  });
+});

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -370,9 +370,11 @@ async function tryReportByok(ctx: ActionCtx, report: ErrorReport): Promise<boole
 
 async function reportError(ctx: ActionCtx, report: ErrorReport): Promise<void> {
   const reason = report.error instanceof Error ? report.error.message : String(report.error);
-  await finalizePendingMessages(ctx, report.threadId, reason);
-
   const transientKind = classifyTransientError(report.error);
+
+  // The browser stream processor re-throws this failed-message error verbatim.
+  await finalizePendingMessages(ctx, report.threadId, transientKind ?? "error");
+
   const content = transientKind
     ? buildProviderTransientMessage(transientKind, report.provider, report.isByok)
     : AI_ERROR_MESSAGE;

--- a/convex/checkIns.test.ts
+++ b/convex/checkIns.test.ts
@@ -9,6 +9,7 @@ import schema from "./schema";
 const modules = import.meta.glob("./**/*.*s");
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const RUN_EVALUATION_PAGE_SIZE = 100;
 
 describe("frequencyWindowMs", () => {
   it("daily returns exactly 24 hours", () => {
@@ -144,17 +145,61 @@ describe("runCheckInTriggerEvaluation", () => {
     await t.action(internal.checkIns.runCheckInTriggerEvaluation, {});
   });
 
-  test("exits before scheduling users when deadline is already past", async () => {
+  test("schedules evaluateCheckInForUser for each eligible user", async () => {
     const t = convexTest(schema, modules);
     await insertUserWithProfile(t);
+    await insertUserWithProfile(t);
+
+    await t.action(internal.checkIns.runCheckInTriggerEvaluation, {});
+
+    const scheduled = await t.run(async (ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect(),
+    );
+    const userEvals = scheduled.filter((fn) => fn.name.includes("evaluateCheckInForUser"));
+    expect(userEvals).toHaveLength(2);
+  });
+
+  test("does not schedule ineligible users (disabled or muted)", async () => {
+    const t = convexTest(schema, modules);
+    await insertUserWithProfile(t);
+    await insertUserWithProfile(t, {
+      checkInPreferences: { enabled: false, frequency: "daily", muted: false },
+    });
+    await insertUserWithProfile(t, {
+      checkInPreferences: { enabled: true, frequency: "daily", muted: true },
+    });
+
+    await t.action(internal.checkIns.runCheckInTriggerEvaluation, {});
+
+    const scheduled = await t.run(async (ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect(),
+    );
+    const userEvals = scheduled.filter((fn) => fn.name.includes("evaluateCheckInForUser"));
+    expect(userEvals).toHaveLength(1);
+  });
+
+  test("schedules itself for the next page when there are more results", async () => {
+    const t = convexTest(schema, modules);
+    for (let i = 0; i < RUN_EVALUATION_PAGE_SIZE + 1; i++) {
+      await insertUserWithProfile(t);
+    }
 
     await t.action(internal.checkIns.runCheckInTriggerEvaluation, {
-      _deadlineOffsetMs: -1,
+      cursor: null,
+      totalScheduled: 0,
     });
 
     const scheduled = await t.run(async (ctx) =>
       ctx.db.system.query("_scheduled_functions").collect(),
     );
-    expect(scheduled.some((fn) => fn.name.includes("evaluateCheckInForUser"))).toBe(false);
+    const userEvals = scheduled.filter((fn) => fn.name.includes("evaluateCheckInForUser"));
+    const continuations = scheduled.filter((fn) => fn.name.includes("runCheckInTriggerEvaluation"));
+
+    expect(userEvals).toHaveLength(RUN_EVALUATION_PAGE_SIZE);
+    expect(continuations).toHaveLength(1);
+    expect(continuations[0]?.args[0]).toMatchObject({
+      cursor: expect.any(String),
+      totalScheduled: RUN_EVALUATION_PAGE_SIZE,
+    });
   });
 });

--- a/convex/checkIns.ts
+++ b/convex/checkIns.ts
@@ -272,9 +272,6 @@ async function evaluateUserCheckIn(
 }
 
 const ELIGIBLE_USERS_PAGE_SIZE = 100;
-const ACTION_LIMIT_MS = 600_000;
-const SAFETY_BUFFER_MS = 60_000;
-const DEADLINE_OFFSET_MS = ACTION_LIMIT_MS - SAFETY_BUFFER_MS;
 
 /**
  * Evaluates check-in triggers for a single user and sends any due check-ins.
@@ -307,49 +304,38 @@ export const evaluateCheckInForUser = internalAction({
 
 /**
  * Orchestrates check-in trigger evaluation across all eligible users.
- * Fans out per-user evaluations via the scheduler so no single action can
- * approach the 600 s hard cap as the user base grows.
+ *
+ * Processes one page of users per invocation and schedules itself for the next
+ * page so no single action invocation can approach the 600 s hard cap as the
+ * user base grows. Analytics are emitted only on the final page.
  */
 export const runCheckInTriggerEvaluation = internalAction({
   args: {
-    /** Override the deadline budget for tests (omit in production). */
-    _deadlineOffsetMs: v.optional(v.number()),
+    cursor: v.optional(v.union(v.string(), v.null())),
+    totalScheduled: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
-    const deadline = Date.now() + (args._deadlineOffsetMs ?? DEADLINE_OFFSET_MS);
-    let cursor: string | null = null;
-    let totalScheduled = 0;
+  handler: async (ctx, { cursor = null, totalScheduled: prev = 0 }) => {
+    const result: { page: Id<"users">[]; isDone: boolean; continueCursor: string } =
+      await ctx.runQuery(internal.checkIns.getEligibleUserIdsPage, {
+        paginationOpts: { cursor, numItems: ELIGIBLE_USERS_PAGE_SIZE },
+      });
 
-    pages: while (true) {
-      if (Date.now() >= deadline) {
-        console.warn(
-          "[check-in] Deadline reached - stopping early. Remaining users will be evaluated in the next cron run.",
-        );
-        break;
-      }
+    for (const userId of result.page) {
+      await ctx.scheduler.runAfter(0, internal.checkIns.evaluateCheckInForUser, { userId });
+    }
 
-      const result: { page: Id<"users">[]; isDone: boolean; continueCursor: string } =
-        await ctx.runQuery(internal.checkIns.getEligibleUserIdsPage, {
-          paginationOpts: { cursor, numItems: ELIGIBLE_USERS_PAGE_SIZE },
-        });
+    const scheduled = prev + result.page.length;
 
-      for (const userId of result.page) {
-        if (Date.now() >= deadline) {
-          console.warn(
-            "[check-in] Deadline reached - stopping early. Remaining users will be evaluated in the next cron run.",
-          );
-          break pages;
-        }
-        await ctx.scheduler.runAfter(0, internal.checkIns.evaluateCheckInForUser, { userId });
-        totalScheduled++;
-      }
-
-      if (result.isDone) break;
-      cursor = result.continueCursor;
+    if (!result.isDone) {
+      await ctx.scheduler.runAfter(0, internal.checkIns.runCheckInTriggerEvaluation, {
+        cursor: result.continueCursor,
+        totalScheduled: scheduled,
+      });
+      return;
     }
 
     analytics.captureSystem("check_in_trigger_evaluation_scheduled", {
-      users_scheduled: totalScheduled,
+      users_scheduled: scheduled,
     });
     await analytics.flush();
   },

--- a/convex/coach/rebuildDay.test.ts
+++ b/convex/coach/rebuildDay.test.ts
@@ -168,7 +168,7 @@ describe("rebuildDay", () => {
     expect(oldPlanAfter).toBeNull(); // deleted
   });
 
-  it("rejects rebuild_day on rest/recovery days", async () => {
+  it("returns error for rest day without throwing", async () => {
     const t = convexTest(schema, modules);
     const userId = await t.run((ctx) => ctx.db.insert("users", { email: "u@t" }));
     const weekPlanId = await t.run((ctx) =>
@@ -186,13 +186,43 @@ describe("rebuildDay", () => {
       }),
     );
 
-    await expect(
-      t.action(internal.coach.rebuildDay.rebuildDay, {
+    const result = await t.action(internal.coach.rebuildDay.rebuildDay, {
+      userId,
+      weekPlanId,
+      dayIndex: 0,
+      blocks: [{ exercises: [{ movementId: "x", sets: 1, reps: 1 }] }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; error: string }).error).toMatch(/rest|recovery/i);
+  });
+
+  it("returns error for recovery day without throwing", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run((ctx) => ctx.db.insert("users", { email: "u@t" }));
+    const weekPlanId = await t.run((ctx) =>
+      ctx.db.insert("weekPlans", {
         userId,
-        weekPlanId,
-        dayIndex: 0,
-        blocks: [{ exercises: [{ movementId: "x", sets: 1, reps: 1 }] }],
+        weekStartDate: "2026-04-27",
+        preferredSplit: "full_body",
+        targetDays: 0,
+        days: Array.from({ length: 7 }, () => ({
+          sessionType: "recovery" as const,
+          status: "programmed" as const,
+        })),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
       }),
-    ).rejects.toThrow(/rest|recovery/i);
+    );
+
+    const result = await t.action(internal.coach.rebuildDay.rebuildDay, {
+      userId,
+      weekPlanId,
+      dayIndex: 3,
+      blocks: [{ exercises: [{ movementId: "x", sets: 1, reps: 1 }] }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; error: string }).error).toMatch(/rest|recovery/i);
   });
 });

--- a/convex/coach/rebuildDay.ts
+++ b/convex/coach/rebuildDay.ts
@@ -43,7 +43,7 @@ export const rebuildDay = internalAction({
     const day = plan.days[dayIndex];
     if (!day) throw new Error("Invalid day index");
     if (day.sessionType === "rest" || day.sessionType === "recovery") {
-      throw new Error("Cannot rebuild a rest or recovery day");
+      return { ok: false, error: "Cannot rebuild a rest or recovery day" };
     }
 
     const allMovementIds = blocks.flatMap((b) => b.exercises.map((e) => e.movementId));

--- a/src/lib/sentryBeforeSend.test.ts
+++ b/src/lib/sentryBeforeSend.test.ts
@@ -120,6 +120,41 @@ describe("shouldDropSentryEvent", () => {
     const event = eventWithValue("Uncaught Error: byok_quota_exceeded");
     expect(shouldDropSentryEvent(event, {})).toBe(true);
   });
+
+  it("drops event when hint has generic message but exception value contains quota error", () => {
+    // Real-world scenario: the AI SDK wraps the error with a generic message
+    // while the original quota error is preserved in event.exception.values.
+    const quotaMsg = "You exceeded your current quota, please check your plan and billing details.";
+    const event: ErrorEvent = {
+      exception: {
+        values: [{ value: "Failed to process stream" }, { value: quotaMsg }],
+      },
+    } as unknown as ErrorEvent;
+    const hint = hintWithError("Failed to process stream");
+    expect(shouldDropSentryEvent(event, hint)).toBe(true);
+  });
+
+  it("drops event when hint has generic message but exception value contains free-tier metric", () => {
+    const metricMsg =
+      "Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-3-flash";
+    const event: ErrorEvent = {
+      exception: {
+        values: [{ value: metricMsg }],
+      },
+    } as unknown as ErrorEvent;
+    const hint = hintWithError("Error reading stream");
+    expect(shouldDropSentryEvent(event, hint)).toBe(true);
+  });
+
+  it("keeps event when no message source contains a suppressed substring", () => {
+    const event: ErrorEvent = {
+      exception: {
+        values: [{ value: "Something unexpected went wrong" }],
+      },
+    } as unknown as ErrorEvent;
+    const hint = hintWithError("Something unexpected went wrong");
+    expect(shouldDropSentryEvent(event, hint)).toBe(false);
+  });
 });
 
 describe("sentryBeforeSend", () => {

--- a/src/lib/sentryBeforeSend.ts
+++ b/src/lib/sentryBeforeSend.ts
@@ -46,27 +46,37 @@ const SUPPRESSED_MESSAGE_SUBSTRINGS: readonly string[] = [
   "generate_content_free_tier_requests",
 ];
 
-function errorMessage(event: ErrorEvent, hint: EventHint): string | null {
+// Collect every candidate message from the hint and event so that quota errors
+// nested in event.exception.values are not missed when hint.originalException
+// carries a generic wrapper message.
+function errorMessages(event: ErrorEvent, hint: EventHint): string[] {
+  const messages: string[] = [];
+
   const hintError = hint.originalException;
   if (hintError instanceof Error && typeof hintError.message === "string") {
-    return hintError.message;
+    messages.push(hintError.message);
+  } else if (typeof hintError === "string") {
+    messages.push(hintError);
   }
-  if (typeof hintError === "string") return hintError;
 
   const values = event.exception?.values;
-  if (values && values.length > 0) {
-    const last = values[values.length - 1]?.value;
-    if (typeof last === "string") return last;
+  if (values) {
+    for (const v of values) {
+      if (typeof v?.value === "string") messages.push(v.value);
+    }
   }
 
-  if (typeof event.message === "string") return event.message;
-  return null;
+  if (typeof event.message === "string") messages.push(event.message);
+
+  return messages;
 }
 
 export function shouldDropSentryEvent(event: ErrorEvent, hint: EventHint): boolean {
-  const message = errorMessage(event, hint);
-  if (!message) return false;
-  return SUPPRESSED_MESSAGE_SUBSTRINGS.some((needle) => message.includes(needle));
+  const messages = errorMessages(event, hint);
+  if (messages.length === 0) return false;
+  return messages.some((msg) =>
+    SUPPRESSED_MESSAGE_SUBSTRINGS.some((needle) => msg.includes(needle)),
+  );
 }
 
 export function sentryBeforeSend(event: ErrorEvent, hint: EventHint): ErrorEvent | null {


### PR DESCRIPTION
## Summary

- Combines the useful fixes from #327 and #329 into one current-main branch.
- Fixes three production Sentry paths: nested Gemini quota messages, raw provider finalize reasons, check-in scheduler hard-cap timeouts, and rest/recovery day rebuild throws.
- Supersedes #327 and #329.

## Changes

- Sentry filtering: checks every candidate event message instead of returning after the first hint message, so nested Gemini quota text in exception values is suppressed.
- AI resilience: stores short finalize reasons such as `rate_limit`, `server_error`, `context_limit`, or `error` instead of raw provider error text that the browser stream processor rethrows.
- Check-ins: processes one eligible-user page per action invocation and schedules a continuation when more pages remain.
- Coach rebuilds: returns structured `{ ok: false, error }` results for rest/recovery day rebuild attempts so the tool wrapper can relay the failure to the model.
- Tests: keeps the PR coverage from both branches and replaces the weak #327 pagination test with a real page-boundary continuation scenario.

## Checklist

- [x] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [x] New logic has tests (happy path + at least one error/edge case)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [x] Tested in browser (if UI changes) - no UI changes
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- `npm run typecheck`
- `npx vitest run --project backend convex/checkIns.test.ts convex/coach/rebuildDay.test.ts convex/ai/quotaClassification.test.ts convex/ai/resilience.test.ts`
- `npx vitest run --project frontend src/lib/sentryBeforeSend.test.ts`
- `npm test`
- `npm run format:check`
- `npx eslint --max-warnings=0 convex/ai/quotaClassification.test.ts convex/ai/resilience.ts convex/checkIns.test.ts convex/checkIns.ts convex/coach/rebuildDay.test.ts convex/coach/rebuildDay.ts src/lib/sentryBeforeSend.test.ts src/lib/sentryBeforeSend.ts`

Note: full `npm run lint` is currently blocked locally by preexisting ignored `.claude/worktrees/*/convex/_generated/api.js` files with unused eslint-disable warnings. The changed files pass ESLint directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error categorization to better handle transient failures
  * Optimized check-in trigger scheduling with pagination support
  * Updated day rebuild operations to provide clearer error feedback

* **Tests**
  * Expanded test coverage for error handling, scheduling, and recovery logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->