### PR TITLE
docs: log movement-resolution and model-tier-routing review learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,11 +310,14 @@ duplicated copies, payload transforms that filter elements without re-deriving
 counts/markers or guarding the empty result, retry/fallback paths that flatten
 the concrete error class or await alerts past the action cap, external-payload
 normalization that mistypes nullable fields or clobbers stored values on
-refresh). Skim the matching section before touching Tonal fetch helpers,
-AI cost/budget paths, test fixtures, scheduled sweeps, error boundaries around
-optional integrations, credential/format validators, payload filter/transform
-steps, or retry/fallback and normalization paths -- and append a new entry
-when review surfaces a fresh recurring gap.
+refresh, LLM-driven entity resolution that auto-substitutes a fuzzy match or
+trusts a stale ID over an exact name, and model-tier routing changes that ignore
+the derived fallback tier or the first tool call). Skim the matching section
+before touching Tonal fetch helpers, AI cost/budget paths, model-tier routing,
+LLM name/ID resolvers that write to Tonal, test fixtures, scheduled sweeps, error
+boundaries around optional integrations, credential/format validators, payload
+filter/transform steps, or retry/fallback and normalization paths -- and append
+a new entry when review surfaces a fresh recurring gap.
 
 <!-- convex-ai-start -->
 

--- a/docs/pr-review-learnings.md
+++ b/docs/pr-review-learnings.md
@@ -1,6 +1,6 @@
 # PR Review Learnings
 
-Last reviewed: 2026-06-09
+Last reviewed: 2026-06-12
 
 A running log of recurring, legitimate issues raised in pull-request review that
 agents (and humans) should pre-empt. Each entry records the **problem**, **why
@@ -334,12 +334,125 @@ must never overwrite a previously known value.
 - Add a regression test asserting refresh **preserves stored measurements** when
   the latest payload returns `null` for those fields.
 
