### PR TITLE
perf: route trivial coach prompts to fallback

### DIFF
--- a/convex/ai/coachEvals.test.ts
+++ b/convex/ai/coachEvals.test.ts
@@ -9,18 +9,28 @@
 import { describe, expect, test } from "vitest";
 import { generateText } from "ai";
 import { google } from "@ai-sdk/google";
+import { classifyPromptIntent } from "../chatProcessing";
 import { buildInstructions } from "./promptSections";
+import { PROVIDERS } from "./providers";
 import { EVAL_SCENARIOS, type EvalScenario } from "./evalScenarios";
 
 const apiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 const describeIfKey = apiKey ? describe : describe.skip;
 
 const instructions = buildInstructions();
+const GEMINI_PRIMARY_MODEL = PROVIDERS.gemini.primaryModel;
+const GEMINI_FALLBACK_MODEL = PROVIDERS.gemini.fallbackModel ?? GEMINI_PRIMARY_MODEL;
+
+function selectEvalModel(scenario: EvalScenario): string {
+  return classifyPromptIntent(scenario.userMessage) === "trivial"
+    ? GEMINI_FALLBACK_MODEL
+    : GEMINI_PRIMARY_MODEL;
+}
 
 async function runScenario(scenario: EvalScenario): Promise<void> {
   const system = `${instructions}\n\n<training-data>\n${scenario.snapshot}\n</training-data>`;
   const result = await generateText({
-    model: google("gemini-3-flash-preview"),
+    model: google(selectEvalModel(scenario)),
     system,
     prompt: scenario.userMessage,
     temperature: 0,

--- a/convex/aiUsage.ts
+++ b/convex/aiUsage.ts
@@ -236,12 +236,13 @@ export const recordRouting = internalMutation({
     userId: v.string(),
     threadId: v.string(),
     intent: v.string(),
+    agentName: v.string(),
   },
-  handler: async (ctx, { userId, threadId, intent }) => {
+  handler: async (ctx, { userId, threadId, intent, agentName }) => {
     await ctx.db.insert("aiUsage", {
       userId: userId as Id<"users">,
       threadId,
-      agentName: `router:${intent}`,
+      agentName,
       model: "keyword-classifier",
       provider: "local",
       inputTokens: 0,

--- a/convex/chatProcessing.test.ts
+++ b/convex/chatProcessing.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { classifyPromptIntent, selectCoachRoute } from "./chatProcessing";
+
+describe("classifyPromptIntent", () => {
+  const chars = (length: number) => "x".repeat(length);
+
+  it("routes short low-intent messages as trivial", () => {
+    expect(classifyPromptIntent("hello")).toBe("trivial");
+    expect(classifyPromptIntent("thanks!")).toBe("trivial");
+  });
+
+  it("uses a strict length boundary for trivial messages", () => {
+    expect(classifyPromptIntent(chars(29))).toBe("trivial");
+    expect(classifyPromptIntent(chars(30))).toBe("default");
+  });
+
+  it("keeps short programming and tool commands complex", () => {
+    expect(classifyPromptIntent("push it")).toBe("complex");
+    expect(classifyPromptIntent("swap bench press")).toBe("complex");
+  });
+
+  it("routes longer non-keyword messages as default", () => {
+    expect(classifyPromptIntent("How should I think about my last workout?")).toBe("default");
+  });
+});
+
+describe("selectCoachRoute", () => {
+  const primaryAgent = { name: "primary" };
+  const fallbackAgent = { name: "fallback" };
+
+  it("uses the fallback model as the first attempt for trivial prompts", () => {
+    const route = selectCoachRoute(
+      {
+        primary: primaryAgent,
+        fallback: fallbackAgent,
+        primaryModelName: "claude-sonnet-4-6",
+        fallbackModelName: "claude-haiku-4-5",
+      },
+      "trivial",
+    );
+
+    expect(route.primary).toBe(fallbackAgent);
+    expect(route.fallback).toBe(primaryAgent);
+    expect(route.primaryModelName).toBe("claude-haiku-4-5");
+  });
+
+  it("keeps the primary model first for complex prompts", () => {
+    const route = selectCoachRoute(
+      {
+        primary: primaryAgent,
+        fallback: fallbackAgent,
+        primaryModelName: "claude-sonnet-4-6",
+        fallbackModelName: "claude-haiku-4-5",
+      },
+      "complex",
+    );
+
+    expect(route.primary).toBe(primaryAgent);
+    expect(route.fallback).toBe(fallbackAgent);
+    expect(route.primaryModelName).toBe("claude-sonnet-4-6");
+  });
+
+  it("keeps the primary model first for default prompts", () => {
+    const route = selectCoachRoute(
+      {
+        primary: primaryAgent,
+        fallback: fallbackAgent,
+        primaryModelName: "claude-sonnet-4-6",
+        fallbackModelName: "claude-haiku-4-5",
+      },
+      "default",
+    );
+
+    expect(route.primary).toBe(primaryAgent);
+    expect(route.fallback).toBe(fallbackAgent);
+    expect(route.primaryModelName).toBe("claude-sonnet-4-6");
+  });
+
+  it("keeps the primary model first when the provider has no fallback model", () => {
+    const route = selectCoachRoute(
+      {
+        primary: primaryAgent,
+        fallback: primaryAgent,
+        primaryModelName: "openrouter/auto",
+        fallbackModelName: null,
+      },
+      "trivial",
+    );
+
+    expect(route.primary).toBe(primaryAgent);
+    expect(route.fallback).toBe(primaryAgent);
+    expect(route.primaryModelName).toBe("openrouter/auto");
+  });
+});

--- a/convex/chatProcessing.ts
+++ b/convex/chatProcessing.ts
@@ -16,7 +16,7 @@ import { checkDailyBudget } from "./ai/budget";
 import { streamWithRetry } from "./ai/resilience";
 import type { RunAccumulator } from "./ai/runTelemetry";
 import { sanitizeTimezone } from "./ai/timeDecay";
-import type { ProviderId } from "./ai/providers";
+import { getProviderConfig, type ProviderId } from "./ai/providers";
 import * as analytics from "./lib/posthog";
 import {
   assertThreadOwnership,
@@ -30,12 +30,65 @@ import {
 // prod ones look the same, so we flag prod on Vercel's build env instead.
 const ENVIRONMENT: "dev" | "prod" = process.env.VERCEL_ENV === "production" ? "prod" : "dev";
 const RELEASE_SHA = process.env.VERCEL_GIT_COMMIT_SHA;
+const TRIVIAL_PROMPT_MAX_CHARS = 30;
+const COMPLEX_INTENT_KEYWORDS = ["program", "plan", "build", "swap", "push", "deload"] as const;
+
+export type RoutingIntent = "trivial" | "complex" | "default";
+
+interface CoachRoute<TAgent> {
+  primary: TAgent;
+  fallback: TAgent;
+  primaryModelName: string;
+}
+
+interface CoachRouteOptions<TAgent> extends CoachRoute<TAgent> {
+  fallbackModelName: string | null;
+}
+
+export function classifyPromptIntent(prompt: string): RoutingIntent {
+  const normalized = prompt.trim().toLowerCase();
+  if (COMPLEX_INTENT_KEYWORDS.some((keyword) => normalized.includes(keyword))) {
+    return "complex";
+  }
+  if (normalized.length < TRIVIAL_PROMPT_MAX_CHARS) return "trivial";
+  return "default";
+}
+
+export function selectCoachRoute<TAgent>(
+  agents: CoachRouteOptions<TAgent>,
+  intent: RoutingIntent,
+): CoachRoute<TAgent> {
+  if (intent !== "trivial" || !agents.fallbackModelName) {
+    return {
+      primary: agents.primary,
+      fallback: agents.fallback,
+      primaryModelName: agents.primaryModelName,
+    };
+  }
+
+  return {
+    primary: agents.fallback,
+    fallback: agents.primary,
+    primaryModelName: agents.fallbackModelName,
+  };
+}
 
 async function persistRun(ctx: ActionCtx, accumulator: RunAccumulator): Promise<void> {
   try {
     await ctx.runMutation(internal.aiUsage.recordRun, accumulator.toRow());
   } catch {
     // Never fail the turn on telemetry persistence error.
+  }
+}
+
+async function recordRoutingIntent(
+  ctx: ActionCtx,
+  args: { userId: string; threadId: string; intent: RoutingIntent; agentName: string },
+): Promise<void> {
+  try {
+    await ctx.runMutation(internal.aiUsage.recordRouting, args);
+  } catch {
+    // Routing telemetry should never block the user's chat turn.
   }
 }
 
@@ -69,6 +122,7 @@ export const processMessage = internalAction({
     let accumulator: RunAccumulator | undefined;
     const contextTiming: CoachContextTiming = {};
     const retrievalEnabled = shouldUseCrossThreadSearch(prompt, (imageStorageIds?.length ?? 0) > 0);
+    const routingIntent = classifyPromptIntent(prompt);
     const startTime = Date.now();
     try {
       const providerConfig = await resolveUserProviderConfig(ctx, userId);
@@ -76,17 +130,30 @@ export const processMessage = internalAction({
 
       const resolvedPrompt = await buildPrompt(ctx, prompt, imageStorageIds);
 
-      const { primary, fallback, primaryModelName } = buildCoachAgentsForProvider({
+      const agents = buildCoachAgentsForProvider({
         ...providerConfig,
         userTimezone,
         retrievalEnabled,
         timing: contextTiming,
       });
+      const route = selectCoachRoute(
+        {
+          ...agents,
+          fallbackModelName: getProviderConfig(providerConfig.provider).fallbackModel,
+        },
+        routingIntent,
+      );
+      await recordRoutingIntent(ctx, {
+        userId,
+        threadId,
+        intent: routingIntent,
+        agentName: route.primaryModelName,
+      });
       accumulator = await withByokErrorSanitization(() =>
         streamWithRetry(ctx, {
-          primaryAgent: primary,
-          fallbackAgent: fallback,
-          primaryModelName,
+          primaryAgent: route.primary,
+          fallbackAgent: route.fallback,
+          primaryModelName: route.primaryModelName,
           threadId,
           userId,
           promptMessageId: messageId,


### PR DESCRIPTION
## Summary

- Adds keyword intent classification for coach prompts: trivial, complex, and default.
- Routes trivial prompts through the configured fallback model first while keeping complex/default prompts on the primary model.
- Records routing telemetry for each classified chat turn and updates prompt evals so trivial Gemini scenarios exercise the fallback model.

## Tests

- `npx vitest run convex/chatProcessing.test.ts` (RED first: failed on missing exports)
- `npm run typecheck`
- `npx vitest run convex/chatProcessing.test.ts convex/ai/coachEvals.test.ts`
- `npm test`
- `npm run lint`
- `npm run format:check`

## Residual Risk

- The live LLM eval suite remains skipped locally without `GOOGLE_GENERATIVE_AI_API_KEY`, but it now selects the fallback model for scenarios classified as trivial when run with credentials.

Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Smart prompt routing: The system now intelligently evaluates each query's complexity and automatically routes it to the most suitable AI model. Routine queries use efficient fallback models while complex queries leverage the primary model, enhancing overall system efficiency and response quality.

**Tests**
- Added comprehensive test coverage validating prompt intent classification and routing selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->