### PR TITLE
docs: log payload-filter, refresh-normalization, and fallback-ordering review learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,10 +306,16 @@ errors, tests that don't exercise the real production path, exact-match model
 pricing that bypasses budget guardrails, watchdog/sweep timing windows, error
 boundaries around optional integrations that hide instead of recover/log,
 credential/format validators that reject the real format or drift across their
-duplicated copies). Skim the matching section before touching Tonal fetch helpers,
-AI cost/budget paths, test fixtures, scheduled sweeps, error boundaries around
-optional integrations, or credential/format validators -- and append a new entry
-when review surfaces a fresh recurring gap.
+duplicated copies, payloads filtered before an external push that skip the
+empty-case guard / overstate counts / drop structural markers, "missing ->
+default" normalization that clobbers stored values on refresh/backfill, and AI
+fallback/notification ordering that defers alerts behind the action cap or
+flattens the terminal error class). Skim the matching section before touching
+Tonal fetch helpers, AI cost/budget paths, test fixtures, scheduled sweeps, error
+boundaries around optional integrations, credential/format validators, payloads
+filtered before an external push, profile/data normalization on refresh/backfill,
+or AI fallback/notification ordering -- and append a new entry when review
+surfaces a fresh recurring gap.
 
 <!-- convex-ai-start -->
 

--- a/docs/pr-review-learnings.md
+++ b/docs/pr-review-learnings.md
@@ -1,6 +1,6 @@
 # PR Review Learnings
 
-Last reviewed: 2026-06-01
+Last reviewed: 2026-06-08
 
 A running log of recurring, legitimate issues raised in pull-request review that
 agents (and humans) should pre-empt. Each entry records the **problem**, **why
@@ -223,14 +223,142 @@ at a different boundary, which is hard to diagnose.
 - Add a positive test using the literal target format (here, an `AQ.`-prefixed
   key) at each validation layer.
 
