### PR TITLE
docs: log movement-resolution and tier-routing/fallback review learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,11 +310,15 @@ duplicated copies, payload transforms that filter elements without re-deriving
 counts/markers or guarding the empty result, retry/fallback paths that flatten
 the concrete error class or await alerts past the action cap, external-payload
 normalization that mistypes nullable fields or clobbers stored values on
-refresh). Skim the matching section before touching Tonal fetch helpers,
-AI cost/budget paths, test fixtures, scheduled sweeps, error boundaries around
-optional integrations, credential/format validators, payload filter/transform
-steps, or retry/fallback and normalization paths -- and append a new entry
-when review surfaces a fresh recurring gap.
+refresh, movement/name resolution that pushes the wrong exercise by trusting a
+stale ID or auto-substituting a fuzzy match, AI tier-routing changes that
+re-introduce the bug on the same-turn fallback path or collapse a distinct-model
+fallback on a shared-model provider). Skim the matching section before touching
+Tonal fetch helpers, AI cost/budget paths, test fixtures, scheduled sweeps,
+error boundaries around optional integrations, credential/format validators,
+payload filter/transform steps, retry/fallback and normalization paths,
+movement/name resolution, or AI tier-routing/fallback selection -- and append a
+new entry when review surfaces a fresh recurring gap.
 
 <!-- convex-ai-start -->
 

--- a/docs/pr-review-learnings.md
+++ b/docs/pr-review-learnings.md
@@ -1,6 +1,6 @@
 # PR Review Learnings
 
-Last reviewed: 2026-06-09
+Last reviewed: 2026-06-13
 
 A running log of recurring, legitimate issues raised in pull-request review that
 agents (and humans) should pre-empt. Each entry records the **problem**, **why
@@ -334,6 +334,116 @@ must never overwrite a previously known value.
 - Add a regression test asserting refresh **preserves stored measurements** when
   the latest payload returns `null` for those fields.
 
