### PR TITLE
docs: log catalog-resolution precedence review learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,11 +310,13 @@ duplicated copies, payload transforms that filter elements without re-deriving
 counts/markers or guarding the empty result, retry/fallback paths that flatten
 the concrete error class or await alerts past the action cap, external-payload
 normalization that mistypes nullable fields or clobbers stored values on
-refresh). Skim the matching section before touching Tonal fetch helpers,
+refresh, identity resolution of LLM/user-supplied references against a catalog
+that trusts a stale ID over the correct name or auto-substitutes a fuzzy match).
+Skim the matching section before touching Tonal fetch helpers,
 AI cost/budget paths, test fixtures, scheduled sweeps, error boundaries around
 optional integrations, credential/format validators, payload filter/transform
-steps, or retry/fallback and normalization paths -- and append a new entry
-when review surfaces a fresh recurring gap.
+steps, retry/fallback and normalization paths, or catalog/movement resolution --
+and append a new entry when review surfaces a fresh recurring gap.
 
 <!-- convex-ai-start -->
 

--- a/docs/pr-review-learnings.md
+++ b/docs/pr-review-learnings.md
@@ -1,6 +1,6 @@
 # PR Review Learnings
 
-Last reviewed: 2026-06-09
+Last reviewed: 2026-06-10
 
 A running log of recurring, legitimate issues raised in pull-request review that
 agents (and humans) should pre-empt. Each entry records the **problem**, **why
@@ -334,6 +334,64 @@ must never overwrite a previously known value.
 - Add a regression test asserting refresh **preserves stored measurements** when
   the latest payload returns `null` for those fields.
 
+## 10. Resolve LLM/user-supplied references to a catalog with a strict precedence ladder, and don't let a required field block catalog-exempt sentinels
+
+**Seen in:** #465 (4 review threads, all P2)
+
+**Problem.** `create_workout` made `name` required so the resolver could repair
+missing or fabricated movement IDs (`convex/tonal/movementResolve.ts`,
+`convex/ai/tools.ts`). But the resolution path had four ways to push the _wrong_
+Tonal movement, or block a valid one, from an LLM-supplied `{ name, movementId }`
+reference:
+
+- **A valid-but-stale ID won over the correct name.** When both fields were
+  supplied, the resolver trusted the ID immediately and never checked `name`.
+  An LLM that copied a real ID from a different exercise while giving the correct
+  new name would silently push the wrong movement — defeating the exact reason
+  `name` was made required.
+- **A broad single-word fuzzy match was auto-substituted.** A lone
+  `matchesNameSearchStrict` hit (matches if any 3+ char word appears in a movement
+  name) was pushed silently, so `Decline Push-up` resolved to
+  `Standing Decline Chest Press` and went onto the user's Tonal workout.
+- **An exact full-name match was reported `ambiguous`** when the same string also
+  equaled a _different_ movement's `shortName` alias, blocking a valid tool call
+  that copied `name` straight from `search_exercises`.
+- **A schema-required field rejected a catalog-exempt sentinel.** The required
+  `name` made Zod reject an id-only `Rest` sentinel call _before_
+  `resolveMovement`'s `isWellKnownMovementId` path could run, so single-exercise
+  workouts including the documented Rest sentinel failed unless the model invented
+  a `name`.
+
+**Why it matters.** When an LLM/user-supplied reference is resolved to a canonical
+catalog entity that is then pushed to an external system, both match _precedence_
+and match _strictness_ are correctness-critical: a wrong resolution becomes a wrong
+exercise on the user's machine, and an over-strict one blocks legitimate calls.
+And a required field enforced at the schema layer fires before the resolver's
+special-cases (well-known/synthetic IDs), so it can reject inputs the resolver was
+specifically built to accept.
+
+**Preventive checks.**
+
+- Define an explicit **precedence ladder** for identity resolution and make the
+  most-trustworthy signal win: here, exact full `name` → valid/well-known
+  `movementId` → exact `shortName` alias → (fuzzy only as **candidates**, never
+  auto-substituted). Treat the human-readable name as the source of truth over a
+  possibly-stale supplied ID.
+- **Never auto-substitute a fuzzy/partial match.** Return partial-word matches as
+  `ambiguous` candidates for the model/user to confirm; only exact matches resolve
+  silently.
+- When the same string can match **multiple fields** (full name vs. alias), check
+  the canonical field first and only fall back to aliases when it yields no match —
+  don't merge both into an `ambiguous` result.
+- Keep **schema/input-layer required fields from pre-empting resolver special
+  cases.** If the resolver legitimately accepts an id-only catalog-exempt sentinel
+  (Rest, well-known synthetic IDs), make the companion field optional at the schema
+  boundary so the call reaches the resolver. Cross-check that the not-found error
+  message still degrades gracefully (fall back to the ID) when the optional field
+  is absent.
+- Add positive tests for each ladder rung: stale-id-loses-to-name,
+  fuzzy-stays-candidate, full-name-beats-shortName-alias, and the id-only sentinel.
+
 ---
 
 ## How to use this log
