### PR TITLE
docs: log movement-resolution, model-tier-routing, and clamp-before-write review learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,11 +310,16 @@ duplicated copies, payload transforms that filter elements without re-deriving
 counts/markers or guarding the empty result, retry/fallback paths that flatten
 the concrete error class or await alerts past the action cap, external-payload
 normalization that mistypes nullable fields or clobbers stored values on
-refresh). Skim the matching section before touching Tonal fetch helpers,
+refresh, name/ID-to-catalog resolution that auto-substitutes a fuzzy match or
+trusts a stale ID over the requested name, model-tier routing changes that gut a
+whole classifier or ignore the fallback tier/per-provider model policy, input
+validators that reject the malformed value a downstream clamp is meant to
+repair). Skim the matching section before touching Tonal fetch helpers,
 AI cost/budget paths, test fixtures, scheduled sweeps, error boundaries around
 optional integrations, credential/format validators, payload filter/transform
-steps, or retry/fallback and normalization paths -- and append a new entry
-when review surfaces a fresh recurring gap.
+steps, retry/fallback and normalization paths, movement/catalog resolvers,
+model-tier routing, or input validators upstream of an external write -- and
+append a new entry when review surfaces a fresh recurring gap.
 
 <!-- convex-ai-start -->
 

--- a/docs/pr-review-learnings.md
+++ b/docs/pr-review-learnings.md
@@ -1,6 +1,6 @@
 # PR Review Learnings
 
-Last reviewed: 2026-06-09
+Last reviewed: 2026-06-22
 
 A running log of recurring, legitimate issues raised in pull-request review that
 agents (and humans) should pre-empt. Each entry records the **problem**, **why
@@ -334,6 +334,155 @@ must never overwrite a previously known value.
 - Add a regression test asserting refresh **preserves stored measurements** when
   the latest payload returns `null` for those fields.
 
