### PR TITLE
fix: degrade gracefully on Tonal session expiry and week-plan race condition

### DIFF
--- a/convex/coach/rebuildDay.ts
+++ b/convex/coach/rebuildDay.ts
@@ -82,13 +82,19 @@ export const rebuildDay = internalAction({
       estimatedDuration: day.estimatedDuration,
     })) as Id<"workoutPlans">;
 
-    await ctx.runMutation(internal.weekPlans.linkWorkoutPlanToDayInternal, {
+    const linked = await ctx.runMutation(internal.weekPlans.linkWorkoutPlanToDayInternal, {
       userId,
       weekPlanId,
       dayIndex,
       workoutPlanId: newPlanId,
       estimatedDuration: day.estimatedDuration,
     });
+
+    if (linked === null) {
+      // Week plan was concurrently deleted — clean up the new draft and signal failure.
+      await ctx.runMutation(internal.weekPlans.deleteDraftWorkout, { workoutPlanId: newPlanId });
+      return { ok: false, error: "Week plan no longer exists; please regenerate." };
+    }
 
     if (oldWorkoutPlanId) {
       await ctx.runMutation(internal.weekPlans.deleteDraftWorkout, {

--- a/convex/coach/weekModifications.ts
+++ b/convex/coach/weekModifications.ts
@@ -377,13 +377,20 @@ export const adjustDayDuration = internalAction({
       estimatedDuration: newDurationMinutes,
     })) as Id<"workoutPlans">;
 
-    // Link to week plan
-    await ctx.runMutation(internal.weekPlans.linkWorkoutPlanToDayInternal, {
+    // Link to week plan. If the week plan was concurrently deleted, clean up
+    // the orphaned draft and surface a retryable error to the AI.
+    const linked = await ctx.runMutation(internal.weekPlans.linkWorkoutPlanToDayInternal, {
       userId,
       weekPlanId,
       dayIndex,
       workoutPlanId: newPlanId,
       estimatedDuration: newDurationMinutes,
     });
+    if (linked === null) {
+      await ctx.runMutation(internal.weekPlans.deleteDraftWorkout, { workoutPlanId: newPlanId });
+      throw new Error(
+        "The week plan was modified by a concurrent request. Please try the modification again.",
+      );
+    }
   },
 });

--- a/convex/coach/weekProgramming.test.ts
+++ b/convex/coach/weekProgramming.test.ts
@@ -134,58 +134,49 @@ describe("programWeek return shape contract", () => {
 // Two concurrent calls to generateDraftWeekPlan can interleave like this:
 //   Call A creates weekPlanId
 //   Call B sees existing plan → deletes it → creates its own weekPlanId
-//   Call A tries linkWorkoutPlanToDayInternal → "Week plan not found"
+//   Call A calls linkWorkoutPlanToDayInternal → returns null (plan gone)
 //
-// The fix wraps the link step in a try-catch that returns { success: false }
-// with a retry suggestion instead of letting the error propagate as an
-// unhandled action failure (which Convex would report to Sentry).
+// The fix checks for a null return from linkWorkoutPlanToDayInternal and
+// returns { success: false } with a retry suggestion instead of letting the
+// error propagate as an unhandled action failure (which Convex reports to Sentry).
 // ---------------------------------------------------------------------------
 describe("generateDraftWeekPlan link-step race condition handler", () => {
-  // Simulate the catch logic added to the link step in generateDraftWeekPlan.
-  function simulateLinkStepCatch(err: Error): { success: false; error: string } | never {
-    if (err.message.includes("Week plan not found")) {
-      // Mirrors the real handler: clean up, then return structured failure.
+  // Simulate the null-check logic added to the link step in generateDraftWeekPlan.
+  function simulateLinkStepNullCheck(
+    linked: string | null,
+  ): { success: false; error: string } | { success: true } {
+    if (linked === null) {
       return {
         success: false,
         error:
           "The week plan was modified by a concurrent request. Please try generating the plan again.",
       };
     }
-    throw err;
+    return { success: true };
   }
 
-  it("returns structured failure when link throws 'Week plan not found'", () => {
-    const err = new Error("Week plan not found or access denied");
-
-    const result = simulateLinkStepCatch(err);
+  it("returns structured failure when link returns null (plan concurrently deleted)", () => {
+    const result = simulateLinkStepNullCheck(null);
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain("concurrent");
-    expect(result.error).toContain("generating");
+    if (!result.success) {
+      expect(result.error).toContain("concurrent");
+      expect(result.error).toContain("generating");
+    }
   });
 
-  it("re-throws unexpected errors from the link step unchanged", () => {
-    const err = new Error("database connection failed");
+  it("returns success when link returns a valid id", () => {
+    const result = simulateLinkStepNullCheck("weekPlanId123");
 
-    expect(() => simulateLinkStepCatch(err)).toThrow("database connection failed");
+    expect(result.success).toBe(true);
   });
 
   it("structured failure is distinguishable from success by 'success' discriminant", () => {
-    const err = new Error("Week plan not found or access denied");
-    const result: { success: true } | { success: false; error: string } =
-      simulateLinkStepCatch(err);
+    const result = simulateLinkStepNullCheck(null);
 
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(typeof result.error).toBe("string");
     }
-  });
-
-  it("does not treat 'Workout plan not found' as the race-condition case", () => {
-    // Only the week plan not-found triggers the race handler; workout-plan
-    // not-found is a different validation error that should propagate normally.
-    const err = new Error("Workout plan not found or access denied");
-
-    expect(() => simulateLinkStepCatch(err)).toThrow("Workout plan not found");
   });
 });

--- a/convex/coach/weekProgramming.ts
+++ b/convex/coach/weekProgramming.ts
@@ -288,26 +288,22 @@ export const generateDraftWeekPlan = internalAction({
       // checks for an existing plan and deletes it before creating its own).
       // If that happens, clean up the draft we just saved and bail out so
       // the caller can retry rather than surfacing a confusing server error.
-      try {
-        await ctx.runMutation(internal.weekPlans.linkWorkoutPlanToDayInternal, {
-          userId: args.userId,
-          weekPlanId,
-          dayIndex,
+      const linked = await ctx.runMutation(internal.weekPlans.linkWorkoutPlanToDayInternal, {
+        userId: args.userId,
+        weekPlanId,
+        dayIndex,
+        workoutPlanId: planId,
+        estimatedDuration: sessionDurationMinutes,
+      });
+      if (linked === null) {
+        await ctx.runMutation(internal.weekPlans.deleteDraftWorkout, {
           workoutPlanId: planId,
-          estimatedDuration: sessionDurationMinutes,
         });
-      } catch (err) {
-        if (err instanceof Error && err.message.includes("Week plan not found")) {
-          await ctx.runMutation(internal.weekPlans.deleteDraftWorkout, {
-            workoutPlanId: planId,
-          });
-          return {
-            success: false,
-            error:
-              "The week plan was modified by a concurrent request. Please try generating the plan again.",
-          };
-        }
-        throw err;
+        return {
+          success: false,
+          error:
+            "The week plan was modified by a concurrent request. Please try generating the plan again.",
+        };
       }
 
       // Build summary for agent display

--- a/convex/coach/weekProgrammingDirect.ts
+++ b/convex/coach/weekProgrammingDirect.ts
@@ -164,13 +164,20 @@ async function fillWorkoutsPhase(
       blocks,
     })) as { success: boolean; planId?: Id<"workoutPlans"> };
     if (result.success && result.planId) {
-      await ctx.runMutation(internal.weekPlans.linkWorkoutPlanToDayInternal, {
+      const linked = await ctx.runMutation(internal.weekPlans.linkWorkoutPlanToDayInternal, {
         userId,
         weekPlanId,
         dayIndex,
         workoutPlanId: result.planId,
         estimatedDuration: sessionDurationMinutes,
       });
+      if (linked === null) {
+        // Week plan was concurrently deleted; the pushed workout exists on Tonal
+        // but has no week-plan slot. Log and continue — the sync job will reconcile.
+        console.warn(
+          `[weekProgrammingDirect] Week plan ${weekPlanId} deleted before day ${dayIndex} could be linked`,
+        );
+      }
     }
   }
 }

--- a/convex/progressiveOverload.test.ts
+++ b/convex/progressiveOverload.test.ts
@@ -245,36 +245,49 @@ describe("getPerMovementHistory Tonal API resilience", () => {
     expect(result).toEqual([]);
   });
 
-  it("rethrows session-expired errors so reconnect prompts are not masked", async () => {
+  it("returns empty array when session is expired (not re-thrown)", async () => {
+    // fetchWorkoutHistory now returns [] on session expiry (persisted to DB before
+    // the throw, so the reconnect prompt fires independently). fetchWorkoutHistoryOrEmpty
+    // therefore receives [] without an exception, and getPerMovementHistory returns [].
     const ctx = {
-      runAction: vi.fn().mockRejectedValue(new Error("Tonal session expired — please reconnect")),
-      runQuery: vi.fn(),
+      runAction: vi.fn().mockResolvedValue([]),
+      runQuery: vi.fn().mockResolvedValue([]), // getAllMovements returns []
     } as unknown as ActionCtx;
 
-    await expect(
-      getPerMovementHistoryHandler(ctx, {
-        userId: "test-user-123" as Id<"users">,
-        maxActivities: 20,
-      }),
-    ).rejects.toThrow("session expired");
-    expect(ctx.runQuery).not.toHaveBeenCalled();
+    const result = await getPerMovementHistoryHandler(ctx, {
+      userId: "test-user-123" as Id<"users">,
+      maxActivities: 20,
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(0);
   });
 
-  it("rethrows session-expired errors from detail fetches", async () => {
+  it("stops fetching details and returns partial results when session expires mid-loop", async () => {
+    // If the token expires after the history list is fetched but during detail
+    // fetching, we break out of the loop and return whatever we accumulated.
     const ctx = {
       runAction: vi
         .fn()
-        .mockResolvedValueOnce([{ activityId: "activity-1", activityTime: "2026-03-10T10:00:00Z" }])
+        // First call: fetchWorkoutHistory returns two activities
+        .mockResolvedValueOnce([
+          { activityId: "activity-1", activityTime: "2026-03-10T10:00:00Z" },
+          { activityId: "activity-2", activityTime: "2026-03-11T10:00:00Z" },
+        ])
+        // Second call: fetchWorkoutDetail for activity-1 succeeds (no sets → empty map)
+        .mockResolvedValueOnce(null)
+        // Third call: fetchWorkoutDetail for activity-2 → session expired
         .mockRejectedValueOnce(new Error("Tonal session expired — please reconnect")),
       runQuery: vi.fn().mockResolvedValue([]),
     } as unknown as ActionCtx;
 
-    await expect(
-      getPerMovementHistoryHandler(ctx, {
-        userId: "test-user-123" as Id<"users">,
-        maxActivities: 20,
-      }),
-    ).rejects.toThrow("session expired");
-    expect(ctx.runAction).toHaveBeenCalledTimes(2);
+    const result = await getPerMovementHistoryHandler(ctx, {
+      userId: "test-user-123" as Id<"users">,
+      maxActivities: 20,
+    });
+
+    // Should return partial data (empty since activity-1 had no sets), not throw
+    expect(Array.isArray(result)).toBe(true);
+    expect(ctx.runAction).toHaveBeenCalledTimes(3);
   });
 });

--- a/convex/progressiveOverload.ts
+++ b/convex/progressiveOverload.ts
@@ -142,8 +142,9 @@ async function fetchWorkoutHistoryOrEmpty(
       userId,
       limit: maxActivities,
     });
-  } catch (error) {
-    if (isTonalAuthError(error)) throw error;
+  } catch {
+    // fetchWorkoutHistory already handles session expiry by returning []; any
+    // remaining throw here is a transient network/server error — degrade to [].
     return [];
   }
 }
@@ -178,7 +179,7 @@ export const getPerMovementHistory = internalAction({
           activityId,
         });
       } catch (error) {
-        if (isTonalAuthError(error)) throw error;
+        if (isTonalAuthError(error)) break; // Session expired mid-loop; return what we have
         console.error(
           `[progressiveOverload] Failed to fetch detail for activity ${activityId}`,
           error,

--- a/convex/tonal/workoutHistoryProxy.test.ts
+++ b/convex/tonal/workoutHistoryProxy.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="vite/client" />
+import { describe, expect, it, vi } from "vitest";
+import type { ActionCtx } from "../_generated/server";
+import { fetchWorkoutHistory, fetchWorkoutHistoryPage } from "./workoutHistoryProxy";
+
+// Access the raw handler for unit testing without a full Convex runtime.
+type FetchHistoryHandler = (
+  ctx: ActionCtx,
+  args: { userId: string; limit?: number },
+) => Promise<unknown[]>;
+type FetchPageHandler = (
+  ctx: ActionCtx,
+  args: { userId: string; offset: number },
+) => Promise<{ activities: unknown[]; pageSize: number; pgTotal: number }>;
+
+const fetchHistoryHandler = (fetchWorkoutHistory as unknown as { _handler: FetchHistoryHandler })
+  ._handler;
+
+const fetchPageHandler = (fetchWorkoutHistoryPage as unknown as { _handler: FetchPageHandler })
+  ._handler;
+
+describe("fetchWorkoutHistory session-expiry resilience (TONALCOACH-3Z)", () => {
+  it("returns empty array instead of throwing when session is expired", async () => {
+    // withTokenRetry calls markExpiredAndThrow which persists the expired state
+    // to the DB before throwing. Catching here prevents Convex from reporting
+    // this expected user-level condition to Sentry on every cron/AI tool call.
+    const sessionExpiredError = new Error(
+      "Tonal session expired — please reconnect at /connect-tonal",
+    );
+    // Simulate withTokenRetry throwing by having the action context throw.
+    // We replace runQuery so withTonalToken fails with the session-expired message.
+    const ctx = {
+      runQuery: vi.fn().mockRejectedValue(sessionExpiredError),
+      runMutation: vi.fn(),
+    } as unknown as ActionCtx;
+
+    const result = await fetchHistoryHandler(ctx, {
+      userId: "user-123",
+      limit: 20,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("re-throws non-session-expired errors so real failures surface", async () => {
+    const networkError = new Error("ECONNREFUSED");
+    const ctx = {
+      runQuery: vi.fn().mockRejectedValue(networkError),
+      runMutation: vi.fn(),
+    } as unknown as ActionCtx;
+
+    await expect(fetchHistoryHandler(ctx, { userId: "user-123", limit: 20 })).rejects.toThrow(
+      "ECONNREFUSED",
+    );
+  });
+});
+
+describe("fetchWorkoutHistoryPage session-expiry resilience", () => {
+  it("returns empty page result instead of throwing when session is expired", async () => {
+    const sessionExpiredError = new Error(
+      "Tonal session expired — please reconnect at /connect-tonal",
+    );
+    const ctx = {
+      runQuery: vi.fn().mockRejectedValue(sessionExpiredError),
+      runMutation: vi.fn(),
+    } as unknown as ActionCtx;
+
+    const result = await fetchPageHandler(ctx, { userId: "user-123", offset: 0 });
+
+    expect(result).toEqual({ activities: [], pageSize: 0, pgTotal: 0 });
+  });
+
+  it("re-throws non-session-expired errors", async () => {
+    const networkError = new Error("upstream timeout");
+    const ctx = {
+      runQuery: vi.fn().mockRejectedValue(networkError),
+      runMutation: vi.fn(),
+    } as unknown as ActionCtx;
+
+    await expect(fetchPageHandler(ctx, { userId: "user-123", offset: 0 })).rejects.toThrow(
+      "upstream timeout",
+    );
+  });
+});

--- a/convex/tonal/workoutHistoryProxy.ts
+++ b/convex/tonal/workoutHistoryProxy.ts
@@ -113,31 +113,41 @@ async function enrichWorkoutActivities(
 /** Fetch recent workout history (newest 200). Used by incremental sync. */
 export const fetchWorkoutHistory = internalAction({
   args: { userId: v.id("users"), limit: v.optional(v.number()) },
-  handler: async (ctx, { userId, limit }): Promise<Activity[]> =>
-    withTokenRetry(ctx, userId, async (token, tonalUserId) => {
-      const activities = await cachedFetch<Activity[]>(ctx, {
-        userId,
-        dataType: "workoutHistory_v3",
-        ttl: CACHE_TTLS.workoutHistory,
-        fetcher: async () => {
-          const items = await fetchRecentWorkoutActivities<WorkoutActivityDetail>(
-            token,
-            tonalUserId,
-            WORKOUT_HISTORY_PAGE_LIMIT,
-          );
-          return enrichWorkoutActivities(
-            ctx,
-            userId,
-            token,
-            tonalUserId,
-            items,
-            0,
-            WORKOUT_HISTORY_PAGE_LIMIT,
-          );
-        },
+  handler: async (ctx, { userId, limit }): Promise<Activity[]> => {
+    try {
+      return await withTokenRetry(ctx, userId, async (token, tonalUserId) => {
+        const activities = await cachedFetch<Activity[]>(ctx, {
+          userId,
+          dataType: "workoutHistory_v3",
+          ttl: CACHE_TTLS.workoutHistory,
+          fetcher: async () => {
+            const items = await fetchRecentWorkoutActivities<WorkoutActivityDetail>(
+              token,
+              tonalUserId,
+              WORKOUT_HISTORY_PAGE_LIMIT,
+            );
+            return enrichWorkoutActivities(
+              ctx,
+              userId,
+              token,
+              tonalUserId,
+              items,
+              0,
+              WORKOUT_HISTORY_PAGE_LIMIT,
+            );
+          },
+        });
+        return limit != null ? activities.slice(0, limit) : activities;
       });
-      return limit != null ? activities.slice(0, limit) : activities;
-    }),
+    } catch (error) {
+      // Session expiry is persisted to the DB by markExpiredAndThrow before this
+      // throw, so the frontend reconnect prompt fires independently. Returning []
+      // prevents every caller from generating a separate Sentry error for the
+      // same expected user-level condition.
+      if (error instanceof Error && error.message.includes("session expired")) return [];
+      throw error;
+    }
+  },
 });
 
 /** Fetch one page of workout history at the given offset. Used by backfill to
@@ -152,30 +162,37 @@ interface PageResult {
  *  so backfill batching (20 items/invocation from a 200-item page) doesn't re-fetch. */
 export const fetchWorkoutHistoryPage = internalAction({
   args: { userId: v.id("users"), offset: v.number() },
-  handler: async (ctx, { userId, offset }): Promise<PageResult> =>
-    withTokenRetry(ctx, userId, async (token, tonalUserId) =>
-      cachedFetch<PageResult>(ctx, {
-        userId,
-        dataType: `workoutPage:${offset}`,
-        ttl: CACHE_TTLS.workoutHistory,
-        fetcher: async () => {
-          const { items, pgTotal } = await fetchWorkoutActivitiesPage<WorkoutActivityDetail>(
-            token,
-            tonalUserId,
-            offset,
-            WORKOUT_HISTORY_PAGE_LIMIT,
-          );
-          const activities = await enrichWorkoutActivities(
-            ctx,
-            userId,
-            token,
-            tonalUserId,
-            items,
-            offset,
-            WORKOUT_HISTORY_PAGE_LIMIT,
-          );
-          return { activities, pageSize: items.length, pgTotal };
-        },
-      }),
-    ),
+  handler: async (ctx, { userId, offset }): Promise<PageResult> => {
+    try {
+      return await withTokenRetry(ctx, userId, async (token, tonalUserId) =>
+        cachedFetch<PageResult>(ctx, {
+          userId,
+          dataType: `workoutPage:${offset}`,
+          ttl: CACHE_TTLS.workoutHistory,
+          fetcher: async () => {
+            const { items, pgTotal } = await fetchWorkoutActivitiesPage<WorkoutActivityDetail>(
+              token,
+              tonalUserId,
+              offset,
+              WORKOUT_HISTORY_PAGE_LIMIT,
+            );
+            const activities = await enrichWorkoutActivities(
+              ctx,
+              userId,
+              token,
+              tonalUserId,
+              items,
+              offset,
+              WORKOUT_HISTORY_PAGE_LIMIT,
+            );
+            return { activities, pageSize: items.length, pgTotal };
+          },
+        }),
+      );
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("session expired"))
+        return { activities: [], pageSize: 0, pgTotal: 0 };
+      throw error;
+    }
+  },
 });

--- a/convex/weekPlanInternals.test.ts
+++ b/convex/weekPlanInternals.test.ts
@@ -27,6 +27,97 @@ async function seedWeekPlan(
   );
 }
 
+async function seedWorkoutPlan(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+): Promise<Id<"workoutPlans">> {
+  return t.run(async (ctx) =>
+    ctx.db.insert("workoutPlans", {
+      userId,
+      title: "Test Workout",
+      blocks: [],
+      status: "draft",
+      source: "ai",
+      createdAt: Date.now(),
+    }),
+  );
+}
+
+describe("linkWorkoutPlanToDayInternal", () => {
+  test("links a workout plan to a day and returns the weekPlanId", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+    const weekPlanId = await seedWeekPlan(t, userId);
+    const workoutPlanId = await seedWorkoutPlan(t, userId);
+
+    const result = await t.mutation(internal.weekPlanInternals.linkWorkoutPlanToDayInternal, {
+      userId,
+      weekPlanId,
+      dayIndex: 0,
+      workoutPlanId,
+    });
+
+    expect(result).toBe(weekPlanId);
+    const plan = await t.run(async (ctx) => ctx.db.get(weekPlanId));
+    expect(plan?.days[0].workoutPlanId).toBe(workoutPlanId);
+  });
+
+  test("returns null when the week plan no longer exists (concurrent deletion race)", async () => {
+    // Fixes TONALCOACH-12: instead of throwing "Week plan not found or access denied"
+    // (which Convex would report to Sentry), return null so callers can handle it
+    // gracefully without generating noise.
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+    const weekPlanId = await seedWeekPlan(t, userId);
+    const workoutPlanId = await seedWorkoutPlan(t, userId);
+
+    // Delete the week plan to simulate the race condition
+    await t.run(async (ctx) => ctx.db.delete(weekPlanId));
+
+    const result = await t.mutation(internal.weekPlanInternals.linkWorkoutPlanToDayInternal, {
+      userId,
+      weekPlanId,
+      dayIndex: 0,
+      workoutPlanId,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("throws access denied when week plan belongs to a different user", async () => {
+    const t = convexTest(schema, modules);
+    const ownerId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+    const attackerId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+    const weekPlanId = await seedWeekPlan(t, ownerId);
+    const workoutPlanId = await seedWorkoutPlan(t, attackerId);
+
+    await expect(
+      t.mutation(internal.weekPlanInternals.linkWorkoutPlanToDayInternal, {
+        userId: attackerId,
+        weekPlanId,
+        dayIndex: 0,
+        workoutPlanId,
+      }),
+    ).rejects.toThrow("Week plan access denied");
+  });
+
+  test("throws when dayIndex is out of range", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await t.run(async (ctx) => ctx.db.insert("users", {}));
+    const weekPlanId = await seedWeekPlan(t, userId);
+    const workoutPlanId = await seedWorkoutPlan(t, userId);
+
+    await expect(
+      t.mutation(internal.weekPlanInternals.linkWorkoutPlanToDayInternal, {
+        userId,
+        weekPlanId,
+        dayIndex: 7,
+        workoutPlanId,
+      }),
+    ).rejects.toThrow("dayIndex must be 0");
+  });
+});
+
 describe("deleteWeekPlanInternal", () => {
   test("deletes a week plan that belongs to the user", async () => {
     const t = convexTest(schema, modules);

--- a/convex/weekPlanInternals.ts
+++ b/convex/weekPlanInternals.ts
@@ -63,7 +63,9 @@ export const setDayStatusInternal = internalMutation({
   },
 });
 
-/** Internal: link a workout plan to a day (used by programWeek action). */
+/** Internal: link a workout plan to a day (used by programWeek action).
+ *  Returns null when the week plan no longer exists (concurrent deletion race);
+ *  throws only for true security violations (userId mismatch on an existing doc). */
 export const linkWorkoutPlanToDayInternal = internalMutation({
   args: {
     userId: v.id("users"),
@@ -73,14 +75,13 @@ export const linkWorkoutPlanToDayInternal = internalMutation({
     status: v.optional(dayStatusValidator),
     estimatedDuration: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<Id<"weekPlans"> | null> => {
     if (args.dayIndex < 0 || args.dayIndex > 6) {
       throw new Error("dayIndex must be 0 (Monday) through 6 (Sunday)");
     }
     const plan = await ctx.db.get(args.weekPlanId);
-    if (!plan || plan.userId !== args.userId) {
-      throw new Error("Week plan not found or access denied");
-    }
+    if (!plan) return null; // Concurrent deletion — caller should handle gracefully
+    if (plan.userId !== args.userId) throw new Error("Week plan access denied");
     const workout = await ctx.db.get(args.workoutPlanId);
     if (!workout || workout.userId !== args.userId) {
       throw new Error("Workout plan not found or access denied");


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes 4 open Sentry issues (TONALCOACH-3Z, TONALCOACH-40, TONALCOACH-P, TONALCOACH-12) by treating expected user-level conditions as graceful degradation rather than unhandled exceptions.

### TONALCOACH-3Z / TONALCOACH-40 / TONALCOACH-P — Tonal session expired errors flooding Sentry

**Root cause:** When a user's Tonal token expires, `withTokenRetry` calls `markExpiredAndThrow` which correctly persists the expired state to the DB — but then throws an error that propagated through multiple `ctx.runAction` call boundaries. Convex reports each function that throws an unhandled exception to Sentry, so a single expired session could generate 3 separate Sentry issues (one per function boundary) with increasingly wrapped error messages ("Uncaught Error: Uncaught Error: Uncaught Error: Tonal session expired…").

**Fix:**
- `fetchWorkoutHistory` and `fetchWorkoutHistoryPage` (`workoutHistoryProxy.ts`) now catch session-expired errors and return empty results. Since `markExpiredAndThrow` already persisted the state before throwing, the frontend reconnect prompt fires independently — callers don't need the exception to know the user must reconnect.
- `fetchWorkoutHistoryOrEmpty` in `progressiveOverload.ts` simplified to catch all errors (the auth re-throw was predicated on callers handling it, but none of them did).
- `getPerMovementHistory` detail-fetch loop now `break`s instead of re-throwing on mid-loop auth errors, returning partial results rather than propagating an exception.

**TONALCOACH-1C** (AI model high demand — `@convex-dev/agent@0.6.1` race condition) is a library-level race that the existing `onError` pre-emption already mitigates. No additional code change is possible without a library update; left as-is.

### TONALCOACH-12 — "Week plan not found or access denied" from `linkWorkoutPlanToDayInternal`

**Root cause:** When two concurrent `generateDraftWeekPlan` calls race, call B deletes the week plan that call A just created. Call A's subsequent `linkWorkoutPlanToDayInternal` threw `"Week plan not found or access denied"`. `weekProgramming.ts` already had a try/catch for this, but `weekModifications.ts`, `weekProgrammingDirect.ts`, and `rebuildDay.ts` did not, so those paths still generated Sentry errors.

**Fix:**
- `linkWorkoutPlanToDayInternal` now returns `null` when the week plan no longer exists (race condition) and only throws for a real security violation (userId mismatch on an existing document). This eliminates the Sentry error at the mutation level entirely.
- All four call sites updated to check `linked === null` and handle gracefully: clean up the orphaned draft workout and return a descriptive error to the AI.

## Files changed

| File | Change |
|------|--------|
| `convex/tonal/workoutHistoryProxy.ts` | Session-expired catch in `fetchWorkoutHistory` + `fetchWorkoutHistoryPage` |
| `convex/progressiveOverload.ts` | Simplified `fetchWorkoutHistoryOrEmpty`; `break` on auth error in detail loop |
| `convex/weekPlanInternals.ts` | `linkWorkoutPlanToDayInternal` returns `null` on not-found, throws on access denied |
| `convex/coach/weekProgramming.ts` | Convert try/catch to null-return check |
| `convex/coach/weekModifications.ts` | Handle null return + clean up orphan draft |
| `convex/coach/weekProgrammingDirect.ts` | Handle null return with warning log |
| `convex/coach/rebuildDay.ts` | Handle null return + clean up orphan draft |

## Test plan

- [x] New `convex/tonal/workoutHistoryProxy.test.ts`: verifies session-expired returns `[]` / empty page; non-session errors still throw
- [x] Updated `convex/progressiveOverload.test.ts`: replaced "rethrows session-expired" tests with "returns empty array" and "stops mid-loop" tests
- [x] Updated `convex/weekPlanInternals.test.ts`: added `linkWorkoutPlanToDayInternal` tests for null on not-found, throw on access denied, success case, and out-of-range dayIndex
- [x] Updated `convex/coach/weekProgramming.test.ts`: replaced exception-simulation tests with null-return simulation tests
- [x] Full test suite: 1717 passed, 0 failed
- [x] `npm run typecheck`: clean

https://claude.ai/code/session_016rb9ftiyFnWcAg1oRuQYFB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016rb9ftiyFnWcAg1oRuQYFB)_