+## 10. When the LLM resolves an entity by name/ID before pushing it to an external system, prefer exact matches and never auto-substitute a broad fuzzy hit
+
+**Seen in:** #465 (4 review threads, all P2)
+
+**Problem.** `create_workout` was changed to require a movement `name` (so the
+coach could repair missing or fabricated `movementId`s) and `resolveMovement`
+gained a fuzzy fallback. Four distinct gaps let the resolver push the _wrong_
+Tonal movement — or reject a valid call — without surfacing it:
+
+- **A supplied ID won over the requested name.** When both `name` and
+  `movementId` were present, a valid-but-stale ID resolved immediately and the
+  name was never checked, so an LLM that reused a real ID from a different
+  exercise (while giving the correct new name) silently pushed the wrong
+  movement.
+- **A broad fuzzy match was auto-substituted.** The non-catalog path reused
+  `matchesNameSearchStrict` (matches if any 3+ char word appears in a movement
+  name) and silently pushed the sole match — so `Decline Push-up` resolved to
+  `Standing Decline Chest Press` and went straight onto the user's workout.
+- **A `shortName` alias tied with an exact full name.** When the requested name
+  exactly matched one movement's full `name` _and_ another movement's
+  `shortName`, the resolver merged both rows and returned `ambiguous`, blocking a
+  valid tool call that had copied the `name` straight from `search_exercises`.
+- **A required schema field rejected a documented sentinel.** Making `name`
+  required in the Zod tool schema meant the catalog-exempt `Rest` sentinel
+  (supplied by `movementId` only, and which can't come from `search_exercises`)
+  was rejected by Zod _before_ `resolveMovement`'s `isWellKnownMovementId` path
+  could run.
+
+**Why it matters.** These resolvers sit between a non-deterministic LLM and a
+destructive external write (a workout pushed to the user's Tonal). "Resolve to
+the closest thing and proceed" turns a near-miss into a wrong exercise on a real
+account; "tighten the schema" can lock out the exact legitimate inputs the
+resolver was built to accept. Both failures are silent at the call site.
+
+**Preventive checks.**
+
+- **Validate the name before trusting a supplied ID.** Check for an exact
+  full-name match _first_; only fall back to a supplied/well-known ID when no
+  exact name match exists, so a stale or copied ID can't override the correct
+  name.
+- **Never auto-substitute a broad/partial-word fuzzy match.** Limit automatic
+  resolution to exact full-name and exact `shortName` matches (plus a
+  valid/well-known ID); return any fuzzy/partial hit as a **candidate** for the
+  model to confirm, not a silent substitution.
+- **Stage exact matching: full `name` first, `shortName` aliases only as a
+  fallback.** Don't merge the two domains into one `ambiguous` result when the
+  full-name match is itself unambiguous.
+- **Don't let a tightened schema field block a documented sentinel.** When a
+  resolver has a legitimate ID-only path (well-known/catalog-exempt values like
+  `Rest`), keep the corresponding schema field optional (or special-case the
+  sentinel) so validation doesn't reject the input before the resolver runs.
+- Add coverage for each trap: stale-ID-vs-exact-name, broad-fuzzy-not-
+  substituted, full-name-beats-shortName-alias, and the ID-only sentinel path.
+
+## 11. Changing which model tier a turn starts on ripples into the derived fallback tier and the first tool call — audit both, not just the happy path
+
+**Seen in:** #469 (4 review threads, all P2), related to #368 (§3)
+
+**Problem.** A fix to route short "just give me a workout" turns onto the
+tool-capable `chat` tier (instead of the flash-lite `router` tier) kept tripping
+secondary routing hazards because tier selection has non-obvious couplings:
+
+- **The fallback tier is _derived_ from the primary.** `selectCoachTierRoute`
+  computes the fallback with `getFallbackTier(primaryTier)`, and
+  `getFallbackTier("chat")` is the `router` tier. So even after the primary path
+  moved to a tool-capable tier, a transient failure or open circuit ran the
+  fallback on flash-lite — re-introducing the exact no-workout behavior the PR
+  was closing.
+- **"Just make the fallback tool-capable" broke a different guarantee.** Changing
+  `getFallbackTier("chat")` to `programming` made the house-key Gemini default
+  fall back to the _same_ model (`chat` and `programming` both resolve to
+  `gemini-2.5-flash`), dropping the distinct `flash-lite` model-level fallback
+  that protected against a flash outage / circuit trip. Tool-capability and
+  distinct-model fallback can't both hold on Gemini without a model-policy change.
+- **Removing a routing gate dropped a routing class.** Deleting the whole
+  classifier gate (to fix the trivial-request bug) also dropped
+  `complex→programming` routing, so BYOK Claude/OpenAI users' explicit "program a
+  week" requests started on the `chat` tier (Sonnet / GPT-mini).
+- **Retrospective escalation doesn't cover the first tool call.** The
+  `prepareStep` escalation in `convex/ai/coach.ts` only switches to the
+  programming tier _after_ a prior step has already used a programming tool, so
+  the first planning tool call still ran on the weaker tier.
+
+**Why it matters.** Tier routing looks like a single dial but is really three
+coupled decisions — primary tier, _derived_ fallback tier, and per-step
+escalation. A change aimed at one quietly weakens another: the requests a tier
+is reserved for (planning) get downgraded, or the protection a fallback provides
+(distinct model on outage) silently disappears, exactly on the failure paths
+that are hardest to observe. The surgical fix here re-routed only the offending
+`trivial` branch and left both the classifier and the fallback tier untouched.
+
+**Preventive checks.**
+
+- When you change which tier a turn _starts_ on, trace the **derived fallback
+  tier** (`getFallbackTier`) for that route and confirm the transient/circuit-open
+  path still lands somewhere acceptable — the fallback isn't pinned independently.
+- Prefer the **smallest re-route** (one branch) over deleting a classifier gate;
+  removing the gate also removes every other routing class it carried (e.g.
+  `complex→programming` for BYOK planning).
+- Remember that **retrospective `prepareStep` escalation is too late for the
+  first tool call** — if a request needs the programming tier, it must _start_
+  there, not escalate after the first programming tool already ran on a weaker
+  model.
+- Don't "fix" a fallback by making it reuse the primary model: on a provider
+  where two tiers resolve to the same model, that silently drops the distinct
+  model-level fallback. Treat tool-capability vs. distinct-model fallback as a
+  deliberate, provider-specific tradeoff (see also §3).
+- Add a regression assertion on the invariant you care about (e.g. the default
+  route's `fallbackTier` is never `router`, or that explicit plan requests start
+  on the programming tier).
+
 ---
 
 ## How to use this log
 
 - Before opening a PR that touches **Tonal fetch helpers, AI cost/budget paths,
-  test fixtures, scheduled sweeps, React error boundaries around optional
+  model-tier routing (primary/fallback/per-step escalation), LLM-driven entity
+  resolution that writes to an external system (movement name/ID matching), test
+  fixtures, scheduled sweeps, React error boundaries around optional
   integrations, credential/format validators, payload transforms that
   filter/drop elements, retry/fallback error reporting, or external-payload
   normalization (nullable typing, refresh vs. first-connect defaults)**, skim the


### PR DESCRIPTION
## What

Distills two new recurring, legitimate gaps from recent PR review into `docs/pr-review-learnings.md`, and extends the AGENTS.md "Learning From Past Reviews" trigger list to match.

## Method

Reviewed the 10 most recently merged substantive PRs and read every review thread:

| PR | Topic | Outcome |
|----|-------|---------|
| #472, #470, #413 | movement-search ranking, thread sweep, history chunking | no review threads |
| #429, #426, #417, #412, #392 | nullable normalization, Garmin error boundary, AQ keys, watchdog timing, deterministic fixtures | **already captured** (§9, §5, §6, §4, §2) |
| **#465** | LLM resolves movement by name/ID before pushing to Tonal | **new → §10** |
| **#469** | routing chat turns to the tool-capable tier | **new → §11** |

Only legitimate correctness gaps were kept (all were P2 issues that were fixed before merge); stylistic/minor notes were filtered out.

## New learnings

- **§10 — LLM entity resolution before an external write.** From #465 (4 P2 threads): prefer exact name over a supplied/stale ID, never auto-substitute a broad fuzzy match (return candidates), stage full-name before `shortName` aliases, and don't let a tightened schema field reject a documented sentinel (`Rest`) before the resolver runs.
- **§11 — Model-tier routing changes.** From #469 (4 P2 threads): the fallback tier is *derived* from the primary, so a primary re-route silently changes it; making the fallback tool-capable can drop a distinct-model fallback on providers where two tiers resolve to the same model; deleting a classifier gate drops other routing classes (`complex→programming`); and retrospective `prepareStep` escalation is too late for the first tool call.

## Notes

- Docs-only change; no code paths touched.
- `prettier --check` passes on both edited files.

https://claude.ai/code/session_01DrrYTm5ti743PZrCKo5zd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrrYTm5ti743PZrCKo5zd8)_