### PR TITLE
docs: add engineering learning log from PR review findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to AI coding agents (Claude Code, GitHub Copilot, Cursor, Windsurf, Codex, Gemini, etc.) when working with code in this repository. Follows the [agents.md](https://agents.md) open standard.
 
+> **Learning log:** `docs/learnings.md` records non-obvious bugs caught in PR review, distilled into preventive checks. Skim it before touching related code; add an entry after a review surfaces a real logic/edge-case issue.
+
 ## What This Project Is
 
 Roni is an AI coaching companion for Tonal fitness machines. Users connect their Tonal account, and the AI coach reads their training history, strength scores, and workout data to program custom weekly plans. The coach pushes approved workouts directly to Tonal.
@@ -260,6 +262,7 @@ When principles conflict, the higher number always wins.
 - Validate external input with Zod at the action boundary. Internal functions receive typed data.
 - The Tonal API integration uses `cachedFetch` pattern -- check cache, fetch if expired, update cache.
 - **Schema narrows that could reject existing rows must use widen → migrate → narrow.** Convex validates schema against existing data on `npx convex deploy` (Vercel runs this on every merge to main). A narrowing PR that ships before its data backfill migration runs will fail the deploy and lock prod until recovered. Pattern: PR 1 ships the migration code with the validator still wide; operator runs the migration; PR 2 ships the narrow. The `npm run convex:smoke` pre-push hook catches this against the dev deployment if dev has the same data shape.
+- **One-shot cleanup/watchdog timers must outlast the latest possible row creation, not just the start of the action that schedules them.** A long-running action (retry path: up to 3 × 180s attempts) can create the row it needs to clean up late in its life. Derive the delay from `action-cap + retry-budget + grace` (`STUCK_MESSAGE_WATCHDOG_DELAY_MS` in `convex/ai/stuckMessageWatchdog.ts`), or reschedule while a non-terminal row is still newer than the grace window — otherwise the sweep skips a late row as "too new" and strands it forever. Lock the invariant with a test (e.g. `WATCHDOG_DELAY - GRACE > CONVEX_ACTION_MAX_MS`). See `docs/learnings.md`.
 
 ## Key Type Locations
 

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1,0 +1,56 @@
+# Engineering Learning Log
+
+A running record of non-obvious mistakes caught in PR review, distilled into
+preventive checks so they don't recur. Each entry: the gap, why it matters, and
+the check that would have caught it. Add to this when a review surfaces a real
+logic/completeness/edge-case issue (not style nits). Promote the most reusable
+checks into `AGENTS.md` so they become part of the standing ruleset.
+
+## How to use this log
+
+- **Before writing similar code**, skim the relevant entries below.
+- **After a PR review flags a real issue**, add an entry here in the same shape.
+- Keep entries concrete: name the PR, the failure mode, and the verifiable check.
+
+---
+
+## 2026-05 — Scheduled cleanup timers must outlast the latest possible row creation
+
+- **Source:** PR #412 (`fix(chat): finalize orphaned messages so chat can't hang on "generating"`), review thread on `convex/ai/stuckMessageWatchdog.ts`.
+- **The gap:** A one-shot "watchdog" sweep was scheduled at the *start* of a coach
+  turn, before provider resolution, prompt/context building, and `streamWithRetry`.
+  The retry path budgets up to 3 × 180s attempts, so the assistant row for the
+  *final* attempt can be created late in the action's life — long after the timer
+  was queued. A single sweep that fires too early relative to that late row's
+  creation + grace window sees the row as "too new", skips it, and queues no
+  follow-up sweep. The orphaned message (and its perpetual "generating" spinner)
+  is then stranded indefinitely.
+- **Why it matters:** A self-healing recovery mechanism silently fails to heal
+  exactly the slowest, most-degraded turns it exists to protect — the worst case,
+  with no later retry. It looks correct in tests that use fast/happy-path turns.
+- **Preventive check:** When scheduling a one-shot cleanup timer for rows that a
+  long-running action may create *late*, derive the delay from
+  `action-cap + retry-budget + grace`, not from turn start. Concretely, either:
+  - delay ≥ `grace + max-late-creation-window` (the path taken here:
+    `WATCHDOG_DELAY = grace + CONVEX_ACTION_MAX_MS + buffer`), **or**
+  - reschedule the sweep when it still sees a non-terminal row newer than `grace`.
+  Lock the invariant with a test, e.g. assert
+  `WATCHDOG_DELAY_MS - GRACE_MS > CONVEX_ACTION_MAX_MS`, so a future constant tweak
+  can't silently regress it. Prefer a larger fixed delay over self-rescheduling to
+  keep the sweep stateless.
+
+## 2026-05 — Test fixtures must not derive values from `Date.now()` / system time
+
+- **Source:** PR #392 (`fix(tonal): replace fragile string check with instanceof …`), review thread on `convex/tonal/cachedFetch.test.ts`.
+- **The gap:** Cache-entry fixtures computed `expiresAt` from `Date.now()`
+  (`Date.now() - 1000` for stale, `Date.now() + 60_000` for fresh), making the
+  tests time-dependent and theoretically flaky near boundaries.
+- **Why it matters:** Reinforces the standing rule "Tests must be deterministic.
+  No reliance on system time, random values, or network." Time-derived fixtures
+  are the most common way this rule slips through, because they *look* like
+  ordinary constants.
+- **Preventive check:** For stale/fresh (or before/after) fixtures, use fixed
+  sentinel constants instead of clock arithmetic — e.g.
+  `const STALE_EXPIRES_AT = 0;` and `const FRESH_EXPIRES_AT = Number.MAX_SAFE_INTEGER;`.
+  Already covered by **Testing Rules** in `AGENTS.md`; this entry is the worked
+  example to point to.


### PR DESCRIPTION
## Summary

Reviewed the **10 most recently closed/merged PRs** (#412, #410, #396, #395, #394, #393, #392, #391, #380, #369) and extracted actionable learnings from their review comments. Most were dependabot/release PRs with no review threads; only two carried substantive feedback. Both were fixed within their original PR, but each represents a non-obvious pitfall worth documenting so it doesn't recur.

This PR adds `docs/learnings.md` (a running engineering learning log) and promotes the most reusable check into `AGENTS.md`.

## Learnings captured

### 1. Scheduled cleanup/watchdog timers must outlast the latest possible row creation (from #412)
- **Gap:** A one-shot watchdog sweep was scheduled at the *start* of a coach turn. The retry path (up to 3 × 180s) can create the final-attempt assistant row late in the action's life. A sweep firing too early skips that row as "too new", queues no follow-up, and strands the orphaned message + "generating" spinner indefinitely.
- **Why it matters:** The recovery mechanism silently fails exactly the slowest/most-degraded turns it exists to protect — invisible to happy-path tests.
- **Preventive check:** Derive the delay from `action-cap + retry-budget + grace`, or reschedule while a non-terminal row is still newer than grace. Lock with an invariant test (`WATCHDOG_DELAY - GRACE > CONVEX_ACTION_MAX_MS`).
- Promoted into the **Convex Patterns** section of `AGENTS.md`.

### 2. Test fixtures must not derive values from `Date.now()` (from #392)
- **Gap:** Cache-entry fixtures computed `expiresAt` from `Date.now()`, making tests time-dependent.
- **Why it matters:** Reinforces the existing determinism rule; clock-derived fixtures are the most common way it slips through because they look like ordinary constants.
- **Preventive check:** Use fixed sentinel constants (`0` / `Number.MAX_SAFE_INTEGER`). Already covered by **Testing Rules**; logged here as the worked example.

## Changes
- `docs/learnings.md` — new learning log with both entries (gap / why it matters / check).
- `AGENTS.md` — top-level pointer to the log + a new reusable timer check under Convex Patterns.

No code or behavior changes.

https://claude.ai/code/session_01FkT8y3qxT1ZJXKpmgNYfiY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkT8y3qxT1ZJXKpmgNYfiY)_