+## 10. Resolving a movement by name must not silently push the wrong exercise — trust exact matches only, treat fuzzy as candidates
+
+**Seen in:** #465 (4 review threads, all P2)
+
+**Problem.** Making `name` required on `create_workout` so the resolver could
+repair missing/wrong movement IDs introduced four ways to push the _wrong_
+Tonal movement (or block a valid call):
+
+- **A supplied ID won over the name.** When both `name` and `movementId` were
+  present, a valid-but-stale ID resolved immediately and the name was never
+  checked — so an LLM that reused a real ID from a _different_ exercise while
+  giving the correct new name silently pushed the wrong movement, defeating the
+  very reason `name` was made required.
+- **A broad single-word fuzzy match auto-resolved.** Non-catalog names reused
+  `matchesNameSearchStrict` (matches if any 3+ char word appears in a movement
+  name) and silently pushed the sole match — e.g. `Decline Push-up` resolved to
+  `Standing Decline Chest Press`, a different exercise, onto the user's workout.
+- **A shortName alias outranked an exact full name.** When a name equaled one
+  movement's full `name` _and_ another movement's `shortName`, both rows were
+  combined and returned `ambiguous`, blocking a valid tool call that had simply
+  copied the `name` from `search_exercises`.
+- **A required schema field rejected a catalog-exempt sentinel.** The synthetic
+  `Rest` movement is supplied by `movementId` only and cannot come from
+  `search_exercises`, but the now-required `name` made Zod reject the tool call
+  before `resolveMovement`'s `isWellKnownMovementId` path could run.
+
+**Why it matters.** A resolver that picks the wrong row writes a wrong exercise
+to the user's real Tonal account — a silent correctness failure with no error.
+Conversely, an over-strict schema or an alias collision blocks legitimate calls
+the change was meant to enable. Both directions degrade the exact path the PR
+set out to repair.
+
+**Preventive checks.**
+
+- **Verify the name even when an ID is supplied.** Resolve/confirm an exact
+  full-name match _before_ trusting a supplied `movementId`, or reject ID/name
+  mismatches — a valid ID is not proof it matches the requested name.
+- **Auto-resolve only on exact identity** (full `name`, then `shortName`, then a
+  valid/well-known ID). Return any fuzzy/partial-word match as an `ambiguous`
+  **candidate** for the model to confirm — never auto-substitute a lone fuzzy
+  hit.
+- **Stage exact matching: full name first, alias second.** Check full `name`
+  across the catalog and resolve unambiguously before falling back to
+  `shortName` aliases, so a full-name match isn't drowned out by an alias
+  collision.
+- **Keep catalog-exempt sentinels (`Rest`, well-known IDs) loose at the schema
+  layer.** Make the repaired field optional (or special-case the sentinel) so a
+  `movementId`-only call isn't rejected before the resolver's well-known-ID path
+  runs; ensure the not-found error message falls back to the ID when no name is
+  present.
+- Add coverage for each trap: stale-ID-vs-correct-name, broad-fuzzy-no-substitute,
+  full-name-over-alias, and the `movementId`-only sentinel.
+
+## 11. A primary-tier routing change also changes the same-turn fallback path — and on shared-model providers the two can collapse
+
+**Seen in:** #469 (4 review threads, all P2)
+
+**Problem.** A fix to route short/"trivial" chat turns to the tool-capable
+`chat` tier (so `search_exercises → create_workout` reliably completes) kept
+tripping over the fallback path, because `streamWithRetry` runs the route's
+_fallback_ agent **in the same user turn** on transient failures or when the
+provider circuit is open:
+
+- **The fallback re-introduced the bug.** `selectCoachTierRoute` still derived
+  the fallback via `getFallbackTier(primaryTier)`, and `getFallbackTier("chat")`
+  is the flash-lite **router** tier. So if the chat attempt timed out or the
+  breaker was open, the short workout request fell back to the same flash-lite
+  tier the fix was trying to avoid — the no-workout behavior returned on exactly
+  the failure path.
+- **Fixing the fallback collapsed the distinct-model fallback.** Changing
+  `getFallbackTier("chat")` to `programming` backfired on the default Gemini
+  (house-key) policy, where `chat` and `programming` _both_ resolve to
+  `gemini-2.5-flash`: the retry/fallback now re-ran the same model, dropping the
+  distinct `flash-lite` fallback that protected against a flash outage / circuit
+  trip. On Gemini there is no model that is both distinct from flash _and_
+  reliable at tool-calling, so tool-capable-fallback and distinct-model-fallback
+  can't both hold without a model-policy change.
+- **Removing the whole gate dropped unrelated routing.** Deleting the classifier
+  outright also dropped `complex → programming` routing, so BYOK Claude/OpenAI
+  users' explicit "program a week" requests started on the chat tier (Sonnet /
+  GPT-mini) and only escalated _retrospectively_ after a tool call — weakening
+  the planning path the programming tier is reserved for.
+
+**Why it matters.** Tier routing has two coupled outputs (primary + fallback)
+and the fallback runs within the same turn, so a one-line primary change can be
+silently undone on the failure path, or can collapse a deliberate distinct-model
+fallback on providers where two tiers share a model. The final fix was
+**surgical**: keep the classifier and `complex → programming`, reroute only the
+`trivial → router` branch to the `chat` tier, and leave the fallback tier
+untouched — accepting the rare circuit-open fallback to flash-lite as a
+documented tradeoff rather than changing the Gemini model policy.
+
+**Preventive checks.**
+
+- When you change which tier a route's **primary** uses, trace what
+  `getFallbackTier(primary)` now resolves to and confirm the **same-turn
+  fallback** (transient/circuit-open path) doesn't re-introduce the behavior you
+  just fixed.
+- Before changing a fallback tier, check the active **model policy**: if two
+  tiers resolve to the same model for a provider (e.g. Gemini default
+  `chat == programming == flash`), moving the fallback there silently drops the
+  distinct-model fallback. Tool-capability and distinct-model fallback may be
+  mutually exclusive on that provider — surface the tradeoff, don't assume both.
+- Prefer the **smallest branch-level fix** over deleting a whole classifier/gate:
+  removing the gate can drop adjacent routing (here `complex → programming`) that
+  had nothing to do with the bug.
+- Add a regression assertion pinning the invariant you care about (e.g. the
+  default route's `fallbackTier` is never `router`, or `trivial` resolves to the
+  tool-capable tier), and document any accepted residual fallback tradeoff inline.
+
 ---
 
 ## How to use this log
