### PR TITLE
fix(sentry): resolve TONALCOACH-C and TONALCOACH-1C noise

### DIFF
--- a/src/lib/sentryBeforeSend.test.ts
+++ b/src/lib/sentryBeforeSend.test.ts
@@ -84,6 +84,14 @@ describe("shouldDropSentryEvent", () => {
     expect(shouldDropSentryEvent(eventWithValue(payload), hintWithError(payload))).toBe(true);
   });
 
+  it("drops provider_overload sanitized finalize codes re-thrown by the client stream consumer", () => {
+    // After getFinalizeCodeForError sanitizes the raw model message into
+    // "provider_overload", the client-side stream processor re-throws that
+    // code verbatim. Suppress it the same way as the raw message form.
+    const payload = "provider_overload";
+    expect(shouldDropSentryEvent(eventWithValue(payload), hintWithError(payload))).toBe(true);
+  });
+
   it("drops Gemini RESOURCE_EXHAUSTED errors", () => {
     const payload = "Error: 429 RESOURCE_EXHAUSTED";
     expect(shouldDropSentryEvent(eventWithValue(payload), hintWithError(payload))).toBe(true);

--- a/src/lib/sentryBeforeSend.ts
+++ b/src/lib/sentryBeforeSend.ts
@@ -37,6 +37,11 @@ const SUPPRESSED_MESSAGE_SUBSTRINGS: readonly string[] = [
   "function call turn comes immediately after",
   "model is currently experiencing high demand",
   "RESOURCE_EXHAUSTED",
+  // Sanitized finalize code written by getFinalizeCodeForError when a transient
+  // provider error is stored in messages:finalizeMessage. The client's stream
+  // consumer re-throws the stored code verbatim, so both old (raw message) and
+  // new (sanitized code) representations are suppressed here.
+  "provider_overload",
   // Gemini free-tier quota errors. The leading "You exceeded" prefix is
   // Gemini's exact phrasing (capitalized "You exceeded ..."), so it covers
   // both the full billing sentence and truncated variants without matching


### PR DESCRIPTION
## Summary

This PR closes out two open Sentry issues — one with a full code fix already merged to `main`, and one that required an additional targeted suppression improvement.

---

### TONALCOACH-C — `TonalApiError: Tonal API 404: workout summary doesn't exist`

**Root cause:** `fetchFormattedSummary` propagated a Tonal API 404 as an unhandled exception. Workout summaries can legitimately be absent for some activity types; the 404 should yield `null`, not throw.

**Fix (already in `main` via #339 / commit `3229749`):**
- Added `fetchProjectedFormattedSummary` in `convex/tonal/proxyProjected.ts` — a thin wrapper that catches `TonalApiError` with `status === 404` and returns `null` instead of throwing.
- `processOneActivity` in `historySyncCore.ts` already wrapped the summary fetch in its own `try/catch` so a failure here never blocked workout persistence; the null return now makes the intent explicit.
- `shouldCache: (summary) => summary !== null` prevents null entries from polluting the stale-while-revalidate cache.

**Tests added (commit `3229749`):**
- `convex/tonal/proxyProjected.test.ts` — 404→null, successful projection, non-404 `TonalApiError` propagation, non-Tonal error propagation.
- `convex/tonal/historySync.test.ts` — `buildVolumeByMovement` with null summary returns empty map; volume is indexed correctly by movement ID.

**Sentry:** Closed as resolved. Last event was May 4 at 19:28 UTC, before the fix deployed at 23:12 UTC — no recurrence since.

---

### TONALCOACH-1C — `Uncaught Error: This model is currently experiencing high demand…`

**Root cause (two layers):**

1. **Raw error messages stored in finalize codes.** Before commit `5b397e7`, `reportError` passed `error.message` directly to `finalizePendingMessages`. The raw model string (e.g. `"This model is currently experiencing high demand…"`) was written into `messages:finalizeMessage`. When the client-side stream consumer processed a finalised-with-error message, `process-ui-message-stream.ts` re-threw that raw string verbatim, landing in Sentry as an unhandled exception.

2. **`sentryBeforeSend` only suppressed the old raw-message form.** After `getFinalizeCodeForError` was introduced (commit `5b397e7`), transient errors are now stored as a clean code (`"provider_overload"`) rather than the raw provider string. The `beforeSend` filter already suppressed the raw message, but not the sanitized code that would now reach the browser.

**Fixes:**

| Commit | Change |
|--------|--------|
| `f4777c6` | `reportError` stores `transientKind ?? "error"` instead of raw message |
| `5b397e7` | Introduced `getFinalizeCodeForError` for consistent, sanitized finalize codes; added `resilienceFinalize.test.ts` asserting `"provider_overload"` is returned (not the raw string) |
| **`b978745` (this PR)** | Added `"provider_overload"` to `SUPPRESSED_MESSAGE_SUBSTRINGS` in `sentryBeforeSend.ts`; added a test confirming client-side re-throws of sanitized codes are also suppressed |

**What remains / known limitation:** A separate Convex server-side Sentry SDK instance (configured via the `SENTRY_DSN` dashboard variable, independent of our Next.js SDK) captures errors from `@convex-dev/agent`'s internal V8 mutations before our `beforeSend` callback runs. Events from `chatty-hawk-*` hosts with `func_runtime: default` originate there. Filtering those would require either modifying `@convex-dev/agent` internals or a Convex-side configuration API that does not currently exist. From the user's perspective the error is already handled — `streamWithRetry` catches the overload, retries, and ultimately surfaces a friendly attributed message via `buildProviderTransientMessage`.

**Sentry:** Resolved. User-visible impact is fully handled; remaining server-side telemetry events are inherent platform noise outside application control.

---

## Test plan

- [ ] `npx vitest run src/lib/sentryBeforeSend.test.ts` — new `provider_overload` test passes
- [ ] `npx vitest run convex/tonal/proxyProjected.test.ts` — all four paths pass
- [ ] `npx vitest run convex/tonal/historySync.test.ts` — volume map tests pass
- [ ] `npm run typecheck` — no type errors
- [ ] TONALCOACH-C closed in Sentry; no new 404 events since fix deployed
- [ ] TONALCOACH-1C resolved in Sentry; client-side `provider_overload` codes now suppressed

https://claude.ai/code/session_012vyP3Arq561WgNKcX1FRvf

---
_Generated by [Claude Code](https://claude.ai/code/session_012vyP3Arq561WgNKcX1FRvf)_