### PR TITLE
fix: surface BYOK stream response failures

### DIFF
--- a/convex/ai/byokErrors.ts
+++ b/convex/ai/byokErrors.ts
@@ -50,6 +50,8 @@ export function classifyByokError(error: unknown): ByokErrorCode | null {
     : (error as Error & { status?: number }).status;
   const lower = gatherErrorText(error);
 
+  if (lower.includes("provider_response_failed")) return "byok_unknown_error";
+
   if (status === 401 || status === 403) return "byok_key_invalid";
   if (
     lower.includes("api key not valid") ||

--- a/convex/ai/resilience.ts
+++ b/convex/ai/resilience.ts
@@ -266,7 +266,7 @@ async function attemptStream({
       STREAM_OPTIONS,
     );
     await result.text;
-
+    if (accumulator.toRow().finishReason === "error") throw new Error("provider_response_failed");
     if (budgetTrip) {
       await ctx.runMutation(internal.aiUsage.recordBudgetStop, {
         userId: userId as Id<"users">,

--- a/convex/ai/resilienceStreamFailure.test.ts
+++ b/convex/ai/resilienceStreamFailure.test.ts
@@ -1,0 +1,115 @@
+import type { Agent } from "@convex-dev/agent";
+import { saveMessage } from "@convex-dev/agent";
+import type { StepResult, ToolSet } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionCtx } from "../_generated/server";
+import { streamWithRetry } from "./resilience";
+
+const runWithPrimaryCircuitBreakerMock = vi.hoisted(() => vi.fn());
+const recordErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@convex-dev/agent", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@convex-dev/agent")>()),
+  saveMessage: vi.fn(async () => undefined),
+}));
+
+vi.mock("./otel", () => ({
+  runInRunSpan: async (
+    _metadata: unknown,
+    fn: (span: { runId: string; recordError: (error: string) => void }) => Promise<unknown>,
+  ) => fn({ runId: "run-response-failed", recordError: recordErrorMock }),
+}));
+
+vi.mock("./resilienceCircuitBreaker", () => ({
+  runWithPrimaryCircuitBreaker: runWithPrimaryCircuitBreakerMock,
+}));
+
+function responseFailedStep(): StepResult<ToolSet> {
+  return {
+    finishReason: "error",
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    toolCalls: [],
+    toolResults: [],
+    response: {
+      id: "resp_failed",
+      model: {
+        provider: "openai.responses",
+        modelId: "gpt-5.4",
+      },
+      timestamp: new Date(0),
+    },
+    model: {
+      provider: "openai.responses",
+      modelId: "gpt-5.4",
+    },
+    stepNumber: 0,
+  } as unknown as StepResult<ToolSet>;
+}
+
+describe("streamWithRetry provider response failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runWithPrimaryCircuitBreakerMock.mockImplementation(
+      async (options: { primaryAgent: Agent; runAttempt: unknown }) => {
+        const runAttempt = options.runAttempt as (agent: Agent) => Promise<unknown>;
+        return await runAttempt(options.primaryAgent);
+      },
+    );
+  });
+
+  it("surfaces non-thrown provider finish errors as BYOK messages", async () => {
+    const streamText = vi.fn(
+      async (options: { onStepFinish: (step: StepResult<ToolSet>) => void }) => {
+        options.onStepFinish(responseFailedStep());
+        return { text: Promise.resolve("") };
+      },
+    );
+    const agent = {
+      continueThread: vi.fn(async () => ({ thread: { streamText } })),
+    } as unknown as Agent;
+    const runQuery = vi.fn(async () => ({
+      page: [{ _id: "pending-message", status: "pending" }],
+    }));
+    const runMutation = vi.fn(async () => undefined);
+    const runAction = vi.fn(async () => undefined);
+
+    const accumulator = await streamWithRetry(
+      { runQuery, runMutation, runAction } as unknown as ActionCtx,
+      {
+        primaryAgent: agent,
+        fallbackAgent: agent,
+        primaryModelName: "gpt-5.4",
+        threadId: "thread-1",
+        userId: "user-1",
+        prompt: "hello",
+        isByok: true,
+        provider: "openai",
+        source: "chat",
+        environment: "prod",
+      },
+    );
+
+    expect(accumulator.toRow()).toMatchObject({
+      finishReason: "error",
+      terminalErrorClass: "byok_unknown_error",
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        messageId: "pending-message",
+        result: { status: "failed", error: "byok_unknown_error" },
+      }),
+    );
+    expect(saveMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        message: expect.objectContaining({
+          content: expect.stringContaining("OpenAI returned an unexpected error"),
+        }),
+      }),
+    );
+    expect(runAction).toHaveBeenCalledTimes(1);
+    expect(recordErrorMock).toHaveBeenCalledWith("byok_unknown_error");
+  });
+});


### PR DESCRIPTION
## Summary

- Surface OpenAI Responses stream failures that finish with `error` but do not throw provider exceptions.
- Route those non-thrown provider failures through existing BYOK handling so users see the OpenAI-specific fallback message instead of the generic empty failed-message banner.
- Add regression coverage for the djwhelan failure shape.

## Changes

- `convex/ai/resilience.ts`: throws a safe `provider_response_failed` sentinel when the stream accumulator records `finishReason: "error"` after `result.text` resolves.
- `convex/ai/byokErrors.ts`: classifies that sentinel as `byok_unknown_error` so the existing BYOK reporting path finalizes the pending message safely.
- `convex/ai/resilienceStreamFailure.test.ts`: exercises the non-thrown provider failure path through `streamWithRetry` and asserts the BYOK message path is used.

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing + new tests)
- [x] New logic has tests (happy path + at least one error/edge case)
- [x] No new or materially expanded file exceeds the 300-line soft cap
- [x] No file exceeds the 400-line hard cap (enforced by CI)
- [x] Functions stay near the 60-line convention
- [x] No new `any` types (enforced by ESLint); `as` casts only at deserialization boundaries
- [ ] Tested in browser (if UI changes)
- [x] Commits follow conventional format (`type: description`)
- [x] No unused exports or dead code introduced

## Test Plan

- `npm run typecheck`
- `npm run lint`
- `npx vitest run convex/ai/resilience.test.ts convex/ai/resilienceFinalize.test.ts convex/ai/resilienceStreamFailure.test.ts`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection during streaming operations to catch and properly report provider response failures that were previously undetected
  * Enhanced error classification system to better identify and handle provider-related failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->