+## 7. When filtering a payload before an external push, guard the empty case, re-derive every dependent count, and preserve structural markers
+
+**Seen in:** #440 (3 review threads — one P2, two P3, all addressed in one follow-up)
+
+**Problem.** `buildTonalWorkoutSets` began stripping synthetic movements (e.g.
+rest sentinels) out of the set list before POSTing to Tonal. Filtering a
+collection just before it leaves the system created three distinct gaps:
+
+- **Empty payload reached the wire.** The helper can legitimately return `[]`
+  (a rest-only block filters down to nothing), but the push path still
+  constructed `{ title, sets: [], ... }` and POSTed it. Tonal answers an empty
+  set list with a misleading 400, so `createWorkout` recorded a _failed plan_
+  after a remote round-trip instead of failing fast with a clear local error.
+  The estimate path already guarded this; the push path didn't.
+- **A dependent count was computed from the unfiltered source.** `createWorkout`
+  still derived `setCount` from a _separate_ `expandBlocksToSets(blocks)` call,
+  so the user/LLM-visible success result counted the rest sentinels that were
+  never pushed (3 work sets + 3 rest sentinels reported 6, only 3 posted).
+- **Filtering stripped a structural marker.** `expandBlocksToSets` marks the
+  first set of each block `blockStart: true`. If a block led with a synthetic
+  movement, filtering removed exactly that set, so the first _real_ set shipped
+  with `blockStart: false` — a payload whose block boundaries no longer matched
+  the internally validated block structure.
+
+**Why it matters.** A filter step looks local, but everything _downstream_ of it
+— the empty-case contract, any count/metadata computed in parallel from the
+unfiltered input, and structural invariants the removed elements carried — can
+silently drift out of sync with what actually gets sent. The failures surface as
+opaque remote 4xx, overstated success metrics, or structurally invalid payloads
+that already passed validation.
+
+**Preventive checks.**
+
+- After a filter that can empty a collection bound for an external API, **guard
+  `length === 0` before constructing/sending the payload** and fail with a clear
+  local error (matching the function's existing `{ error } | { ok }` contract),
+  rather than letting the remote service reject it.
+- **Derive every reported count/metadata from the same filtered list** that
+  forms the payload — never from a parallel unfiltered computation of the same
+  source.
+- After removing elements, **re-establish positional/structural invariants** the
+  removed elements may have carried (here, re-mark the first remaining set per
+  block as `blockStart`), or reject inputs that place a removable element in a
+  structural position.
+- Check the sibling path (estimate vs. push, dry-run vs. commit): if one already
+  guards a case, the other almost certainly needs the same guard.
+
+## 8. Don't let "missing → default" normalization clobber previously-stored real values on refresh/backfill
+
+**Seen in:** #429 (P2, plus a typing thread; both addressed)
+
+**Problem.** Tonal sub-accounts return `null` for `heightInches`,
+`weightPounds`, and `workoutsPerWeek`. `toUserProfileData` normalized those nulls
+to `0` (`?? 0`) so first-time-connect validation had concrete numbers. But
+`userProfiles.updateProfileData` **replaces the whole stored `profileData`**, and
+the same mapper ran on refresh/backfill paths (`forceRefreshUserData`,
+`maybeRefreshProfile`, `profileBackfill`). So a user who already had a real
+height/weight/frequency got **downgraded to `0`** whenever a later payload merely
+said "unknown" — and those zeros then flowed into the AI context as `0"/0lbs`,
+`0x/week`. Separately, the `TonalUser` interface still typed these fields as
+non-nullable `number` while the real payload (and the test fixture) sent `null`.
+
+**Why it matters.** A default-fill that is _correct_ for an initial write becomes
+_destructive_ on an update: "the latest payload doesn't know this value" is not
+the same as "this value is now zero." Clobbering silently degrades data the
+system already had, and the degraded values propagate into downstream consumers
+(AI context, stats) where they look like real measurements.
+
+**Preventive checks.**
+
+- A normalization that injects a default for a missing field must, on
+  **update/refresh/backfill** paths, **fall back to the previously-stored value
+  first**, and only to the hard default when both the new payload _and_ the prior
+  record are missing it (`tonalValue ?? existingValue ?? 0`). Thread the existing
+  record into the mapper at every refresh call site.
+- Distinguish **first-write** (no prior value to protect) from **update** (prior
+  value must not be silently overwritten by a "missing"); a mapper used by both
+  needs the existing record as an input.
+- **Type the field as it really arrives.** If the upstream payload can send
+  `null`, model it as `number | null` (don't assume non-null because the happy
+  path usually has a value) — and cover the nullable case in a fixture/test.
+- Add a regression test that seeds a real prior value, refreshes with a `null`
+  payload, and asserts the stored value is **preserved**, not zeroed.
+
+## 9. On the AI action-cap budget, emit critical notifications before long awaits and carry the concrete terminal error class through fallback
+
+**Seen in:** #434 (2 P2 threads; both addressed)
+
+**Problem.** The circuit-breaker alerting was reworked to add fallback context.
+Two gaps appeared, both rooted in the same 600s Convex action cap that drives
+learning #4:
+
+- **Notification deferred behind a long await.** The breaker-open alert was sent
+  only _after_ the final fallback attempt finished. With `convex/ai/resilience.ts`
+  budgeting 180s per attempt, two primary timeouts plus the fallback can run
+  close to the 600s cap, so the action could be killed _before_ the notification
+  fired — even though the breaker had already opened. An alert you only send
+  after the risky work completes is exactly the alert the action cap can eat.
+- **Terminal error class flattened.** When the fallback ended via `runAttempt`
+  returning `{ done: true, success: false }` (the BYOK/quota/other non-transient
+  path), the alert always reported a generic `TerminalFallbackAttemptFailure`,
+  discarding the concrete class `streamWithRetry` had already determined — so the
+  alert was least informative precisely when fallback failed for a known reason.
+
+**Why it matters.** This is the action-cap discipline of learning #4 applied to
+_ordering and signal fidelity_, not just timer math. A self-reporting mechanism
+that does its reporting after the part most likely to be killed loses the report
+on exactly the slow/retried turns it exists to flag; and collapsing a known error
+class into a generic sentinel strips the operator's ability to tell a billing
+failure from a quota failure from a transient one (the same "don't swallow the
+signal" thread as learnings #1 and #3).
+
+**Preventive checks.**
+
+- Emit the **critical/state-change notification before awaiting** any long
+  operation that could approach the action cap (here: send breaker-open with
+  `Fallback: pending` _before_ starting the final fallback, then send the
+  outcome separately or from a best-effort `finally`). Don't gate a
+  must-deliver alert on work that may not complete.
+- **Carry the concrete terminal error class** end to end (thread `errorClass`
+  through `AttemptOutcome`) and use it for both primary and fallback terminal
+  alerts; never replace a known class with a generic fallback sentinel.
+- When reordering work around the action cap, add a regression test asserting
+  the **ordering invariant** (notification happens before the final fallback
+  await), the same way learning #4 pins the timer invariant.
+
 ---
 
 ## How to use this log
 
 - Before opening a PR that touches **Tonal fetch helpers, AI cost/budget paths,
   test fixtures, scheduled sweeps, React error boundaries around optional
-  integrations, or credential/format validators**, skim the matching section
-  above.
+  integrations, credential/format validators, payloads filtered before an
+  external push, profile/data normalization on refresh/backfill, or AI
+  fallback/notification ordering under the action cap**, skim the matching
+  section above.
 - When a review surfaces a _new_ recurring, legitimate gap (not stylistic, not
   one-off), add an entry here with the PR reference so the next agent inherits
   the lesson.


### PR DESCRIPTION
## Summary

Reviewed the review comments on the 10 most recently merged PRs and distilled the legitimate, recurring issues into `docs/pr-review-learnings.md` (3 new entries) plus the `AGENTS.md` pointer.

Last reviewed date bumped `2026-06-01` → `2026-06-08`.

## What I reviewed

| PR | Substance | Finding |
|----|-----------|---------|
| #440 `fix: omit synthetic rest from Tonal payloads` | ✅ code | 3 legit threads → **new §7** |
| #434 `fix: add circuit breaker fallback context` | ✅ code | 2 legit P2 threads → **new §9** |
| #429 `fix: normalize Tonal sub-account profile data` | ✅ code | 2 legit threads → **new §8** |
| #433 `fix: preserve duration exercises in week card` | ✅ code | no review findings |
| #428 `chore: remove stale knip ignore` | chore | no review findings |
| #435, #431, #418 | release-please | n/a |
| #430 | docs (added §5/§6, already in log) | n/a |
| #425 | dependabot | n/a |

## New learnings

**§7 — Filtering a payload before an external push** (#440). When a filter step can empty a collection bound for an external API, guard the empty case (fail fast locally instead of eating a misleading remote 400), re-derive every dependent count from the *filtered* list rather than a parallel unfiltered computation, and re-establish structural markers (`blockStart`) that removed elements carried. Check the sibling path (estimate vs. push) for the same guard.

**§8 — "missing → default" normalization on refresh/backfill** (#429). A default-fill that's correct on first write becomes destructive on update: when Tonal returns `null` for height/weight/frequency, falling back to `0` clobbered a user's previously-stored real values (which then flowed into the AI context). Fall back to the prior stored value first (`tonalValue ?? existingValue ?? 0`), thread the existing record into the mapper at every refresh call site, type nullable payload fields as `number | null`, and add a preserve-on-null regression test.

**§9 — AI fallback ordering under the action cap** (#434). Extends §4's action-cap discipline to ordering and signal fidelity: emit the breaker-open notification *before* awaiting the long final fallback (two 180s attempts + fallback can approach the 600s cap and get killed before the alert fires), and carry the concrete terminal `errorClass` through `AttemptOutcome` instead of flattening it into a generic `TerminalFallbackAttemptFailure`.

All three issues were already fixed in their own PRs — this captures them so the next agent inherits the pattern. Prettier check passes.

https://claude.ai/code/session_01VyDVEXRtxpSKTwaKWzwwzM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyDVEXRtxpSKTwaKWzwwzM)_