### PR TITLE
docs: log payload-transform, nullable-normalization, and resilience review learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,10 +306,15 @@ errors, tests that don't exercise the real production path, exact-match model
 pricing that bypasses budget guardrails, watchdog/sweep timing windows, error
 boundaries around optional integrations that hide instead of recover/log,
 credential/format validators that reject the real format or drift across their
-duplicated copies). Skim the matching section before touching Tonal fetch helpers,
-AI cost/budget paths, test fixtures, scheduled sweeps, error boundaries around
-optional integrations, or credential/format validators -- and append a new entry
-when review surfaces a fresh recurring gap.
+duplicated copies, payload transforms before an external API boundary that skip
+empty/recount/structure handling, nullable-field normalization that clobbers
+stored values on a replace-write, and resilience paths that lose the concrete
+error class or defer outage notifications past the action cap). Skim the matching
+section before touching Tonal fetch helpers, AI cost/budget paths, test fixtures,
+scheduled sweeps, error boundaries around optional integrations, credential/format
+validators, external-API payload transforms, nullable-field normalization on
+replace-writes, or resilience/notification paths -- and append a new entry when
+review surfaces a fresh recurring gap.
 
 <!-- convex-ai-start -->
 

--- a/docs/pr-review-learnings.md
+++ b/docs/pr-review-learnings.md
@@ -1,6 +1,6 @@
 # PR Review Learnings
 
-Last reviewed: 2026-06-01
+Last reviewed: 2026-06-04
 
 A running log of recurring, legitimate issues raised in pull-request review that
 agents (and humans) should pre-empt. Each entry records the **problem**, **why
@@ -223,14 +223,134 @@ at a different boundary, which is hard to diagnose.
 - Add a positive test using the literal target format (here, an `AQ.`-prefixed
   key) at each validation layer.
 