@@ -341,9 +451,11 @@ must never overwrite a previously known value.
 - Before opening a PR that touches **Tonal fetch helpers, AI cost/budget paths,
   test fixtures, scheduled sweeps, React error boundaries around optional
   integrations, credential/format validators, payload transforms that
-  filter/drop elements, retry/fallback error reporting, or external-payload
-  normalization (nullable typing, refresh vs. first-connect defaults)**, skim the
-  matching section above.
+  filter/drop elements, retry/fallback error reporting, external-payload
+  normalization (nullable typing, refresh vs. first-connect defaults),
+  movement/name resolution that writes to a user's Tonal account, or AI
+  tier-routing changes that touch the fallback tier or a shared-model
+  provider policy**, skim the matching section above.
 - When a review surfaces a _new_ recurring, legitimate gap (not stylistic, not
   one-off), add an entry here with the PR reference so the next agent inherits
   the lesson.


### PR DESCRIPTION
## What

Extracts actionable learnings from review threads on the 10 most recently merged PRs and appends two new entries to `docs/pr-review-learnings.md` (plus the discoverability pointer in `AGENTS.md`).

## How I got here

Reviewed review comments on the 10 most recently merged non-trivial PRs (#472, #470, #469, #465, #429, #428, #426, #417, #413, #412). The log's prior "Last reviewed" date was 2026-06-09, so the already-logged ones were skipped:

- #412 → already §4 (watchdog timing)
- #426 → already §5 (error boundaries recover + log)
- #417 → already §6 (credential format validators)
- #429 → already §9 (nullable typing + refresh clobbering)
- #472, #470, #428, #413 → no review comments

Two PRs merged **after** the last review date surfaced genuinely new recurring gaps:

### §10 — Movement/name resolution must not push the wrong exercise (#465, 4× P2)
Making `name` required on `create_workout` introduced four silent-correctness traps: a supplied stale ID winning over the name, a broad single-word fuzzy match auto-substituting a different exercise, a `shortName` alias outranking an exact full-name match, and the required field rejecting the catalog-exempt `Rest` sentinel. Preventive checks: verify the name even when an ID is given, auto-resolve only on exact identity (fuzzy → candidates), stage full-name-before-alias matching, and keep sentinels loose at the schema layer.

### §11 — A primary-tier routing change also changes the same-turn fallback path (#469, 4× P2)
`streamWithRetry` runs the route's fallback agent **in the same turn**, so a primary-tier fix can be undone on the transient/circuit-open path, and on the default Gemini policy (`chat == programming == flash`) moving the fallback tier collapses the distinct `flash-lite` fallback. Removing the whole classifier also dropped unrelated `complex → programming` routing. Preventive checks: trace `getFallbackTier(primary)` after any primary change, check the model policy before moving a fallback tier, prefer the smallest branch-level fix over deleting a gate, and pin the invariant with a regression assertion.

## Changes

- `docs/pr-review-learnings.md` — two new sections (§10, §11), refreshed "Last reviewed" date and the "How to use this log" domain list
- `AGENTS.md` — extended the "Learning From Past Reviews" pointer with the two new domains

Docs-only; no code or test changes.

https://claude.ai/code/session_01PLjF4PiL37Sr9MNpiiGJuA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLjF4PiL37Sr9MNpiiGJuA)_