+## 10. Resolving an LLM-supplied name/ID to a catalog entry that drives an external write must prefer the exact name, never auto-substitute a fuzzy match, and not let new schema requirements block exempt sentinels
+
+**Seen in:** #465 (4 review threads, all P2)
+
+**Problem.** `create_workout` was changed to require a `name` for each movement
+and resolve it against the Tonal catalog (repairing missing/wrong
+`movementId`s). The resolver (`convex/tonal/movementResolve.ts`) had four gaps,
+each of which could silently push the **wrong** exercise to the user's Tonal
+workout — or block a valid call:
+
+- **A supplied ID won over the requested name.** When both `name` and
+  `movementId` were present, a valid-but-stale ID resolved immediately and the
+  name was never checked. An LLM that reuses a real ID from another exercise
+  while giving the correct new name would silently push the wrong movement.
+- **A broad fuzzy match was auto-substituted.** Non-catalog names fell through to
+  `matchesNameSearchStrict`, which matches if any 3+ character word appears in a
+  movement name, then pushed the sole match. `Decline Push-up` could resolve to
+  `Standing Decline Chest Press` and be pushed silently.
+- **shortName aliases shadowed exact full names.** When the requested `name`
+  exactly equalled one movement's full `name` but also another movement's
+  `shortName`, the resolver merged both rows and returned `ambiguous`, blocking a
+  call whose full-name match was actually unambiguous.
+- **A newly-required field rejected an exempt sentinel.** Making `name` required
+  in the tool's Zod schema rejected the synthetic `Rest` sentinel (supplied by
+  `movementId` only, catalog-exempt, can't come from `search_exercises`) before
+  `resolveMovement`'s well-known-ID path could run.
+
+**Why it matters.** Resolution sits between a fallible LLM and an external
+side-effect (a real workout pushed to the user's machine). "Resolve to something
+plausible" is the wrong default: a stale ID, a partial-word collision, or an
+alias shadow becomes a wrong exercise the user actually trains on, with no error
+surfaced. And tightening an input schema to enable a new path can simultaneously
+break an existing exempt path if you don't account for sentinels.
+
+**Preventive checks.**
+
+- **Verify the exact name before trusting a supplied ID.** When both name and ID
+  arrive, resolve/confirm the exact full-name match first; only trust the ID when
+  no name is given (or the name confirms it). Reject ID/name mismatches rather
+  than letting the ID win.
+- **Only auto-resolve on exact matches.** Restrict silent auto-substitution to
+  exact full-name (then exact shortName) matches plus known/well-known IDs. Return
+  any fuzzy/partial-word match as an `ambiguous` **candidate** for the model to
+  confirm — never push it.
+- **Order the match tiers explicitly:** exact full `name` → exact `shortName`
+  alias → valid/well-known ID. Check full names first so an alias collision can't
+  turn an unambiguous full-name match into `ambiguous`.
+- **When you make a field required to enable a new path, enumerate the inputs that
+  legitimately lack it** (synthetic/sentinel/catalog-exempt values like `Rest`)
+  and keep the schema (and the resolver's not-found message) from rejecting them —
+  make the field optional and special-case the exempt IDs.
+- Add coverage for each: stale-id-vs-correct-name, broad-fuzzy-not-substituted,
+  full-name-over-shortName, and the sentinel/not-found path.
+
+## 11. A model-tier routing change has a primary path and a fallback path — reason about both, and reroute the one buggy branch instead of removing the whole gate
+
+**Seen in:** #469 (4 review threads, all P2)
+
+**Problem.** A bug where short workout requests routed to the flash-lite
+`router` tier (which doesn't reliably drive `search_exercises → create_workout`)
+prompted a fix that removed the whole pre-routing classifier gate so chat turns
+always started on the `chat` tier. Two separate regressions fell out, plus a
+fallback-path trap:
+
+- **Removing the gate dropped an unrelated branch.** The same classifier also
+  routed `complex` prompts ("program a week", "build a plan") to the
+  `programming` tier. Deleting it meant BYOK Claude/OpenAI users' explicit
+  planning requests now started on the cheaper `chat` tier (Sonnet / GPT-mini)
+  and only escalated _retrospectively_ in `prepareStep` after a programming tool
+  had already run — weakening exactly the requests the programming tier is
+  reserved for.
+- **The fallback tier was a separate decision the primary fix didn't touch.**
+  `selectCoachTierRoute` derives the fallback with `getFallbackTier(primaryTier)`,
+  and `getFallbackTier("chat")` is the `router` (flash-lite) tier. On
+  circuit-open / transient-timeout paths, `streamWithRetry` runs the **fallback**
+  agent for the same turn — so a short workout request whose primary `chat`
+  attempt failed would still be handled by flash-lite, reintroducing the exact
+  no-workout behavior the change was meant to fix.
+- **...but changing the fallback tier broke a different provider.** Trying to fix
+  that by making `getFallbackTier("chat")` return `programming` made the default
+  house-key Gemini policy (where `chat` and `programming` both resolve to
+  `gemini-2.5-flash`) re-run the _same_ model on fallback, dropping the distinct
+  `flash-lite` fallback that protected against a flash outage / circuit trip.
+  Tool-capability and distinct-fallback-model can't both hold on Gemini without a
+  model-policy change.
+
+The accepted resolution was **surgical**: keep the classifier, keep
+`complex → programming`, and reroute only the `trivial` branch to the `chat`
+tier — leaving the fallback tier untouched.
+
+**Why it matters.** Tier routing is two decisions, not one — the primary tier and
+the fallback tier the retry/circuit path uses — and they interact with per-provider
+model policy. A change that improves the primary path can silently degrade the
+fallback path (or vice versa), and ripping out a multi-branch classifier to fix
+one branch takes the other branches' behavior with it. The damage lands on the
+exact slow/failed/planning turns the tiers exist to protect.
+
+**Preventive checks.**
+
+- **Prefer the surgical reroute.** When one branch of a classifier/router is
+  wrong, change that branch — don't delete the whole gate. Enumerate every branch
+  the gate controls (`trivial`, `complex`, …) and confirm each still routes as
+  before.
+- **Trace both the primary and the fallback tier for the changed route.** Check
+  what `getFallbackTier(primaryTier)` resolves to and remember the fallback agent
+  runs the _same turn_ on circuit-open/timeout — a primary-only fix can leave the
+  failure path on the tier you were escaping.
+- **Resolve tiers per active provider/model policy before concluding.** A fallback
+  that looks distinct in the abstract (`chat` vs `programming`) can collapse to the
+  same model under a provider's policy (Gemini flash == flash), erasing the
+  fallback's value. Decide consciously between a tool-capable fallback and a
+  distinct-model fallback when a provider can't offer both.
+- Add a regression assertion for the invariant you're protecting (e.g. the default
+  route's `fallbackTier` is never `router`, or `complex` still maps to
+  `programming`) so the routing can't silently regress.
+
+## 12. Keep the input schema permissive and repair invalid values before the external write, so the normalization covers every push path — not just some
+
+**Seen in:** #460 (1 P2 review thread)
+
+**Problem.** The fix for non-positive reps/duration reaching Tonal (#447) added a
+`positiveOr` clamp inside `buildTonalWorkoutSets`, but the `create_workout` tool's
+Zod input schema still validated reps/duration with `.positive()`. Tool input is
+validated **before** `execute` runs, so on the standalone one-off push path the
+coach's malformed `reps: 0` / negative `duration` was rejected at the schema
+boundary and never reached the new clamp. The retry and week-plan paths were
+repaired; the direct `create_workout` path still failed on the exact input the PR
+existed to fix.
+
+**Why it matters.** When a normalization/repair step is meant to absorb fallible
+LLM output before an external API, an upstream `.positive()`/`.min()` validator
+that rejects the same malformed value defeats the repair on whichever path runs
+the validator first. The feature ships "fixed," but the originally-reported path
+still bounces — and the gap is invisible because the other paths pass.
+
+**Preventive checks.**
+
+- When you add a clamp/normalize step to repair fallible external/LLM input before
+  a write, **make the input schema permissive enough to let the invalid value
+  through to the repair** (`int().optional()` rather than `.positive()`), and
+  normalize in one shared place all paths funnel through (`buildSet` /
+  `buildTonalWorkoutSets`).
+- **Enumerate every path that constructs the payload** (one-off tool call, retry,
+  week-plan/batch) and confirm the repair sits downstream of all of them — a fix
+  verified only on the retry/batch path can leave the direct path broken.
+- Add coverage that drives the **originally-reported malformed input through the
+  standalone path**, not just the batch path, asserting the clamp produced a valid
+  payload.
+
 ---
 
 ## How to use this log
@@ -341,9 +490,12 @@ must never overwrite a previously known value.
 - Before opening a PR that touches **Tonal fetch helpers, AI cost/budget paths,
   test fixtures, scheduled sweeps, React error boundaries around optional
   integrations, credential/format validators, payload transforms that
-  filter/drop elements, retry/fallback error reporting, or external-payload
-  normalization (nullable typing, refresh vs. first-connect defaults)**, skim the
-  matching section above.
+  filter/drop elements, retry/fallback error reporting, external-payload
+  normalization (nullable typing, refresh vs. first-connect defaults),
+  name/ID-to-catalog resolution that drives an external write, model-tier routing
+  (primary vs. fallback tier, per-provider model policy), or input
+  validators/normalization upstream of an external write**, skim the matching
+  section above.
 - When a review surfaces a _new_ recurring, legitimate gap (not stylistic, not
   one-off), add an entry here with the PR reference so the next agent inherits
   the lesson.


### PR DESCRIPTION
## What

Extracts actionable learnings from review comments on the 10 most recently merged PRs and appends three new entries to `docs/pr-review-learnings.md` (plus the matching skim-trigger pointers in `AGENTS.md`).

## How the PRs were triaged

Reviewed the substantive (non-deps/non-release) merged PRs in the recent window: #489, #460, #472, #470, #469, #465, #433, #434, #429, #428, #426, #417, #413, #410.

- **#489, #433, #434, #428, #413, #410, #470, #472** — no review comments, or already captured in the log.
- **#429 (§9), #426 (§5), #417 (§6)** — findings already in the existing log; nothing new.
- **#465, #469, #460** — each merged after the log's previous `Last reviewed: 2026-06-09` and carried legitimate P2 review threads representing recurring themes the log exists to pre-empt. Every issue was addressed before merge, but the underlying gaps are the kind future agents should anticipate.

> Note: #465 and #469 were previously drafted as §10/§11 in PRs #486 and #477, but **both closed unmerged**, so those learnings never landed in `main`. This PR re-lands them (verified against the actual review threads) and adds a third (#460) the earlier draft missed.

## New entries

**§10 — Name/ID → catalog resolution that drives an external write** (from #465, 4 P2 threads). The resolver must verify the exact name before trusting a supplied (possibly stale/copied) ID, never auto-substitute a broad fuzzy match (return candidates instead), order match tiers (exact full name → shortName alias → known ID), and not let a newly-required `name` field reject catalog-exempt sentinels like `Rest`. Each gap could silently push the wrong exercise to the user's machine.

**§11 — Model-tier routing has a primary path and a fallback path** (from #469, 4 P2 threads). Removing a whole classifier gate silently dropped `complex → programming` routing for BYOK users, and the primary-vs-fallback tier split (plus per-provider model policy — Gemini `chat == programming == flash`) created a tension where helping the primary path degrades the fallback path. The accepted resolution was a surgical single-branch reroute. Checklist: prefer the surgical reroute over gutting the gate; trace both primary and fallback tiers (the fallback agent runs the same turn); resolve tiers against the active provider's policy; assert the protected invariant.

**§12 — Keep the input schema permissive and repair invalid values before the external write** (from #460, 1 P2 thread). The #447 clamp for non-positive reps/duration lived in `buildTonalWorkoutSets`, but the `create_workout` tool schema still validated with `.positive()`, which runs *before* `execute` — so the standalone one-off push path rejected the malformed input before it reached the clamp. The fix repaired retry/week-plan paths but left the directly-reported path broken. Checklist: keep the schema permissive enough to let the invalid value reach the shared repair step, enumerate every payload-construction path, and test the originally-reported input through the standalone path.

Also refreshed `Last reviewed` to 2026-06-22 and extended the "How to use this log" + `AGENTS.md` skim-triggers to cover movement/catalog resolvers, model-tier routing, and input validators upstream of an external write.

## Notes

Docs-only change. Prettier check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vj665csrTEzdt6noy9T9ia

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj665csrTEzdt6noy9T9ia)_