+## 7. When filtering a payload before an external API boundary, handle empty, recount, and re-anchor structure
+
+**Seen in:** #440 (3 review threads — one P2/Major, two P3)
+
+**Problem.** The Tonal push path gained `buildTonalWorkoutSets`, which strips
+well-known synthetic movements (the internal Rest sentinel) out of the set list
+before crossing the `POST /v6/user-workouts` boundary. The internal block
+validation still _accepts_ the Rest sentinel, so synthetic-only or
+synthetic-leading blocks can reach the filter. Stripping them introduced three
+distinct gaps:
+
+- **Empty payload not rejected.** A rest-only block filtered down to `[]`, but
+  the code still POSTed the empty set list. Tonal then failed with a misleading
+  downstream 400 and `createWorkout` recorded a failed plan, instead of failing
+  fast with a clear local validation error (the estimate path already guarded
+  this; the push path didn't).
+- **Derived count drifted from the payload.** `createWorkout` still reported
+  `setCount` from a _separate_ unfiltered `expandBlocksToSets(blocks)` call, so
+  "3 work sets + 3 rest sentinels" reported 6 sets pushed while only 3 were
+  actually sent — the user/LLM-visible success overstated the result.
+- **Structural marker lost.** If a block _started_ with a synthetic movement,
+  filtering removed the only set marked `blockStart: true`, so the first real set
+  of that block crossed the boundary with `blockStart: false` — the outbound
+  block boundaries no longer matched the internally validated structure.
+
+**Why it matters.** A transform that drops elements just before an external call
+quietly breaks three invariants at once: the call can be made with nothing to do,
+any count computed from the _pre-filter_ data lies about what was sent, and any
+positional/structural marker the filter happened to remove is silently dropped.
+All three surface as confusing remote errors or wrong success metadata rather
+than a clear local failure.
+
+**Preventive checks.**
+
+- After filtering, **guard the empty result** and fail with a clear local error
+  (or handled `{ error }`) _before_ constructing/sending the payload — never let
+  the remote API reject an empty request on your behalf.
+- Compute any **derived count or metadata from the filtered payload**, not from a
+  separate pre-filter calculation, so success messages match what was sent.
+- If the filter can remove an element carrying a **positional/structural marker**
+  (block start, "first item", ordering index), re-derive that marker on the
+  filtered output (e.g. re-mark the first remaining set in each block).
+- Add coverage for the all-synthetic (empty) case and the synthetic-leading case,
+  not just the happy path.
+
+## 8. Don't clobber existing stored values when normalizing nullable upstream fields on a replace-write
+
+**Seen in:** #429 (1 P2 thread, plus a type-honesty Major)
+
+**Problem.** Tonal sub-account profiles can return `null` for `heightInches`,
+`weightPounds`, and `workoutsPerWeek`, but the `profileData` validator requires
+numbers, so `toUserProfileData` normalized `null → 0` to pass validation. That
+default is correct for first-time connect, but `userProfiles.updateProfileData`
+**replaces the whole stored `profileData` object**. On a refresh or backfill, a
+user who previously had real height/weight/frequency was downgraded to `0` when
+the latest Tonal payload merely reported those fields as unknown — and those
+zeros then flowed into the AI context as `0"/0lbs`, `0x/week`. Separately, the
+`TonalUser` type declared the fields as non-nullable `number` while the code
+already handled `null` and tests fed `null`, so the type lied about the payload.
+
+**Why it matters.** A "missing → default" rule that is safe on _create_ becomes
+destructive on a _replace-write_ refresh path: it overwrites previously-known
+good data with placeholders whenever the upstream source happens to omit a value.
+The corruption is silent (validation passes) and propagates into downstream
+consumers that trust the stored values.
+
+**Preventive checks.**
+
+- Distinguish **create vs. refresh/replace** when defaulting nullable upstream
+  fields. On a path that replaces the whole record, pass the existing stored
+  values into the mapper and fall back to a default only when _both_ the new
+  payload and the stored value are missing — never let "unknown upstream" erase
+  "previously known."
+- Keep the **type honest about nullability**: if the runtime normalizes `null`,
+  the source type (`TonalUser`) should be `number | null`, not `number`, so the
+  normalization site is visible and type-checked rather than relying on a silent
+  `?? 0`.
+- Add a regression test that seeds prior measurements, refreshes with a
+  null-bearing payload, and asserts the stored values are **preserved** (not
+  zeroed).
+
+## 9. Keep error classification concrete through resilience wrappers, and notify before long awaits that can hit the action cap
+
+**Seen in:** #434 (2 P2 threads)
+
+**Problem.** The AI circuit-breaker wrapper added fallback context to its Discord
+outage alert, but two gaps undercut it:
+
+- **Terminal class collapsed to a placeholder.** When a fallback attempt ended
+  with `runAttempt` returning `{ done: true, success: false }` — the path used in
+  `convex/ai/resilience.ts` for BYOK, quota, and other non-transient provider
+  errors _after it had already recorded the real class_ — the alert always
+  reported a generic `TerminalFallbackAttemptFailure`. The new context was least
+  accurate exactly when fallback failed for a known reason.
+- **Notification deferred past the action cap.** The breaker-open alert was
+  delayed until after the final fallback finished. With each attempt budgeting
+  180s under Convex's 600s action cap, two primary timeouts plus the fallback can
+  run close enough to the cap that the action is killed before reaching the
+  notification — even though the breaker had already opened.
+
+**Why it matters.** Resilience/observability code is the last thing watching when
+everything else is failing. If it discards the concrete error class it already
+computed, the alert misleads operators precisely during a real outage; if it
+saves the alert for _after_ a long await, the action can die before the alert is
+ever sent, so the outage looks like silence.
+
+**Preventive checks.**
+
+- Carry the **concrete terminal error class** through the retry/fallback wrapper
+  (e.g. in `AttemptOutcome.errorClass`) and report it for both primary and
+  fallback terminal outcomes — don't overwrite an already-known class with a
+  generic placeholder.
+- Emit the **outage/breaker notification before awaiting** a long final fallback
+  (with `Fallback: pending`), then send a follow-up completion notification if the
+  action reaches the fallback result. Assume any single await can be killed by the
+  600s action cap (see learning #4 for the cap-derived timing rule).
+- Add coverage asserting the notification fires _before_ the final fallback
+  attempt, and that terminal failures report their real class.
+
 ---
 
 ## How to use this log
 
 - Before opening a PR that touches **Tonal fetch helpers, AI cost/budget paths,
   test fixtures, scheduled sweeps, React error boundaries around optional
-  integrations, or credential/format validators**, skim the matching section
-  above.
+  integrations, credential/format validators, payload transforms at an external
+  API boundary, nullable-field normalization on replace-writes, or
+  resilience/notification paths**, skim the matching section above.
 - When a review surfaces a _new_ recurring, legitimate gap (not stylistic, not
   one-off), add an entry here with the PR reference so the next agent inherits
   the lesson.


### PR DESCRIPTION
## Summary

Reviewed the 10 most recently closed/merged PRs and extracted recurring, legitimate review issues into `docs/pr-review-learnings.md` (plus the AGENTS.md pointer). Three new learnings were derived; the rest were release chores, dependency bumps, or PRs with no substantive review.

## What was reviewed

| PR | Outcome |
|----|---------|
| #440 fix: omit synthetic rest from Tonal payloads | **New learning #7** — 1 P2/Major + 2 P3 findings (empty payload, recount, block-start) |
| #429 fix: normalize Tonal sub-account profile data | **New learning #8** — P2 clobber-on-refresh + type-honesty finding |
| #434 fix: add circuit breaker fallback context | **New learning #9** — 2× P2 (terminal error class, notify-before-cap) |
| #433 fix: preserve duration exercises in week card | No review comments — filtered |
| #428 chore: remove stale knip ignore | No review comments — filtered |
| #430 docs: prior learnings PR | The previous review pass (covered through #426) — not re-reviewed |
| #435, #431, #418 release chores | No substantive review |
| #425 dependency bump | No substantive review |

## New learnings added

**#7 — When filtering a payload before an external API boundary, handle empty, recount, and re-anchor structure.** (#440) Stripping the synthetic Rest sentinel before `POST /v6/user-workouts` introduced three gaps at once: an all-synthetic block POSTed an empty set list (misleading remote 400 instead of a clear local error); `setCount` was still computed from the unfiltered blocks and overstated what was sent; and filtering a leading synthetic set dropped the `blockStart: true` marker so the outbound block boundaries no longer matched the validated structure. Preventive checks: guard the empty result before sending, derive counts from the filtered payload, and re-anchor positional/structural markers on the filtered output.

**#8 — Don't clobber existing stored values when normalizing nullable upstream fields on a replace-write.** (#429) A `null → 0` default that is correct for first-time connect became destructive on refresh/backfill, where `updateProfileData` replaces the whole `profileData` object — downgrading a user's real height/weight/frequency to `0` (which then flowed into the AI context) whenever Tonal merely reported the field as unknown. The `TonalUser` type also lied (`number` while the code handled `null`). Preventive checks: distinguish create vs. replace-write, fall back to a default only when both new payload and stored value are missing, keep the type honest about nullability, and add a preserve-on-refresh regression test.

**#9 — Keep error classification concrete through resilience wrappers, and notify before long awaits that can hit the action cap.** (#434) The circuit-breaker alert collapsed known terminal classes (BYOK, quota) into a generic `TerminalFallbackAttemptFailure`, and deferred the breaker-open notification until after a long final fallback that could exceed the 600s action cap before the alert ever sent. Preventive checks: carry the concrete `errorClass` through retry/fallback, emit the outage notification before awaiting the final fallback (with a follow-up on completion), and cover both with regression tests.

## Files changed

- `docs/pr-review-learnings.md` — three new sections (#7, #8, #9); updated "Last reviewed" date and trigger list.
- `AGENTS.md` — extended the "Learning From Past Reviews" pointer with the new areas.

Docs-only; no code paths touched.

https://claude.ai/code/session_01UkNNutXd9zMyyeHBpizkJE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNNutXd9zMyyeHBpizkJE)_