### PR TITLE
fix: handle missing Tonal formatted summaries

### DIFF
--- a/convex/tonal/historySync.test.ts
+++ b/convex/tonal/historySync.test.ts
@@ -3,6 +3,7 @@ import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { internal } from "../_generated/api";
 import schema from "../schema";
+import { buildVolumeByMovement } from "./historySyncCore";
 import {
   TIER_INTERVAL_SLACK_MS,
   TIER_INTERVALS_MS,
@@ -24,6 +25,26 @@ afterEach(() => {
 
 const TODAY_ISO = "2026-04-25";
 const FROZEN_NOW = Date.UTC(2026, 3, 25, 12, 0, 0);
+
+describe("buildVolumeByMovement", () => {
+  test("returns an empty map when a formatted summary is missing", () => {
+    const volumes = buildVolumeByMovement(null);
+
+    expect(volumes.size).toBe(0);
+  });
+
+  test("indexes movement volume by movement id", () => {
+    const volumes = buildVolumeByMovement({
+      movementSets: [
+        { movementId: "movement-1", totalVolume: 1200 },
+        { movementId: "movement-2", totalVolume: 800 },
+      ],
+    });
+
+    expect(volumes.get("movement-1")).toBe(1200);
+    expect(volumes.get("movement-2")).toBe(800);
+  });
+});
 
 async function seedConnectedUser(t: ReturnType<typeof convexTest>) {
   return await t.run(async (ctx) => {

--- a/convex/tonal/historySyncCore.ts
+++ b/convex/tonal/historySyncCore.ts
@@ -42,6 +42,19 @@ function activityToWorkoutPayload(activity: Activity): WorkoutPayload {
   };
 }
 
+export function buildVolumeByMovement(
+  summary: FormattedWorkoutSummary | null,
+): Map<string, number> {
+  const volumeByMovement = new Map<string, number>();
+  if (summary === null) return volumeByMovement;
+
+  for (const ms of summary.movementSets) {
+    volumeByMovement.set(ms.movementId, ms.totalVolume);
+  }
+
+  return volumeByMovement;
+}
+
 /** Fetch detail/summary for one activity and return persistence payloads. */
 async function processOneActivity(
   ctx: ActionCtx,
@@ -65,15 +78,13 @@ async function processOneActivity(
 
   // Fetch formatted summary for per-movement totalVolume (optional).
   // totalVolume is a work-based metric (not weight x reps); kept for volume display.
-  const volumeByMovement = new Map<string, number>();
+  let volumeByMovement = new Map<string, number>();
   try {
     const summary = (await ctx.runAction(internal.tonal.proxyProjected.fetchFormattedSummary, {
       userId,
       summaryId: activityId,
-    })) as FormattedWorkoutSummary;
-    for (const ms of summary.movementSets) {
-      volumeByMovement.set(ms.movementId, ms.totalVolume);
-    }
+    })) as FormattedWorkoutSummary | null;
+    volumeByMovement = buildVolumeByMovement(summary);
   } catch (err) {
     // Volume display is optional, so the workout payload still persists
     // without it — but log so projection drift is observable.

--- a/convex/tonal/proxyProjected.test.ts
+++ b/convex/tonal/proxyProjected.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { TonalApiError } from "./client";
+import { fetchProjectedFormattedSummary } from "./proxyProjected";
+
+describe("fetchProjectedFormattedSummary", () => {
+  it("returns null when Tonal reports a missing formatted summary", async () => {
+    const fetchRaw = vi.fn(async () => {
+      throw new TonalApiError(404, '{"message":"workout summary does not exist","status":404}');
+    });
+
+    const result = await fetchProjectedFormattedSummary(fetchRaw);
+
+    expect(result).toBeNull();
+    expect(fetchRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("projects formatted summary payloads", async () => {
+    const fetchRaw = vi.fn(async () => ({
+      ignored: "field",
+      movementSets: [
+        { movementId: "movement-1", totalVolume: 1200, extra: "ignored" },
+        { movementId: "movement-2", totalVolume: 800 },
+      ],
+    }));
+
+    const result = await fetchProjectedFormattedSummary(fetchRaw);
+
+    expect(result).toEqual({
+      movementSets: [
+        { movementId: "movement-1", totalVolume: 1200 },
+        { movementId: "movement-2", totalVolume: 800 },
+      ],
+    });
+  });
+
+  it("propagates Tonal errors that are not missing summaries", async () => {
+    const error = new TonalApiError(500, "Internal Server Error");
+    const fetchRaw = vi.fn(async () => {
+      throw error;
+    });
+
+    await expect(fetchProjectedFormattedSummary(fetchRaw)).rejects.toBe(error);
+  });
+
+  it("propagates non-Tonal errors", async () => {
+    const error = new TypeError("fetch failed");
+    const fetchRaw = vi.fn(async () => {
+      throw error;
+    });
+
+    await expect(fetchProjectedFormattedSummary(fetchRaw)).rejects.toBe(error);
+  });
+});

--- a/convex/tonal/proxyProjected.ts
+++ b/convex/tonal/proxyProjected.ts
@@ -12,7 +12,7 @@
 
 import { v } from "convex/values";
 import { internalAction } from "../_generated/server";
-import { tonalFetch } from "./client";
+import { TonalApiError, tonalFetch } from "./client";
 import { CACHE_TTLS } from "./cache";
 import { cachedFetch } from "./proxy";
 import { withTokenRetry } from "./tokenRetry";
@@ -28,6 +28,20 @@ import {
 } from "./formattedSummaryProjection";
 import { projectStrengthHistory, projectStrengthHistoryStrict } from "./strengthHistoryProjection";
 import type { FormattedWorkoutSummary, StrengthScoreHistoryEntry, UserWorkout } from "./types";
+
+export async function fetchProjectedFormattedSummary(
+  fetchRaw: () => Promise<unknown>,
+): Promise<FormattedWorkoutSummary | null> {
+  try {
+    const raw = await fetchRaw();
+    return projectFormattedSummaryStrict(raw);
+  } catch (error) {
+    if (error instanceof TonalApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
 
 export const fetchStrengthHistory = internalAction({
   args: { userId: v.id("users") },
@@ -55,21 +69,24 @@ export const fetchFormattedSummary = internalAction({
     userId: v.id("users"),
     summaryId: v.string(),
   },
-  handler: async (ctx, { userId, summaryId }): Promise<FormattedWorkoutSummary> => {
+  handler: async (ctx, { userId, summaryId }): Promise<FormattedWorkoutSummary | null> => {
     const result = await withTokenRetry(ctx, userId, (token, tonalUserId) =>
-      cachedFetch<FormattedWorkoutSummary>(ctx, {
+      cachedFetch<FormattedWorkoutSummary | null>(ctx, {
         userId,
         dataType: `formattedSummary:${summaryId}`,
         ttl: CACHE_TTLS.workoutHistory,
+        shouldCache: (summary) => summary !== null,
         fetcher: async () => {
-          const raw = await tonalFetch<unknown>(
-            token,
-            `/v6/formatted/users/${tonalUserId}/workout-summaries/${summaryId}`,
+          return await fetchProjectedFormattedSummary(() =>
+            tonalFetch<unknown>(
+              token,
+              `/v6/formatted/users/${tonalUserId}/workout-summaries/${summaryId}`,
+            ),
           );
-          return projectFormattedSummaryStrict(raw);
         },
       }),
     );
+    if (result === null) return null;
     return projectFormattedSummary(result);
   },
 });


### PR DESCRIPTION
## Summary

- Treat Tonal formatted-summary 404 responses as optional missing data instead of throwing during history sync.
- Skip caching missing formatted summaries so a temporary 404 is not pinned in the immutable workout cache.
- Add focused tests for the missing-summary, success, and error paths.

## Changes

- `convex/tonal/proxyProjected.ts`: add `fetchProjectedFormattedSummary`, return `FormattedWorkoutSummary | null`, convert only `TonalApiError` 404 responses to `null`, and keep non-404 errors propagating.
- `convex/tonal/historySyncCore.ts`: explicitly map a missing formatted summary to an empty movement-volume map.
- `convex/tonal/proxyProjected.test.ts`: cover 404-to-null, successful projection, non-404 Tonal error propagation, and non-Tonal error propagation.
- `convex/tonal/historySync.test.ts`: cover missing summaries and movement-volume indexing.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [x] New logic has tests (happy path + at least one error/edge case)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [x] Tested in browser (if UI changes): not applicable, backend-only change
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- `npm run typecheck`
- `npx vitest run convex/tonal/proxyProjected.test.ts convex/tonal/proxyCacheBehavior.test.ts`
- `npx vitest run convex/tonal/proxyProjected.test.ts convex/tonal/proxyCacheBehavior.test.ts convex/tonal/historySync.test.ts`
- `npm run lint`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for volume calculation and formatted summary fetching, including edge cases for missing data.

* **Refactor**
  * Improved internal handling of workout summary data retrieval with better error management for missing summaries.
  * Extracted volume calculation logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->