@@ -341,9 +399,11 @@ must never overwrite a previously known value.
 - Before opening a PR that touches **Tonal fetch helpers, AI cost/budget paths,
   test fixtures, scheduled sweeps, React error boundaries around optional
   integrations, credential/format validators, payload transforms that
-  filter/drop elements, retry/fallback error reporting, or external-payload
-  normalization (nullable typing, refresh vs. first-connect defaults)**, skim the
-  matching section above.
+  filter/drop elements, retry/fallback error reporting, external-payload
+  normalization (nullable typing, refresh vs. first-connect defaults), or
+  identity resolution of LLM/user-supplied references against a catalog
+  (match precedence/strictness, schema-required fields vs. resolver special
+  cases)**, skim the matching section above.
 - When a review surfaces a _new_ recurring, legitimate gap (not stylistic, not
   one-off), add an entry here with the PR reference so the next agent inherits
   the lesson.


### PR DESCRIPTION
## What

Extracts actionable learnings from recent PR review and adds them to the running review-learnings log.

## Review pass

Reviewed the 10 most recently merged PRs (#465, #441, #464, #463, #459, #411, #415, #413, #412, #410). Of these:

- **#465** — the only PR with actionable review threads: **4 legitimate P2 issues**, all on the `create_workout` movement-resolution path, all addressed before merge.
- #413, #410, #463, #464 — no review comments / no actionable gaps.
- #441, #411 (releases), #464/#463 (deps), #459/#415 (the learnings logs themselves) — chores with nothing to distill.
- #412 is already captured in the log (§4).

No new gaps surfaced outside #465.

## New learning (§10)

The four #465 threads share one theme: **resolving an LLM/user-supplied `{ name, movementId }` reference to a canonical catalog entity before pushing it to Tonal**. The issues:

1. A valid-but-stale **ID won over the correct name** → wrong movement pushed silently.
2. A **broad single-word fuzzy match was auto-substituted** (`Decline Push-up` → `Standing Decline Chest Press`).
3. An exact **full-name match was reported `ambiguous`** when the string also equaled another movement's `shortName` alias.
4. A **schema-required `name` rejected an id-only catalog-exempt `Rest` sentinel** before the resolver's well-known-id path could run.

The new entry codes the preventive checks: a strict precedence ladder (exact name → valid/well-known id → shortName alias → fuzzy-as-candidate), never auto-substitute a fuzzy match, prefer the canonical field over aliases, and don't let a schema-required field pre-empt resolver special cases.

## Changes

- `docs/pr-review-learnings.md` — new §10 entry, updated scope line and "Last reviewed" date.
- `AGENTS.md` — extended the "Learning From Past Reviews" pointer to cover catalog/movement resolution.

Docs-only; no code paths touched.

https://claude.ai/code/session_015UjKwjUqoidraxd49Gwmy8

---
_Generated by [Claude Code](https://claude.ai/code/session_015UjKwjUqoidraxd49Gwmy8)_