### PR TITLE
chore: temp diagnostic for Tonal read-back shape (#308 follow-up)

### DIFF
--- a/convex/_checkPushDivergence.ts
+++ b/convex/_checkPushDivergence.ts
@@ -1,0 +1,26 @@
+// One-off diagnostic query — delete after use (see PR #308 follow-up).
+// Run via Convex dashboard or `npx convex run _checkPushDivergence:recentPushDivergences`
+// to find aiRun rows with non-null pushDivergence since 2026-04-30.
+import { v } from "convex/values";
+import { internalQuery } from "./_generated/server";
+
+/** Returns aiRun rows with non-null pushDivergence created after `since` (ms epoch). */
+export const recentPushDivergences = internalQuery({
+  args: { since: v.optional(v.number()) },
+  handler: async (ctx, { since }) => {
+    const cutoff = since ?? new Date("2026-04-30T00:00:00Z").getTime();
+    const rows = await ctx.db
+      .query("aiRun")
+      .withIndex("by_createdAt", (q) => q.gte("createdAt", cutoff))
+      .filter((q) => q.neq(q.field("pushDivergence"), undefined))
+      .take(100);
+
+    return rows.map((r) => ({
+      _id: r._id,
+      createdAt: new Date(r.createdAt).toISOString(),
+      userId: r.userId,
+      pushDivergence: r.pushDivergence,
+      workoutPushOutcome: r.workoutPushOutcome,
+    }));
+  },
+});

--- a/convex/tonal/mutations.ts
+++ b/convex/tonal/mutations.ts
@@ -182,7 +182,12 @@ export const pushWorkoutToTonal = internalAction({
           id: string;
           sets?: { movementId: string; prescribedReps?: number; prescribedDuration?: number }[];
         }>(token, `/v6/user-workouts/${tonalWorkoutId}`);
-        console.log('[trace shape #308] keys:', Object.keys(stored ?? {}).join(','), '| preview:', JSON.stringify(stored).slice(0, 800));
+        console.log(
+          "[trace shape #308] keys:",
+          Object.keys(stored ?? {}).join(","),
+          "| preview:",
+          JSON.stringify(stored).slice(0, 800),
+        );
         if (stored.sets !== undefined) {
           // sets[] in the request is already expanded one-per-set, so each row counts as 1.
           const intended = sets.map((s) => ({ movementId: s.movementId, sets: 1 }));

--- a/convex/tonal/mutations.ts
+++ b/convex/tonal/mutations.ts
@@ -182,6 +182,7 @@ export const pushWorkoutToTonal = internalAction({
           id: string;
           sets?: { movementId: string; prescribedReps?: number; prescribedDuration?: number }[];
         }>(token, `/v6/user-workouts/${tonalWorkoutId}`);
+        console.log('[trace shape #308] keys:', Object.keys(stored ?? {}).join(','), '| preview:', JSON.stringify(stored).slice(0, 800));
         if (stored.sets !== undefined) {
           // sets[] in the request is already expanded one-per-set, so each row counts as 1.
           const intended = sets.map((s) => ({ movementId: s.movementId, sets: 1 }));


### PR DESCRIPTION
## Summary

Two-week follow-up on #308 (real push verification, merged 2026-04-30).

The concern: if Tonal's `GET /v6/user-workouts/{id}` response shape is not
`{ id, sets: [{movementId, prescribedReps?, prescribedDuration?}, ...] }`,
the `stored.sets === undefined` guard silently no-ops — zero divergence is
indistinguishable from "everything matched" without independent evidence.

### What was attempted first (Step 1)

`npx convex logs --prod --history 10000 | grep 'Push divergence\|read-back failed'`
was run but returned no output — the environment running this agent has no
Convex auth credentials, so prod logs were inaccessible.

### What this PR adds

1. **`convex/tonal/mutations.ts`** — a single `console.log` added
   immediately after `stored` is assigned in the verification `try` block:
   ```
   [trace shape #308] keys: <comma-separated top-level keys> | preview: <first 800 chars of JSON>
   ```
   This will appear in Convex prod function logs the first time a workout is
   pushed after this deploys, revealing Tonal's actual response shape.

2. **`convex/_checkPushDivergence.ts`** — a one-off `internalQuery` that
   scans `aiRun` rows for non-null `pushDivergence` since 2026-04-30.
   Run via the Convex dashboard or:
   ```
   npx convex run _checkPushDivergence:recentPushDivergences
   ```
   This is the Step 1 fallback; it answers "has divergence detection ever
   fired?" without needing raw log access.

### Next steps after one push fires in prod

- If `[trace shape #308]` shows `keys: id,sets` → shape is correct; the
  reason no divergence appeared is that all pushes matched intent. Green.
- If keys differ (e.g. `setList`, `workout.sets`, etc.) → fix the access
  path in a follow-up PR.

**Both files will be removed within 24 h** in a follow-up PR
(`chore/remove-trace-tonal-readback-shape` or
`fix(tonal): correct read-back shape…`) once the shape is confirmed.

The `stored.sets === undefined` guard is intentionally left unchanged.

https://claude.ai/code/session_01Tcpptjuz9mP5bTVgRuwysH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcpptjuz9mP5bTVgRuwysH)_